### PR TITLE
Scapy service gui updates

### DIFF
--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/protocols.json
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/protocols.json
@@ -1,0 +1,194 @@
+[
+  {
+    "id": "Ether",
+    "name": "Ethernet II",
+    "fields": [
+      {
+        "id": "dst",
+        "name": "Destination",
+        "type": "MAC_ADDRESS",
+        "regex": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+      },
+      {
+        "id": "src",
+        "name": "Source",
+        "type": "MAC_ADDRESS",
+        "regex": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+      },
+      {
+        "id": "type",
+        "name": "Type"
+      }
+    ],
+    "payload": ["IP", "IPv6", "Dot1Q", "Raw"]
+  },
+  {
+    "id": "IP",
+    "name": "IPv4",
+    "fields": [
+      {
+        "id": "version",
+        "name": "Version"
+      },
+      {
+        "id": "ihl",
+        "name": "IHL",
+        "type": "NUMBER",
+        "auto": true
+      },
+      {
+        "id": "tos",
+        "name": "TOS",
+        "type": "NUMBER"
+      },
+      {
+        "id": "len",
+        "name": "Total Length",
+        "type": "NUMBER",
+        "auto": true
+      },
+      {
+        "id": "id",
+        "name": "Identification",
+        "type": "NUMBER"
+      },
+      {
+        "id": "flags",
+        "name": "Flags",
+        "type": "BITMASK",
+        "bits": [
+          {"name": "Reserved", "mask": 4, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 4}]},
+          {"name": "Fragment", "mask": 2, "values":[{"name":"May fragment (0)", "value": 0}, {"name":"Don't fragment (1)", "value": 2}]},
+          {"name": "More Fragments(MF)", "mask": 1, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 1}]}
+        ]
+      },
+      {
+        "id": "frag",
+        "name": "Fragment offset",
+        "type": "NUMBER"
+      },
+      {
+        "id": "ttl",
+        "name": "TTL",
+        "type": "NUMBER",
+        "min": 1,
+        "max": 255
+        
+      },
+      {
+        "id": "proto",
+        "name": "Protocol"
+      },
+      {
+        "id": "chksum",
+        "name": "Checksum",
+        "type": "STRING",
+        "auto": true
+      },
+      {
+        "id": "src",
+        "name": "Source address",
+        "type": "IP_ADDRESS"
+      },
+      {
+        "id": "dst",
+        "name": "Destination address",
+        "type": "IP_ADDRESS"
+      },
+      {
+        "id": "options",
+        "name": "Options",
+        "type": "IP_OPTIONS"
+      }
+    ],
+    "payload": ["TCP", "UDP", "ICMP", "Raw"]
+  },
+  {
+    "id": "TCP",
+    "name": "TCP",
+    "fields": [
+      {
+        "id": "sport",
+        "name": "Source port",
+        "type": "NUMBER",
+        "min": 0,
+        "max": 65535
+        
+      },
+      {
+        "id": "dport",
+        "name": "Destination port",
+        "type": "NUMBER",
+        "min": 0,
+        "max": 65535
+      },
+      {
+        "id": "seq",
+        "name": "Sequence number",
+        "type": "NUMBER"
+      },
+      {
+        "id": "ack",
+        "name": "Acknowledgment number",
+        "type": "NUMBER"
+      },
+      {
+        "id": "dataofs",
+        "name": "Data offset",
+        "type": "NUMBER"
+      },
+      {
+        "id": "reserved",
+        "name": "Reserved",
+        "type": "NUMBER"
+      },
+      {
+        "id": "flags",
+        "name": "Flags",
+        "auto": false,
+        "type": "BITMASK",
+        "bits": [
+          {"name": "URG", "mask": 32, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 32}]},
+          {"name": "ACK", "mask": 16, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 16}]},
+          {"name": "PSH", "mask": 8, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 8}]},
+          {"name": "RST", "mask": 4, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 4}]},
+          {"name": "SYN", "mask": 2, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 2}]},
+          {"name": "FIN", "mask": 1, "values":[{"name":"Not Set", "value": 0}, {"name":"Set", "value": 1}]}
+        ]
+      },
+      {
+        "id": "window",
+        "name": "Window size",
+        "type": "NUMBER"
+      },
+      {
+        "id": "chksum",
+        "name": "Checksum",
+        "auto": true,
+        "type": "NUMBER"
+      },
+      {
+        "id": "urgptr",
+        "name": "Urgent pointer",
+        "type": "NUMBER"
+      },
+      {
+        "id": "options",
+        "name": "Options",
+        "type": "TCP_OPTIONS"
+      }
+    ]
+  },
+  {
+    "id": "Raw",
+    "name": "Raw",
+    "fields": [
+      {
+        "id": "load",
+        "name": "Payload",
+        "type": "BYTES"
+      }
+    ]
+  }
+]
+

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -315,18 +315,21 @@ def generate_bytes(bytes_definition):
     # {generate: template, template_base64: '<base64str>',  size: <size_bytes>}
     # {generate: template_code, template_text_code: '<template_code_str>',  size: <size_bytes>}
     gen_type = bytes_definition.get('generate')
-    bytes_size = bytes_definition.get('size') 
-    seed = bytes_definition.get('seed') or 12345
-    if gen_type == 'random_bytes':
-        return generate_random_bytes(bytes_size, seed, 0, 0xFF)
-    elif gen_type == 'random_ascii':
-        return generate_random_bytes(bytes_size, seed, 0x20, 0x7E)
-    elif gen_type == 'template':
-        return generate_bytes_from_template(bytes_size, b64_to_bytes(bytes_definition["template_base64"]))
-    elif gen_type == 'template_code':
-        return generate_bytes_from_template(bytes_size, bytes_definition["template_code"])
-    elif gen_type == None:
+    if gen_type == None:
         return b64_to_bytes(bytes_definition['base64'])
+    else:
+        bytes_size = int(bytes_definition['size']) # required
+        seed = int(bytes_definition.get('seed') or 12345) # optional
+        if (bytes_size > (1<<20)): # 1Mb ought to be enough for anybody
+            raise ValueError('size is too large')
+        if gen_type == 'random_bytes':
+            return generate_random_bytes(bytes_size, seed, 0, 0xFF)
+        elif gen_type == 'random_ascii':
+            return generate_random_bytes(bytes_size, seed, 0x20, 0x7E)
+        elif gen_type == 'template':
+            return generate_bytes_from_template(bytes_size, b64_to_bytes(bytes_definition["template_base64"]))
+        elif gen_type == 'template_code':
+            return generate_bytes_from_template(bytes_size, bytes_definition["template_code"])
 
 
 class ScapyException(Exception): pass

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -309,6 +309,11 @@ def parse_template_code(template_code):
     template_code = re.sub("[\s]", '', template_code) # remove spaces
     return bytearray.fromhex(template_code)
 
+def verify_payload_size(size):
+    assert(size != None)
+    if (size > (1<<20)): # 1Mb ought to be enough for anybody
+        raise ValueError('size is too large')
+
 def generate_bytes(bytes_definition):
     # accepts a bytes definition object
     # {generate: random_bytes or random_ascii, seed: <seed_number>, size: <size_bytes>}
@@ -317,20 +322,21 @@ def generate_bytes(bytes_definition):
     gen_type = bytes_definition.get('generate')
     if gen_type == None:
         return b64_to_bytes(bytes_definition['base64'])
+    elif gen_type == 'template_code':
+        code = parse_template_code(bytes_definition["template_code"])
+        bytes_size = int(bytes_definition.get('size') or len(code))
+        verify_payload_size(bytes_size)
+        return generate_bytes_from_template(bytes_size, code)
     else:
         bytes_size = int(bytes_definition['size']) # required
         seed = int(bytes_definition.get('seed') or 12345) # optional
-        if (bytes_size > (1<<20)): # 1Mb ought to be enough for anybody
-            raise ValueError('size is too large')
+        verify_payload_size(bytes_size)
         if gen_type == 'random_bytes':
             return generate_random_bytes(bytes_size, seed, 0, 0xFF)
         elif gen_type == 'random_ascii':
             return generate_random_bytes(bytes_size, seed, 0x20, 0x7E)
         elif gen_type == 'template':
             return generate_bytes_from_template(bytes_size, b64_to_bytes(bytes_definition["template_base64"]))
-        elif gen_type == 'template_code':
-            return generate_bytes_from_template(bytes_size, parse_template_code(bytes_definition["template_code"]))
-
 
 class ScapyException(Exception): pass
 class Scapy_service(Scapy_service_api):

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -424,7 +424,7 @@ class Scapy_service(Scapy_service_api):
         if type(val) == type({}):
             value_type = val['vtype']
             if value_type == 'EXPRESSION':
-                return eval(val['expr'], {})
+                return eval(val['expr'], scapy.all.__dict__)
             elif value_type == 'BYTES':   # bytes payload(ex Raw.load)
                 return generate_bytes(val)
             elif value_type == 'OBJECT':

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -329,7 +329,7 @@ def generate_bytes(bytes_definition):
         elif gen_type == 'template':
             return generate_bytes_from_template(bytes_size, b64_to_bytes(bytes_definition["template_base64"]))
         elif gen_type == 'template_code':
-            return generate_bytes_from_template(bytes_size, bytes_definition["template_code"])
+            return generate_bytes_from_template(bytes_size, parse_template_code(bytes_definition["template_code"]))
 
 
 class ScapyException(Exception): pass

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -282,12 +282,17 @@ def get_sample_field_val(scapy_layer, fieldId):
 
 def generate_random_bytes(sz, seed, start, end):
     # generate bytes of specified range with a fixed seed and size
-    rnd = random.Random(seed)
-    end = end + 1 # to include end value
-    res = [rnd.randrange(start, end) for _i in range(sz)]
+    rnd = random.Random()
+    n = end - start + 1
     if is_python(2):
+        rnd = random.Random(seed)
+        res = [start + int(rnd.random()*n) for _i in range(sz)]
         return ''.join(chr(x) for x in res)
     else:
+        rnd = random.Random()
+        # to generate same random sequence as 2.x
+        rnd.seed(seed, version=1)
+        res = [start + int(rnd.random()*n) for _i in range(sz)]
         return bytes(res)
 
 def generate_bytes_from_template(sz, template):
@@ -363,7 +368,7 @@ class Scapy_service(Scapy_service_api):
     def _load_definitions_from_json(self):
         # load protocol definitions from a json file
         self.protocol_definitions = {}
-        with file('protocols.json') as f:
+        with open('protocols.json', 'r') as f:
             protocols = json.load(f)
             for protocol in protocols:
                 self.protocol_definitions[ protocol['id'] ] = protocol

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/basetest.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/basetest.py
@@ -62,6 +62,9 @@ def reconstruct_pkt(bytes_b64, model_def):
 def get_definitions(def_filter):
     return pass_result(service.get_definitions(v_handler, def_filter))
 
+def get_definition_of(scapy_classname):
+    return pass_result(service.get_definitions(v_handler, [scapy_classname]))['protocols'][0]
+
 def get_payload_classes(def_filter):
     return pass_result(service.get_payload_classes(v_handler, def_filter))
 

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
@@ -163,7 +163,7 @@ def test_layer_wrong_structure():
     assert(real_structure == ["Ether", "IP", "Raw", None, None])
     assert(valid_structure_flags == [True, True, True, False, False])
 
-def test_hand_crafted_definitions():
+def test_ether_definitions():
     etherDef = get_definition_of("Ether")
     assert(etherDef['name'] == "Ethernet II")
     etherFields = etherDef['fields']
@@ -173,4 +173,28 @@ def test_hand_crafted_definitions():
     assert(etherFields[1]['name'] == 'Source')
     assert(etherFields[2]['id'] == 'type')
     assert(etherFields[2]['name'] == 'Type')
+
+def test_ether_definitions():
+    pdef = get_definition_of("ICMP")
+    assert(pdef['id'] == "ICMP")
+    assert(pdef['name'])
+    assert(pdef['fields'])
+
+def test_ip_definitions():
+    pdef = get_definition_of("IP")
+    fields = pdef['fields']
+    assert(fields[0]['id'] == 'version')
+
+    assert(fields[1]['id'] == 'ihl')
+    assert(fields[1]['auto'] == True)
+
+    assert(fields[3]['id'] == 'len')
+    assert(fields[3]['auto'] == True)
+
+    assert(fields[5]['id'] == 'flags')
+    assert(fields[5]['type'] == 'BITMASK')
+    assert(fields[5]['bits'][0]['name'] == 'Reserved')
+
+    assert(fields[9]['id'] == 'chksum')
+    assert(fields[9]['auto'] == True)
 

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
@@ -78,6 +78,35 @@ def test_build_Raw():
         ])
     assert(str(pkt[Raw].load == "hi"))
 
+def test_build_fixed_pkt_size_bytes_gen():
+    pkt = build_pkt_get_scapy([
+        layer_def("Ether"),
+        layer_def("IP"),
+        layer_def("TCP"),
+        layer_def("Raw", load={
+            "vtype": "BYTES",
+            "generate": "template",
+            "total_size": 64,
+            "template_base64": bytes_to_b64(b"hi")
+        })
+        ])
+    print(len(pkt))
+    assert(len(pkt) == 64)
+
+def test_build_fixed_pkt_size_bytes_gen():
+    pkt = build_pkt_get_scapy([
+        layer_def("Ether"),
+        layer_def("IP"),
+        layer_def("TCP"),
+        layer_def("Raw", load={
+            "vtype": "BYTES",
+            "generate": "random_ascii",
+            "total_size": 256
+        })
+        ])
+    print(len(pkt))
+    assert(len(pkt) == 256)
+
 def test_get_all():
     service.get_all(v_handler)
 

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
@@ -159,6 +159,28 @@ def test_layer_random_value():
     ether_fields = fields_to_map(res['data'][0]['fields'])
     assert(re.match(RE_MAC, ether_fields['src']['value']))
 
+def test_IP_options():
+    options_expr = "[IPOption_SSRR(copy_flag=0, routers=['1.2.3.4', '5.6.7.8'])]"
+    res = build_pkt([
+        layer_def("Ether"),
+        layer_def("IP", options={"vtype": "EXPRESSION", "expr": options_expr}),
+        ])
+    pkt = build_pkt_to_scapy(res)
+    options = pkt[IP].options
+    assert(options[0].__class__.__name__ == 'IPOption_SSRR')
+    assert(options[0].copy_flag == 0)
+    assert(options[0].routers == ['1.2.3.4', '5.6.7.8'])
+
+def test_TCP_options():
+    options_expr = "[('MSS', 1460), ('NOP', None), ('NOP', None), ('SAckOK', b'')]"
+    pkt = build_pkt_get_scapy([
+        layer_def("Ether"),
+        layer_def("IP"),
+        layer_def("TCP", options={"vtype": "EXPRESSION", "expr": options_expr}),
+        ])
+    options = pkt[TCP].options
+    assert(options[0] == ('MSS', 1460) )
+
 def test_layer_wrong_structure():
     payload = [
             layer_def("Ether"),

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
@@ -98,6 +98,16 @@ def test_get_payload_classes():
     assert("IP" in eth_payloads)
     assert("Dot1Q" in eth_payloads)
     assert("TCP" not in eth_payloads)
+    assert(eth_payloads[0] == "IP") # order(based on prococols.json)
+
+def test_get_tcp_payload_classes():
+    payloads = get_payload_classes([{"id":"TCP"}])
+    assert("Raw" in payloads)
+
+def test_get_dot1q_payload_classes():
+    payloads = get_payload_classes([{"id":"Dot1Q"}])
+    assert("Dot1Q" in payloads)
+    assert("IP" in payloads)
 
 def test_pcap_read_and_write():
     pkts_to_write = [bytes_to_b64(bytes(TEST_PKT))]
@@ -152,4 +162,15 @@ def test_layer_wrong_structure():
     valid_structure_flags = [layer["valid_structure"] for layer in model]
     assert(real_structure == ["Ether", "IP", "Raw", None, None])
     assert(valid_structure_flags == [True, True, True, False, False])
+
+def test_hand_crafted_definitions():
+    etherDef = get_definition_of("Ether")
+    assert(etherDef['name'] == "Ethernet II")
+    etherFields = etherDef['fields']
+    assert(etherFields[0]['id'] == 'dst')
+    assert(etherFields[0]['name'] == 'Destination')
+    assert(etherFields[1]['id'] == 'src')
+    assert(etherFields[1]['name'] == 'Source')
+    assert(etherFields[2]['id'] == 'type')
+    assert(etherFields[2]['name'] == 'Type')
 

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
@@ -54,7 +54,7 @@ def test_generate_template_code():
     print(res)
     assert(res == bytearray.fromhex('DE AD BE EF DE AD'))
 
-def test_generate_template_code():
+def test_generate_template_base64():
     res = generate_bytes({"generate":"template", "template_base64": bytes_to_b64(b'hi'), "size": 5})
     print(res)
     assert(res == b'hihih')

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
@@ -49,9 +49,16 @@ def test_generate_ascii_default_seed():
     assert(len(res) == 14)
 
 
-def test_generate_template_code():
+def test_generate_template_code_no_size():
+    res = generate_bytes({"generate":"template_code", "template_code": "BE EF"})
+    assert(res == bytearray.fromhex('BE EF'))
+
+def test_generate_template_code_less():
+    res = generate_bytes({"generate":"template_code", "template_code": "DE AD BE EF", "size": 2})
+    assert(res == bytearray.fromhex('DE AD'))
+
+def test_generate_template_code_more():
     res = generate_bytes({"generate":"template_code", "template_code": "0xDEAD 0xBEEF", "size": 6})
-    print(res)
     assert(res == bytearray.fromhex('DE AD BE EF DE AD'))
 
 def test_generate_template_base64():

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
@@ -1,0 +1,58 @@
+# run with 'nosetests' utility
+
+from basetest import *
+from scapy_service import *
+
+def test_generate_random_bytes():
+    res = generate_random_bytes(10, 333, ord('0'), ord('9'))
+    print(res)
+    assert(len(res) == 10)
+    assert(res == '5390532937') # random value with this seed
+
+def test_generate_bytes_from_template_empty():
+    res = generate_bytes_from_template(5, b"")
+    print(res)
+    assert(res == b"")
+
+def test_generate_bytes_from_template_less():
+    res = generate_bytes_from_template(5, b"qwe")
+    print(res)
+    assert(res == b"qweqw")
+
+def test_generate_bytes_from_template_same():
+    res = generate_bytes_from_template(5, b"qwert")
+    print(res)
+    assert(res == b"qwert")
+
+def test_generate_bytes_from_template_more():
+    res = generate_bytes_from_template(5, b"qwerty")
+    print(res)
+    assert(res == b"qwert")
+
+def test_parse_template_code_with_trash():
+    res = parse_template_code("0xDE AD\n be ef \t0xDEAD")
+    print(res)
+    assert(res == bytearray.fromhex('DEADBEEFDEAD'))
+
+def test_generate_bytes():
+    res = generate_bytes({"generate":"random_bytes", "seed": 123, "size": 12})
+    print(res)
+    assert(len(res) == 12)
+
+def test_generate_ascii_default_seed():
+    res = generate_bytes({"generate":"random_ascii", "size": 14})
+    print(res)
+    assert(len(res) == 14)
+
+
+def test_generate_template_code():
+    res = generate_bytes({"generate":"template_code", "template_code": "0xDEAD 0xBEEF", "size": 6})
+    print(res)
+    assert(res == bytearray.fromhex('DE AD BE EF DE AD'))
+
+def test_generate_template_code():
+    res = generate_bytes({"generate":"template", "template_base64": bytes_to_b64(b'hi'), "size": 5})
+    print(res)
+    assert(res == b'hihih')
+
+

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
@@ -7,7 +7,7 @@ def test_generate_random_bytes():
     res = generate_random_bytes(10, 333, ord('0'), ord('9'))
     print(res)
     assert(len(res) == 10)
-    assert(res == '5390532937') # random value with this seed
+    assert(res == b'5390532937') # random value with this seed
 
 def test_generate_bytes_from_template_empty():
     res = generate_bytes_from_template(5, b"")

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_utils.py
@@ -14,6 +14,10 @@ def test_generate_bytes_from_template_empty():
     print(res)
     assert(res == b"")
 
+def test_generate_bytes_from_template_neg():
+    res = generate_bytes_from_template(-5, b"qwe")
+    assert(res == b"")
+
 def test_generate_bytes_from_template_less():
     res = generate_bytes_from_template(5, b"qwe")
     print(res)


### PR DESCRIPTION
this PR contains hand-crafted protocol definition file - it allows to adjust field names and UI controls on scapy server side without UI code modification - trex-doc is up to date

added payload generation on scapy_server side(with optional fixed random seed and ability to specify full pkt size)

payload gen documentation: https://github.com/cisco-system-traffic-generator/trex-doc/pull/2, also see unit tests as usage examples
