### PR TITLE
Added MAC learning in NAT mode

### DIFF
--- a/src/bp_gtest.cpp
+++ b/src/bp_gtest.cpp
@@ -2416,7 +2416,7 @@ public:
                 assert(ipv4->getTimeToLive()==255);
                 /* ip option packet */
                 printf(" rx got ip option packet ! \n");
-                mg->handle_packet_ipv4(option,ipv4);
+                mg->handle_packet_ipv4(option,ipv4,(EthernetHeader *)(mp));
                 delay(10);          // delay for queue flush 
                 mg->handle_aging(); // flush the RxRing 
             }

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -4207,6 +4207,7 @@ void CFlowGenListPerThread::handle_nat_msg(CGenNodeNatInfo * msg){
         #ifdef NAT_TRACE_
         printf(" %.03f  RX :set node %p:%x  %x:%x:%x \n",now_sec() ,node,nat_msg->m_fid,nat_msg->m_external_ip,nat_msg->m_external_ip_server,nat_msg->m_external_port);
         #endif
+        node->set_nat_mac_addr(nat_msg->m_external_mac);
         node->set_nat_ipv4_addr(nat_msg->m_external_ip);
         node->set_nat_ipv4_port(nat_msg->m_external_port);
         node->set_nat_ipv4_addr_server(nat_msg->m_external_ip_server);
@@ -6359,7 +6360,7 @@ bool CSimplePacketParser::Parse(){
 
     rte_mbuf_t * m=m_m;
     uint8_t *p=rte_pktmbuf_mtod(m, uint8_t*);
-    EthernetHeader *m_ether = (EthernetHeader *)p;
+    EthernetHeader *ether = (EthernetHeader *)p;
     IPHeader * ipv4=0;
     IPv6Header * ipv6=0;
     m_vlan_offset=0;
@@ -6368,7 +6369,7 @@ bool CSimplePacketParser::Parse(){
     uint8_t protocol = 0;
 
     // Retrieve the protocol type from the packet
-    switch( m_ether->getNextProtocol() ) {
+    switch( ether->getNextProtocol() ) {
     case EthernetHeader::Protocol::IP :
         // IPv4 packet
         ipv4=(IPHeader *)(p+14);
@@ -6385,7 +6386,7 @@ bool CSimplePacketParser::Parse(){
         break;
     case EthernetHeader::Protocol::VLAN :
         m_vlan_offset = 4;
-        switch ( m_ether->getVlanProtocol() ){
+        switch ( ether->getVlanProtocol() ){
         case EthernetHeader::Protocol::IP:
             // IPv4 packet
             ipv4=(IPHeader *)(p+18);
@@ -6409,6 +6410,7 @@ bool CSimplePacketParser::Parse(){
     m_protocol =protocol;
     m_ipv4=ipv4;
     m_ipv6=ipv6;
+    m_ether=ether;
 
     if ( protocol == 0 ){
         return (false);

--- a/src/latency.cpp
+++ b/src/latency.cpp
@@ -436,7 +436,7 @@ bool CCPortLatency::check_packet(rte_mbuf_t * m,CRx_check_header * & rx_p) {
                         m_no_ipv4_option++;
                         return (false);
                     }
-                    m_parent->get_nat_manager()->handle_packet_ipv4(lp,parser.m_ipv4);
+                    m_parent->get_nat_manager()->handle_packet_ipv4(lp,parser.m_ipv4,parser.m_ether);
                     opt_len -= CNatOption::noOPTION_LEN;
                     opt_ptr += CNatOption::noOPTION_LEN;
                     break;
@@ -447,7 +447,7 @@ bool CCPortLatency::check_packet(rte_mbuf_t * m,CRx_check_header * & rx_p) {
         } // End of while
 	if (CGlobalInfo::is_learn_mode(CParserOption::LEARN_MODE_TCP_ACK)
 	    && parser.IsNatInfoPkt()) {
-		m_parent->get_nat_manager()->handle_packet_ipv4(NULL, parser.m_ipv4);
+		m_parent->get_nat_manager()->handle_packet_ipv4(NULL, parser.m_ipv4,parser.m_ether);
 	}
 
         return (true);

--- a/src/latency.h
+++ b/src/latency.h
@@ -123,6 +123,7 @@ public:
     }
 
 public:
+    EthernetHeader *m_ether;
     IPHeader *      m_ipv4;
     IPv6Header *    m_ipv6;
     uint8_t         m_protocol;

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -2215,7 +2215,11 @@ int CCoreEthIF::send_node(CGenNode * node){
     uint8_t p_id=lp_port->m_port->get_port_id();
 
 
-    memcpy(p,CGlobalInfo::m_options.get_dst_src_mac_addr(p_id),12);
+    if (node->get_dont_override_dst_mac()) {
+        memcpy(p+6,CGlobalInfo::m_options.get_dst_src_mac_addr(p_id)+6,6);
+    } else {
+        memcpy(p,CGlobalInfo::m_options.get_dst_src_mac_addr(p_id),12);
+    }
 
     /* if customer enables both mac_file and get_mac_ip_overide,
      * we will apply mac_file.

--- a/src/nat_check.cpp
+++ b/src/nat_check.cpp
@@ -148,7 +148,7 @@ void CNatRxManager::get_info_from_tcp_ack(uint32_t tcp_ack, uint32_t &fid, uint8
  *      If it is NULL, the NAT info is in the TCP ACK number
  *   ipv4 - pointer to ipv4 header to extract info from.
  */
-void CNatRxManager::handle_packet_ipv4(CNatOption *option, IPHeader *ipv4) {
+void CNatRxManager::handle_packet_ipv4(CNatOption *option, IPHeader *ipv4, EthernetHeader *ether) {
     CNatPerThreadInfo * thread_info;
     uint32_t fid=0;
 
@@ -194,6 +194,7 @@ void CNatRxManager::handle_packet_ipv4(CNatOption *option, IPHeader *ipv4) {
     CNatFlowInfo * msg=node->get_next_msg();
 
     /* fill the message */
+    ether->getSrcMacP()->copyToArray(msg->m_external_mac);
     msg->m_external_ip   = ext_ip;
     msg->m_external_ip_server = ext_ip_server;
     msg->m_external_port = ext_port;

--- a/src/nat_check.h
+++ b/src/nat_check.h
@@ -120,6 +120,7 @@ private:
 };
 
 struct CNatFlowInfo {
+    uint8_t m_external_mac[6];
     uint32_t m_external_ip;
     uint32_t m_external_ip_server;
     uint32_t m_fid;
@@ -216,7 +217,7 @@ class CNatRxManager {
 public:
     bool Create();
     void Delete();
-    void handle_packet_ipv4(CNatOption * option, IPHeader * ipv4);
+    void handle_packet_ipv4(CNatOption * option, IPHeader * ipv4, EthernetHeader * ether);
     void handle_aging();
     void Dump(FILE *fd);
     void DumpShort(FILE *fd);


### PR DESCRIPTION
When NAT learning is enabled, TRex will also learn the source MAC address used
when sending packets to the server side. This MAC address will be used as the
destination MAC when sending packets from server to client. This will ignore the
destination MAC address defined in /etc/trex_cfg.yaml.
