### PR TITLE
Add support for encapsulating flows with GRE

### DIFF
--- a/src/common/Network/Packet/GREHeader.cpp
+++ b/src/common/Network/Packet/GREHeader.cpp
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2015-2015 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#include "GREHeader.h"
+
+void GREHeader::dump(FILE*  fd)
+{
+    fprintf(fd, "GREHeader\n");
+    fprintf(fd, "Checksum enabled: %d, Key enabled: %d, "
+        "Sequence number enabled: %d\n", isChecksumEnabled(), isKeyEnabled(),
+	isSequenceNumberEnabled());
+    fprintf(fd, "Protocol type: 0x%04x \n", getProtocolType());
+    fprintf(fd, "Key: 0x%04x\n", getKey());
+}

--- a/src/common/Network/Packet/GREHeader.h
+++ b/src/common/Network/Packet/GREHeader.h
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2015-2015 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _GRE_HEADER_H_
+#define _GRE_HEADER_H_
+
+#include "PacketHeaderBase.h"
+
+/**
+ * This class encapsulates a GRE header.
+ * It has fields that are equivalent to the GRE header fields.
+ * The data is saved in network byte order, and therefore the class can be used
+ * to create a packet in a buffer and send it over the network.
+ */
+class GREHeader
+{
+public:
+
+    struct Protocol
+    {
+        enum Type
+        {
+            TRANSPARENT_ETHERNET_BRIDIGING = 0x6558,
+        };
+    };
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Common Header Interface
+////////////////////////////////////////////////////////////////////////////////////////
+
+public:
+    //Empty constructor
+    GREHeader() :
+    _flagsVersion(0) //must initialize it because when doing setFlags or setVersion we mask it
+    {}
+    //Construct a GREHeader object from a given buffer, ordered in Network byte order
+    inline GREHeader(uint8_t* packet);
+
+    inline uint8_t* getPointer() { return (uint8_t*)this; }
+    static inline uint32_t getSize() { return (uint32_t)sizeof(GREHeader); }
+
+    inline bool isChecksumEnabled();
+    inline bool isKeyEnabled();
+    inline bool isSequenceNumberEnabled();
+    inline void setFlags(bool checksumEnabled, bool keyEnabled,
+        bool sequenceNumberEnable);
+
+    inline uint8_t getVersion();
+    inline void setVersion(uint8_t version);
+
+    inline uint16_t getProtocolType();
+    inline void setProtocolType(uint16_t protocolType);
+
+    inline uint32_t getKey();
+    inline void setKey(uint32_t key);
+
+    void dump(FILE* fd);
+
+public:
+    uint16_t _flagsVersion;
+    uint16_t _protocolType;
+    uint32_t _key;
+};
+
+#include "GREHeader.inl"
+
+#endif

--- a/src/common/Network/Packet/GREHeader.inl
+++ b/src/common/Network/Packet/GREHeader.inl
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2015-2015 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <common/BigEndianBitManipulation.h>
+
+inline GREHeader::GREHeader(uint8_t* packet)
+{
+    *this = *((GREHeader*)packet);
+}
+
+inline bool GREHeader::isChecksumEnabled()
+{
+    return getMaskBit16(PKT_NTOHS(_flagsVersion), 0, 0);
+}
+inline bool GREHeader::isKeyEnabled()
+{
+    return getMaskBit16(PKT_NTOHS(_flagsVersion), 2, 2);
+}
+inline bool GREHeader::isSequenceNumberEnabled()
+{
+    return getMaskBit16(PKT_NTOHS(_flagsVersion), 3, 3);
+}
+inline void GREHeader::setFlags(bool checksumEnabled, bool keyEnabled,
+    bool sequenceNumberEnable)
+{
+    uint16_t flagsVersionWord = (PKT_NTOHS(_flagsVersion));
+    setMaskBit16(flagsVersionWord, 0, 0, checksumEnabled ? 1 : 0);
+    setMaskBit16(flagsVersionWord, 2, 2, keyEnabled ? 1 : 0);
+    setMaskBit16(flagsVersionWord, 3, 3, sequenceNumberEnable ? 1 : 0);
+    _flagsVersion = (PKT_HTONS(flagsVersionWord));
+}
+
+inline uint8_t GREHeader::getVersion()
+{
+    return getMaskBit16(PKT_NTOHS(_flagsVersion), 13, 15);
+}
+
+inline void GREHeader::setVersion(uint8_t version)
+{
+    uint16_t flagsVersionWord = (PKT_NTOHS(_flagsVersion));
+    setMaskBit16(flagsVersionWord, 13, 15, version);
+    _flagsVersion = (PKT_HTONS(flagsVersionWord));
+}
+
+inline uint16_t GREHeader::getProtocolType()
+{
+    return (PKT_NTOHS(_protocolType));
+}
+inline void GREHeader::setProtocolType(uint16_t protocolType)
+{
+    _protocolType = (PKT_HTONS(protocolType));
+}
+
+inline uint32_t GREHeader::getKey()
+{
+    return (PKT_NTOHL(_key));
+}
+inline void GREHeader::setKey(uint32_t key)
+{
+    _key = (PKT_HTONL(key));
+}

--- a/src/gre_mapping.h
+++ b/src/gre_mapping.h
@@ -1,0 +1,60 @@
+#ifndef GRE_MAPPING_H_
+#define GRE_MAPPING_H_
+
+typedef struct gre_mapping_ {
+    uint8_t gw_mac[6];
+    uint8_t client_mac[6];
+    uint32_t src_ip;
+    uint32_t key;
+} gre_mapping_t;
+
+class CFlowGenListGre {
+public:
+    CFlowGenListGre() {
+        set_configured(false);
+        last_index = 0;
+    }
+
+    std::vector<gre_mapping_t> &get_gre_info () {
+        return m_gre_info;
+    }
+
+    bool is_configured() {
+        return is_gre_info_configured;
+    }
+
+    void set_configured(bool is_conf) {
+        is_gre_info_configured = is_conf;
+    }
+
+    void clear() {
+        set_configured(false);
+        m_gre_info.clear();
+    }
+
+    gre_mapping_t get_gre_info(uint32_t idx) {
+      return m_gre_info[idx];
+    }
+
+    uint32_t get_gre_next_index() {
+      if (last_index >= m_gre_info.size())
+        last_index = 0;
+      return last_index++;
+    }
+
+    void set_gre_dst_ip(uint32_t ip) {
+        dst_ip = ip;
+    }
+
+    uint32_t get_gre_dst_ip() {
+        return dst_ip;
+    }
+
+private:
+    uint32_t last_index;
+    bool is_gre_info_configured;
+    uint32_t dst_ip;
+    std::vector<gre_mapping_t> m_gre_info;  /* global gre info loaded form gre_file*/
+};
+
+#endif //GRE_MAPPING_H_

--- a/src/gtest/tuple_gen_test.cpp
+++ b/src/gtest/tuple_gen_test.cpp
@@ -158,7 +158,7 @@ TEST(tuple_gen,clientPoolL) {
     CClientPool gen;
     gen.Create(cdSEQ_DIST, 
                0x10000001,  0x10000f01, 64000,1,NULL,false, 
-               0,0);
+               NULL,false,0,0);
     CTupleBase result;
     uint32_t result_src;
     uint16_t result_port;
@@ -182,7 +182,7 @@ TEST(tuple_gen,clientPool) {
     CClientPool gen;
     gen.Create(cdSEQ_DIST, 
                0x10000001,  0x10000021, 64000,1000,NULL,false, 
-               0,0);
+               NULL,false,0,0);
     CTupleBase result;
     uint32_t result_src;
     uint16_t result_port;
@@ -274,7 +274,7 @@ TEST(tuple_gen,GenerateTuple2) {
     CClientPool c_gen_2;
     c_gen.Create(cdSEQ_DIST, 
                0x10000001,  0x1000000f, 64000,4,NULL,false, 
-               0,0);
+               NULL,false,0,0);
     CServerPool s_gen;
     CServerPool s_gen_2;
     s_gen.Create(cdSEQ_DIST, 
@@ -303,7 +303,7 @@ TEST(tuple_gen,GenerateTuple2) {
 //    EXPECT_EQ((size_t)0, gen.m_clients.size());
     c_gen.Create(cdSEQ_DIST, 
                0x10000001,  0x1000000f, 64000,400,NULL,false, 
-               0,0);
+               NULL,false,0,0);
     s_gen.Create(cdSEQ_DIST, 
                0x30000001,  0x30000001, 64000,10);
     for(int i=0;i<200;i++) {
@@ -332,7 +332,7 @@ TEST(tuple_gen,GenerateTupleMac) {
 
     CClientPool gen;
     gen.Create(cdSEQ_DIST, 
-               0x10000001,  0x1000000f, 64000,2, &fl.m_mac_info,true,0,0);
+               0x10000001,  0x1000000f, 64000,2, &fl.m_mac_info,true,NULL,false,0,0);
 
     CTupleBase result;
     uint32_t result_src;
@@ -421,7 +421,7 @@ TEST(tuple_gen,split2) {
 TEST(tuple_gen,template1) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1); 
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x40000001,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);
@@ -446,7 +446,7 @@ TEST(tuple_gen,template1) {
 TEST(tuple_gen,template2) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1);
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x40000001,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);
@@ -475,7 +475,7 @@ TEST(tuple_gen,template2) {
 TEST(tuple_gen,no_free) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1);
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x10000001,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x10000001,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x400000ff,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);
@@ -497,7 +497,7 @@ TEST(tuple_gen,no_free) {
 TEST(tuple_gen,try_to_free) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1); 
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x10000001,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x10000001,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x400000ff,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);
@@ -524,7 +524,7 @@ TEST(tuple_gen,try_to_free) {
 TEST(tuple_gen_2,GenerateTuple) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1); 
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x10000f01,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x10000f01,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x40000001,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);
@@ -552,7 +552,7 @@ TEST(tuple_gen_2,GenerateTuple) {
 TEST(tuple_gen_2,GenerateTuple2) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1);
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x40000001,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);
@@ -576,7 +576,7 @@ TEST(tuple_gen_2,GenerateTuple2) {
     gen.Delete();
 //    EXPECT_EQ((size_t)0, gen.m_clients.size());
     gen.Create(1, 1); 
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x40000001,64000,4,false);
     template_1.Create(&gen,0,0);
     for(int i=0;i<200;i++) {
@@ -599,7 +599,7 @@ TEST(tuple_gen_2,GenerateTuple2) {
 TEST(tuple_gen_2,template1) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1); 
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x40000001,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);
@@ -626,7 +626,7 @@ TEST(tuple_gen_2,template1) {
 TEST(tuple_gen_2,template2) {
     CTupleGeneratorSmart gen;
     gen.Create(1, 1);
-    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,0,0);
+    gen.add_client_pool(cdSEQ_DIST,0x10000001,0x1000000f,64000,4,NULL,NULL,0,0);
     gen.add_server_pool(cdSEQ_DIST,0x30000001,0x40000001,64000,4,false);
     CTupleTemplateGeneratorSmart template_1;
     template_1.Create(&gen,0,0);

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -541,6 +541,7 @@ enum { OPT_HELP,
        OPT_RX_CHECK,
        OPT_IO_MODE,
        OPT_IPV6,
+       OPT_GRE,
        OPT_LEARN,
        OPT_LEARN_MODE,
        OPT_LEARN_VERIFY,
@@ -605,6 +606,7 @@ static CSimpleOpt::SOption parser_options[] =
         { OPT_IO_MODE,   "--iom",  SO_REQ_SEP },
         { OPT_RX_CHECK_HOPS, "--hops", SO_REQ_SEP },
         { OPT_IPV6,       "--ipv6",       SO_NONE   },
+        { OPT_GRE,        "--gre",        SO_REQ_SEP   },
         { OPT_LEARN, "--learn",       SO_NONE   },
         { OPT_LEARN_MODE, "--learn-mode",       SO_REQ_SEP   },
         { OPT_LEARN_VERIFY, "--learn-verify",       SO_NONE   },
@@ -686,6 +688,7 @@ static int usage(){
     printf("  \n");
 
     printf(" --ipv6                     : work in ipv6 mode\n");
+    printf(" --gre [cfg.yaml]           : encapsulate outgoing packets with GRE\n");
     printf(" --learn (deprecated). Replaced by --learn-mode. To get older behaviour, use --learn-mode 2\n");
     printf(" --learn-mode [1-2]         : Work in NAT environments, learn the dynamic NAT translation and ALG  \n");
     printf("      1    Use TCP ACK in first SYN to pass NAT translation information. Will work only for TCP streams. Initial SYN packet must be present in stream.\n");
@@ -839,6 +842,11 @@ static int parse_options(int argc, char *argv[], CParserOption* po, bool first_t
 
             case OPT_IPV6:
                 po->preview.set_ipv6_mode_enable(true);
+                break;
+
+            case OPT_GRE:
+                po->gre_file = args.OptionArg();
+                po->preview.set_gre_mode_enable(true);
                 break;
 
             case OPT_VLAN:
@@ -4205,6 +4213,13 @@ int CGlobalTRex::start_master_statefull() {
         m_fl.m_mac_info.set_configured(true);
     } else {
         m_fl.m_mac_info.set_configured(false);
+    }
+    if (CGlobalInfo::m_options.gre_file != "") {
+        CGlobalInfo::m_options.preview.set_mac_ip_mapping_enable(true);
+        m_fl.load_from_gre_file(CGlobalInfo::m_options.gre_file);
+        m_fl.m_gre_info.set_configured(true);
+    } else {
+        m_fl.m_gre_info.set_configured(false);
     }
 
     m_expected_pps = m_fl.get_total_pps();

--- a/src/pal/linux/mbuf.h
+++ b/src/pal/linux/mbuf.h
@@ -170,7 +170,7 @@ static inline void utl_rte_pktmbuf_check(struct rte_mbuf *m){
     assert(m->magic2== MAGIC2);
 }
 
-#define __rte_cache_aligned 
+#define __rte_cache_aligned __attribute__((__aligned__(64)))
 
 
 #define CACHE_LINE_SIZE 64

--- a/src/stateless/dp/trex_stream_node.h
+++ b/src/stateless/dp/trex_stream_node.h
@@ -40,7 +40,7 @@ friend class TrexStatelessDpCore;
 public:
     TrexStatelessCpToDpMsgBase * m_cmd;
 
-    uint8_t             m_pad_end[104];
+    uint8_t             m_pad_end[120];
 
 public:
     void free_command();
@@ -133,7 +133,7 @@ private:
     /* End Fast Field VM Section */
 
     /* pad to match the size of CGenNode */
-    uint8_t             m_pad_end[20];
+    uint8_t             m_pad_end[36];
 
 
 public:
@@ -616,7 +616,7 @@ private:
     uint8_t             m_port_id;
 
     /* pad to match the size of CGenNode */
-    uint8_t             m_pad_end[33];
+    uint8_t             m_pad_end[97];
 
 } __rte_cache_aligned;
 

--- a/src/tuple_gen.cpp
+++ b/src/tuple_gen.cpp
@@ -59,6 +59,8 @@ void CClientPool::Create(IP_DIST_t  dist_value,
             double t_cps,
             CFlowGenListMac* mac_info,
             bool has_mac_map,
+            CFlowGenListGre* gre_info,
+            bool has_gre_map,
             uint16_t tcp_aging, 
             uint16_t udp_aging) {
     assert(max_ip>=min_ip);
@@ -136,15 +138,17 @@ bool CTupleGeneratorSmart::add_client_pool(IP_DIST_t  client_dist,
                                           double l_flow,
                                           double t_cps,
                                           CFlowGenListMac* mac_info, 
+                                          CFlowGenListGre* gre_info,
                                           uint16_t tcp_aging,
                                           uint16_t udp_aging){
     assert(max_client>=min_client);
     CClientPool* pool = new CClientPool();
     pool->Create(client_dist, min_client, max_client,
                  l_flow, t_cps, mac_info, m_has_mac_mapping,
-                 tcp_aging, udp_aging);
+                 gre_info, m_has_gre_mapping, tcp_aging, udp_aging);
 
     m_client_pool.push_back(pool);
+    m_gre_info = gre_info;
     return(true);
 }
 
@@ -171,18 +175,21 @@ bool CTupleGeneratorSmart::add_server_pool(IP_DIST_t  server_dist,
 
 bool CTupleGeneratorSmart::Create(uint32_t _id,
                                   uint32_t thread_id,
-                                  bool has_mac)
+                                  bool has_mac,
+                                  bool has_gre)
 {
     m_thread_id     = thread_id;
     m_id = _id;
     m_was_init=true;
     m_has_mac_mapping = has_mac;
+    m_has_gre_mapping = has_gre;
     return(true);
 }
 
 void CTupleGeneratorSmart::Delete(){
     m_was_init=false;
     m_has_mac_mapping = false;
+    m_has_gre_mapping = false;
 
     for (int idx=0;idx<m_client_pool.size();idx++) {
         m_client_pool[idx]->Delete();

--- a/src/tuple_gen.h
+++ b/src/tuple_gen.h
@@ -38,6 +38,7 @@ limitations under the License.
 #include <bitset>
 #include <yaml-cpp/yaml.h>
 #include <mac_mapping.h>
+#include <gre_mapping.h>
 
 #include <random>
 
@@ -543,6 +544,8 @@ public:
                 double t_cps,
                 CFlowGenListMac* mac_info,
                 bool has_mac_map, 
+                CFlowGenListGre* gre_info,
+                bool has_gre_map,
                 uint16_t tcp_aging,
                 uint16_t udp_aging); 
 
@@ -686,9 +689,11 @@ public:
     CTupleGeneratorSmart(){
         m_was_init=false;
         m_has_mac_mapping = false;
+        m_gre_info = NULL;
+        m_has_gre_mapping = false;
     }
     bool Create(uint32_t _id,
-            uint32_t thread_id, bool has_mac=false);
+            uint32_t thread_id, bool has_mac=false, bool has_gre=false);
 
     void Delete();
 
@@ -710,6 +715,7 @@ public:
                          double l_flow,
                          double t_cps,
                          CFlowGenListMac* mac_info,
+                         CFlowGenListGre* gre_info,
                          uint16_t tcp_aging,
                          uint16_t udp_aging);
     bool add_server_pool(IP_DIST_t  server_dist,
@@ -730,6 +736,10 @@ public:
     CServerPoolBase* get_server_pool(uint8_t idx) {
         return m_server_pool[idx];
     }
+
+    CFlowGenListGre* get_gre_info() {
+        return m_gre_info;
+    }
 private:
     uint32_t m_id;
     uint32_t m_thread_id;
@@ -737,6 +747,8 @@ private:
     std::vector<CServerPoolBase*> m_server_pool;
     bool     m_was_init;
     bool     m_has_mac_mapping;
+    CFlowGenListGre* m_gre_info;
+    bool     m_has_gre_mapping;
 };
 
 class CTupleTemplateGeneratorSmart {


### PR DESCRIPTION
This is done with the '--gre' command line option which accepts a path to a YAML
file describing the GRE tunnels to generate. The file should be of the following
format:
- remote_ip: "10.1.0.2"
  tunnels:
  - src_ip: "10.1.1.21"
    key: 0x1f
    client_mac: [0x00,0x12,0x34,0x56,0x78,0x90]
    gw_mac: [0x0c,0x5c,0x28,0xf0,0x12,0x06]

Where:
- remote_ip - The endpoint of the GREP dunnel
- src_ip - The source IP of the GRE packet
- key  - The GRE key
- client_mac - The MAC address for client traffic inside the GRE packet
- gw_mac - The destination MAC address for client traffic inside the GRE packet
