### PR TITLE
Toggle-Filter support on trex tui

### DIFF
--- a/scripts/automation/regression/functional_tests/filters_test.py
+++ b/scripts/automation/regression/functional_tests/filters_test.py
@@ -1,0 +1,20 @@
+#!/router/bin/python
+
+import functional_general_test
+import misc_methods
+from nose.tools import assert_equal
+from nose.tools import assert_not_equal
+from nose.tools import assert_raises
+from nose.tools import raises
+
+
+class ToggleFilter_Test(functional_general_test.CGeneralFunctional_Test):
+
+    def setUp(self):
+        pass
+
+    def test_ipv4_gen(self):
+        pass
+
+    def tearDown(self):
+        pass

--- a/scripts/automation/regression/functional_tests/filters_test.py
+++ b/scripts/automation/regression/functional_tests/filters_test.py
@@ -1,7 +1,14 @@
 #!/router/bin/python
 
 import functional_general_test
-import misc_methods
+#HACK FIX ME START
+import sys
+import os
+
+CURRENT_PATH        = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.abspath(os.path.join(CURRENT_PATH, '../../trex_control_plane/common')))
+#HACK FIX ME END
+import filters
 from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_raises

--- a/scripts/automation/regression/functional_tests/filters_test.py
+++ b/scripts/automation/regression/functional_tests/filters_test.py
@@ -86,7 +86,7 @@ class ToggleFilter_Test(functional_general_test.CGeneralFunctional_Test):
         self.list_db.remove(1)
         assert_equal(toggle_filter.filter_items(), [3, 5, 6])
 
-    def test_list_toggeliing_negative(self):
+    def test_list_toggling_negative(self):
         toggle_filter = filters.ToggleFilter(self.list_db)
         assert_raises(KeyError, toggle_filter.toggle_item, 10)
 

--- a/scripts/automation/regression/functional_tests/filters_test.py
+++ b/scripts/automation/regression/functional_tests/filters_test.py
@@ -12,16 +12,96 @@ import filters
 from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_raises
+from nose.tools import assert_true, assert_false
 from nose.tools import raises
 
 
 class ToggleFilter_Test(functional_general_test.CGeneralFunctional_Test):
 
     def setUp(self):
-        pass
+        self.list_db = [1, 2, 3, 4, 5]
+        self.set_db = {1, 2, 3, 4, 5}
+        self.tuple_db = (1, 2, 3, 4, 5)
+        self.dict_db  = {str(x): x**2
+                         for x in range(5)}
 
-    def test_ipv4_gen(self):
-        pass
+    def test_init_with_dict(self):
+        toggle_filter = filters.ToggleFilter(self.dict_db)
+        assert_equal(toggle_filter._toggle_db, set(self.dict_db.keys()))
+        assert_equal(toggle_filter.filter_items(), self.dict_db)
+
+
+    def test_init_with_list(self):
+        toggle_filter = filters.ToggleFilter(self.list_db)
+        assert_equal(toggle_filter._toggle_db, set(self.list_db))
+        assert_equal(toggle_filter.filter_items(), self.list_db)
+
+    def test_init_with_set(self):
+        toggle_filter = filters.ToggleFilter(self.set_db)
+        assert_equal(toggle_filter._toggle_db, self.set_db)
+        assert_equal(toggle_filter.filter_items(), self.set_db)
+
+    def test_init_with_tuple(self):
+        toggle_filter = filters.ToggleFilter(self.tuple_db)
+        assert_equal(toggle_filter._toggle_db, set(self.tuple_db))
+        assert_equal(toggle_filter.filter_items(), self.tuple_db)
+
+    @raises(TypeError)
+    def test_init_with_non_iterable(self):
+        toggle_filter = filters.ToggleFilter(15)
+
+    def test_dict_toggeling(self):
+        toggle_filter = filters.ToggleFilter(self.dict_db)
+        assert_false(toggle_filter.toggle_item("3"))
+        assert_equal(toggle_filter._toggle_db, {'0', '1', '2', '4'})
+        assert_true(toggle_filter.toggle_item("3"))
+        assert_equal(toggle_filter._toggle_db, {'0', '1', '2', '3', '4'})
+        assert_false(toggle_filter.toggle_item("2"))
+        assert_false(toggle_filter.toggle_item("4"))
+        self.dict_db.update({'5': 25, '6': 36})
+        assert_true(toggle_filter.toggle_item("6"))
+
+        assert_equal(toggle_filter.filter_items(), {'0': 0, '1': 1, '3': 9, '6': 36})
+
+        del self.dict_db['1']
+        assert_equal(toggle_filter.filter_items(), {'0': 0, '3': 9, '6': 36})
+
+    def test_dict_toggeling_negative(self):
+        toggle_filter = filters.ToggleFilter(self.dict_db)
+        assert_raises(KeyError, toggle_filter.toggle_item, "100")
+
+    def test_list_toggeling(self):
+        toggle_filter = filters.ToggleFilter(self.list_db)
+        assert_false(toggle_filter.toggle_item(3))
+        assert_equal(toggle_filter._toggle_db, {1, 2, 4, 5})
+        assert_true(toggle_filter.toggle_item(3))
+        assert_equal(toggle_filter._toggle_db, {1, 2, 3, 4, 5})
+        assert_false(toggle_filter.toggle_item(2))
+        assert_false(toggle_filter.toggle_item(4))
+        self.list_db.extend([6 ,7])
+        assert_true(toggle_filter.toggle_item(6))
+
+        assert_equal(toggle_filter.filter_items(), [1, 3 , 5, 6])
+
+        self.list_db.remove(1)
+        assert_equal(toggle_filter.filter_items(), [3, 5, 6])
+
+    def test_list_toggeliing_negative(self):
+        toggle_filter = filters.ToggleFilter(self.list_db)
+        assert_raises(KeyError, toggle_filter.toggle_item, 10)
+
+    def test_toggle_multiple_items(self):
+        toggle_filter = filters.ToggleFilter(self.list_db)
+        assert_false(toggle_filter.toggle_items(1, 3, 5))
+        assert_equal(toggle_filter._toggle_db, {2, 4})
+        assert_true(toggle_filter.toggle_items(1, 5))
+        assert_equal(toggle_filter._toggle_db, {1, 2, 4, 5})
+
+    def test_dont_show_after_init(self):
+        toggle_filter = filters.ToggleFilter(self.list_db, show_by_default = False)
+        assert_equal(toggle_filter._toggle_db, set())
+        assert_equal(toggle_filter.filter_items(), [])
+
 
     def tearDown(self):
         pass

--- a/scripts/automation/trex_control_plane/common/filters.py
+++ b/scripts/automation/trex_control_plane/common/filters.py
@@ -1,0 +1,86 @@
+
+def shallow_copy(x):
+    return type(x)(x)
+
+
+class ToggleFilter(object):
+    """
+    This class provides a "sticky" filter, that works by "toggling" items of the original database on and off.
+    """
+    def __init__(self, db_ref, show_by_default=True):
+        self._data = db_ref
+        self._toggle_db = set()
+        self._filter_method = filter
+        self.__set_initial_state(show_by_default)
+
+    def toggle_item(self, item_key):
+        if item_key in self._toggle_db:
+            self._toggle_db.remove(item_key)
+            return False
+        elif item_key in self._data:
+            self._toggle_db.add(item_key)
+            return True
+        else:
+            raise KeyError("Provided item key isn't a key of the referenced data structure.")
+
+    def filter_items(self):
+        """
+        Filters the pointed database by showing only the items mapped at toggle_db set.
+
+        :returns:
+            Filtered data of the original object.
+
+        """
+        return self._filter_method(self.__toggle_filter, self._data)
+
+    # private methods
+
+    def __set_initial_state(self, show_by_default):
+        try:
+            _ = (x for x in self._data)
+            if isinstance(self._data, dict):
+                self._filter_method = ToggleFilter.dict_filter
+                if show_by_default:
+                    self._toggle_db = self._data.keys()
+                return
+            elif isinstance(self._data, list):
+                self._filter_method = ToggleFilter.list_filter
+            elif isinstance(self._data, set):
+                self._filter_method = ToggleFilter.set_filter
+            elif isinstance(self._data, tuple):
+                self._filter_method = ToggleFilter.tuple_filter
+            if show_by_default:
+                self._toggle_db = set(shallow_copy(self._data))  # assuming all relevant data with unique identifier
+            return
+        except TypeError:
+            raise TypeError("provided data object is not iterable")
+
+    def __toggle_filter(self, x):
+        return (x in self._toggle_db)
+
+    # static utility methods
+
+    @staticmethod
+    def dict_filter(function, iterable):
+        assert isinstance(iterable, dict)
+        return {k: v
+                for k,v in iterable.iteritems()
+                if function(k, v)}
+
+    @staticmethod
+    def list_filter(function, iterable):
+        return filter(function, iterable)
+
+    @staticmethod
+    def set_filter(function, iterable):
+        return {x
+                for x in iterable
+                if function(x)}
+
+    @staticmethod
+    def tuple_filter(function, iterable):
+        return tuple(filter(function, iterable))
+
+
+if __name__ == "__main__":
+    pass

--- a/scripts/automation/trex_control_plane/common/filters.py
+++ b/scripts/automation/trex_control_plane/common/filters.py
@@ -23,6 +23,9 @@ class ToggleFilter(object):
         else:
             raise KeyError("Provided item key isn't a key of the referenced data structure.")
 
+    def toggle_items(self, *args):
+        return all(map(self.toggle_item, args))
+
     def filter_items(self):
         """
         Filters the pointed database by showing only the items mapped at toggle_db set.
@@ -41,7 +44,7 @@ class ToggleFilter(object):
             if isinstance(self._data, dict):
                 self._filter_method = ToggleFilter.dict_filter
                 if show_by_default:
-                    self._toggle_db = self._data.keys()
+                    self._toggle_db = set(self._data.keys())
                 return
             elif isinstance(self._data, list):
                 self._filter_method = ToggleFilter.list_filter
@@ -65,7 +68,7 @@ class ToggleFilter(object):
         assert isinstance(iterable, dict)
         return {k: v
                 for k,v in iterable.iteritems()
-                if function(k, v)}
+                if function(k)}
 
     @staticmethod
     def list_filter(function, iterable):

--- a/scripts/automation/trex_control_plane/common/filters.py
+++ b/scripts/automation/trex_control_plane/common/filters.py
@@ -8,12 +8,43 @@ class ToggleFilter(object):
     This class provides a "sticky" filter, that works by "toggling" items of the original database on and off.
     """
     def __init__(self, db_ref, show_by_default=True):
+        """
+        Instantiate a ToggleFilter object
+
+        :parameters:
+             db_ref : iterable
+                an iterable object (i.e. list, set etc) that would serve as the reference db of the instance.
+                Changes in that object will affect the output of ToggleFilter instance.
+
+             show_by_default: bool
+                decide if by default all the items are "on", i.e. these items will be presented if no other
+                toggling occurred.
+
+                default value : **True**
+
+        """
         self._data = db_ref
         self._toggle_db = set()
         self._filter_method = filter
         self.__set_initial_state(show_by_default)
 
     def toggle_item(self, item_key):
+        """
+        Toggle a single item in/out.
+
+        :parameters:
+             item_key :
+                an item the by its value the filter can decide to toggle or not.
+                Example: int, str and so on.
+
+        :return:
+            + **True** if item toggled **into** the filtered items
+            + **False** if item toggled **out from** the filtered items
+
+        :raises:
+            + KeyError, in case if item key is not part of the toggled list and not part of the referenced db.
+
+        """
         if item_key in self._toggle_db:
             self._toggle_db.remove(item_key)
             return False
@@ -24,7 +55,23 @@ class ToggleFilter(object):
             raise KeyError("Provided item key isn't a key of the referenced data structure.")
 
     def toggle_items(self, *args):
-        return all(map(self.toggle_item, args))
+        """
+        Toggle multiple items in/out with a single call. Each item will be ha.
+
+        :parameters:
+             args : iterable
+                an iterable object containing all item keys to be toggled in/out
+
+        :return:
+            + **True** if all toggled items were toggled **into** the filtered items
+            + **False** if at least one of the items was toggled **out from** the filtered items
+
+        :raises:
+            + KeyError, in case if ont of the item keys was not part of the toggled list and not part of the referenced db.
+
+        """
+        # in python 3, 'map' returns an iterator, so wrapping with 'list' call creates same effect for both python 2 and 3
+        return all(list(map(self.toggle_item, args)))
 
     def filter_items(self):
         """
@@ -67,12 +114,13 @@ class ToggleFilter(object):
     def dict_filter(function, iterable):
         assert isinstance(iterable, dict)
         return {k: v
-                for k,v in iterable.iteritems()
+                for k,v in iterable.items()
                 if function(k)}
 
     @staticmethod
     def list_filter(function, iterable):
-        return filter(function, iterable)
+        # in python 3, filter returns an iterator, so wrapping with list creates same effect for both python 2 and 3
+        return list(filter(function, iterable))
 
     @staticmethod
     def set_filter(function, iterable):

--- a/scripts/automation/trex_control_plane/stl/console/trex_tui.py
+++ b/scripts/automation/trex_control_plane/stl/console/trex_tui.py
@@ -13,6 +13,8 @@ else:
 from trex_stl_lib.utils.text_opts import *
 from trex_stl_lib.utils import text_tables
 from trex_stl_lib import trex_stl_stats
+import trex_root_path
+from common.filters import ToggleFilter
 
 # for STL exceptions
 from trex_stl_lib.api import *
@@ -65,10 +67,10 @@ class TrexTUIDashBoard(TrexTUIPanel):
         self.key_actions['-'] = {'action': self.action_lower,  'legend': 'low 5%', 'show': True}
 
         self.ports = self.stateless_client.get_all_ports()
-
+        self.toggle_filter = ToggleFilter(self.ports)
 
     def show (self):
-        stats = self.stateless_client._get_formatted_stats(self.ports)
+        stats = self.stateless_client._get_formatted_stats(self.toggle_filter.filter_items())
         # print stats to screen
         for stat_type, stat_data in stats.items():
             text_tables.print_table_with_header(stat_data.text_table, stat_type)
@@ -289,7 +291,7 @@ class TrexTUIPanelManager():
         self.key_actions['s'] = {'action': self.action_show_sstats, 'legend': 'streams stats', 'show': True}
 
         for port_id in self.ports:
-            self.key_actions[str(port_id)] = {'action': self.action_show_port(port_id), 'legend': 'port {0}'.format(port_id), 'show': False}
+            self.key_actions[str(port_id)] = {'action': self.action_toggle_port(port_id), 'legend': 'port {0}'.format(port_id), 'show': False}
             self.panels['port {0}'.format(port_id)] = TrexTUIPort(self, port_id)
 
         # start with dashboard
@@ -386,6 +388,15 @@ class TrexTUIPanelManager():
             return ""
 
         return action_show_port_x
+
+    def action_toggle_port(self, port_id):
+        def action_toggle_port_x():
+            self.panels['dashboard'].toggle_filter.toggle_item(port_id)
+            self.init()
+            return ""
+
+        return action_toggle_port_x
+
 
 
     def action_show_sstats (self):


### PR DESCRIPTION
This request is for allowing user input to toggle port view on and off by hitting the port number when on trex tui display.

It uses the ToggleFilter general class (found at trex_control_plane/common) directory and tested using unit tests found at regression/functional_tests/filters_test.py

Functionality: when user hit the port number, the port display goes off if displayed, or on if not.
When more than one port shown, the 'total' column is also showed.

This change has been tested only using two-ports VM, so further lookup would be great.

Finally, we should consider how to merge it correctly with "Port" panel.