### PR TITLE
Send gratuitous ARPs

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -490,6 +490,7 @@ includes_path =''' ../src/pal/linux_dpdk/
 ../src/dpdk22/lib/librte_kvargs/
 ../src/dpdk22/lib/librte_mbuf/
 ../src/dpdk22/lib/librte_mempool/
+../src/dpdk22/lib/librte_net/
 ../src/dpdk22/lib/librte_pipeline/
 ../src/dpdk22/lib/librte_ring/
 ../src/dpdk22/
@@ -547,6 +548,7 @@ dpdk_includes_path =''' ../src/
 ../src/dpdk22/lib/librte_kvargs/
 ../src/dpdk22/lib/librte_mbuf/
 ../src/dpdk22/lib/librte_mempool/
+../src/dpdk22/lib/librte_net/
 ../src/dpdk22/lib/librte_pipeline/
 ../src/dpdk22/lib/librte_ring/
 ../src/dpdk22/lib/librte_net/

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -1467,7 +1467,7 @@ public:
         EXIT_PORT_SCHED         =8,
 
         PCAP_PKT                =9,
-
+        SEND_ARP                =10,
 
     };
 

--- a/src/latency.h
+++ b/src/latency.h
@@ -345,10 +345,17 @@ public:
     void  stop();
     bool  is_active();
     void set_ip(uint32_t client_ip,
+                size_t num_clients,
                 uint32_t server_ip,
+                size_t num_servers,
                 uint32_t mask_dual_port){
+        m_client_ip = client_ip;
+        m_num_clients = num_clients;
+        m_server_ip = server_ip;
+        m_num_servers = num_servers;
         m_pkt_gen.set_ip(client_ip,server_ip,mask_dual_port);
     }
+    void set_gre_info(CFlowGenListGre *gre_info) { m_gre_info = gre_info; }
     void Dump(FILE *fd); // dump all
     void DumpShort(FILE *fd); // dump short histogram of latency 
 
@@ -380,6 +387,7 @@ public:
 private:
     void  tickle();
     void  send_pkt_all_ports();
+    void  send_arps(void);
     void  try_rx();
     void  try_rx_queues();
     void  run_rx_queue_msgs(uint8_t thread_id,
@@ -408,6 +416,11 @@ private:
      TrexMonitor             m_monitor;
 
      volatile bool           m_do_stop __rte_cache_aligned ;
+     uint32_t                m_client_ip;
+     size_t                  m_num_clients;
+     uint32_t                m_server_ip;
+     size_t                  m_num_servers;
+     CFlowGenListGre         *m_gre_info;
 };
 
 #endif

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4218,9 +4218,14 @@ int CGlobalTRex::start_master_statefull() {
     CTupleGenYamlInfo * tg=&m_fl.m_yaml_info.m_tuple_gen;
 
     m_mg.set_ip( tg->m_client_pool[0].get_ip_start(),
+                 tg->m_client_pool[0].getTotalIps(),
                  tg->m_server_pool[0].get_ip_start(),
+                 tg->m_server_pool[0].getTotalIps(),
                  tg->m_client_pool[0].getDualMask()
                  );
+    if ( CGlobalInfo::is_gre_enable() ) {
+        m_mg.set_gre_info(&m_fl.m_gre_info);
+    }
 
     if (  CGlobalInfo::m_options.preview.getVMode() >0 ) {
         m_fl.DumpCsv(stdout);


### PR DESCRIPTION
Since TRex can (will) not respond to ARP requests, it seems to be simpler to
just send gratuitous ARPs on all ends (clients, servers and GRE tunnels, when
used). This is done every 2 seconds.
