### PR TITLE
scapy_service: take into account Ether.chksum when generating payload

### DIFF
--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -468,7 +468,8 @@ class Scapy_service(Scapy_service_api):
                     gen.update(val)
                     total_sz = gen['total_size']
                     del gen['total_size']
-                    gen['size'] = total_sz - len(scapy_pkt)
+                    ether_chksum_size_bytes = 4 # will be added outside of Scapy. needs to be excluded here
+                    gen['size'] = total_sz - len(scapy_pkt) - ether_chksum_size_bytes
                     return generate_bytes(gen)
                 else:
                     return generate_bytes(val)

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
@@ -6,6 +6,7 @@ import re
 from basetest import *
 
 RE_MAC = "^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$"
+ether_chksum_sz = 4 # this chksum will be added automatically(outside of scapy/packet editor)
 
 TEST_MAC_1 = "10:10:10:10:10:10"
 # Test scapy structure
@@ -78,7 +79,7 @@ def test_build_Raw():
         ])
     assert(str(pkt[Raw].load == "hi"))
 
-def test_build_fixed_pkt_size_bytes_gen():
+def test_build_fixed_pkt_size_template_gen_64():
     pkt = build_pkt_get_scapy([
         layer_def("Ether"),
         layer_def("IP"),
@@ -91,9 +92,9 @@ def test_build_fixed_pkt_size_bytes_gen():
         })
         ])
     print(len(pkt))
-    assert(len(pkt) == 64)
+    assert(len(pkt) == 64 - ether_chksum_sz)
 
-def test_build_fixed_pkt_size_bytes_gen():
+def test_build_fixed_pkt_size_bytes_gen_256():
     pkt = build_pkt_get_scapy([
         layer_def("Ether"),
         layer_def("IP"),
@@ -105,7 +106,7 @@ def test_build_fixed_pkt_size_bytes_gen():
         })
         ])
     print(len(pkt))
-    assert(len(pkt) == 256)
+    assert(len(pkt) == 256 - ether_chksum_sz)
 
 def test_get_all():
     service.get_all(v_handler)


### PR DESCRIPTION
one-line change:  reduce total_size by 4 bytes

CI: https://drone.io/github.com/kisel/trex-core/32