### PR TITLE
[STL_GUI-72] Add predefined packet templates

### DIFF
--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -881,7 +881,7 @@ class Scapy_service(Scapy_service_api):
         for instruction_def in instructions_def:
             instruction_id = instruction_def['id']
             instruction_class = self._vm_instructions[instruction_id]
-            parameters = {k: self._sanitize_value(k, v) for (k, v) in instruction_def['parameters'].iteritems()}
+            parameters = {k: self._sanitize_value(k, v) for (k, v) in instruction_def['parameters'].items()}
             instructions.append(instruction_class(**parameters))
 
         fe_parameters = field_engine_model_descriptor['global_parameters']

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -264,6 +264,34 @@ class Scapy_service_api():
         """
         pass
 
+    def get_templates(self,client_v_handler):
+        """ get_templates(self,client_v_handler)
+
+        Returns an array of templates, which normally can be used for creating packet
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        array of templates
+        """
+        pass
+
+    def get_template(self,client_v_handler,template):
+        """ get_template(self,client_v_handler,template)
+
+        Returns a template, which normally can be used for creating packet
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        base64 of template content
+        """
+        pass
+
 def is_python(version):
     return version == sys.version_info[0]
 
@@ -933,7 +961,7 @@ class Scapy_service(Scapy_service_api):
         else:
             return pkt_class()
 
-        
+
     def _get_payload_classes(self, pkt_class):
         # tries to find, which subclasses allowed.
         # this can take long time, since it tries to build packets with all subclasses(O(N))
@@ -949,6 +977,61 @@ class Scapy_service(Scapy_service_api):
                     # no actions needed on fail, just sliently skip
                     pass
         return allowed_subclasses
+
+
+
+    def _get_templates(self):
+        # Make sure you understand the three return values of os.walk:
+        #
+        # for root, subdirs, files in os.walk(rootdir):
+        #     has the following meaning:
+        #
+        # root: Current path which is "walked through"
+        # subdirs: Files in root of type directory
+        # files: Files in root (not in subdirs) of type other than directory
+        # And please use os.path.join instead of concatenating with a slash!
+        # Your problem is filePath = rootdir + '/' + file - you must concatenate the currently "walked" folder instead of the topmost folder.
+        # So that must be filePath = os.path.join(root, file). BTW "file" is a builtin, so you don't normally use it as variable name.
+
+        templates = []
+        for root, subdirs, files in os.walk("templates"):
+            for file in files:
+                if file.endswith('.trp'):
+                    try:
+                        f = os.path.join(root, file)
+                        o = open(f)
+                        c = json.loads(o.read())
+                        o.close()
+                        id = f.replace("templates" + os.path.sep, "", 1)
+                        id = id.split(os.path.sep)
+                        id[-1] = id[-1].replace(".trp", "", 1)
+                        id = "/".join(id)
+                        t = {
+                                "id": id,
+                                 "meta": {
+                                     "name": c["metadata"]["caption"],
+                                     "description": ""
+                                 }
+                            }
+                        templates.append(t)
+                    except:
+                        pass
+        return templates
+
+    def _get_template(self,template):
+        id = template["id"]
+        f2 = "templates" + os.path.sep + os.path.sep.join(id.split("/")) + ".trp"
+        for c in r'[]\;,><&*:%=+@!#^()|?^':
+            id = id.replace(c,'')
+        id = id.replace("..", "")
+        id = id.split("/")
+        f = "templates" + os.path.sep + os.path.sep.join(id) + ".trp"
+        if f != f2:
+            return ""
+        with open(f, 'r') as content_file:
+            content = base64.b64encode(content_file.read())
+        return content
+
 
     def _get_fields_definition(self, pkt_class, fieldsDef):
         # fieldsDef - array of field definitions(or empty array)
@@ -1009,6 +1092,12 @@ class Scapy_service(Scapy_service_api):
         if protocolDef and protocolDef.get('payload'):
             return protocolDef['payload']
         return [c.__name__ for c in self._get_payload_classes(pkt_class)]
+
+    def get_templates(self,client_v_handler):
+        return self._get_templates()
+
+    def get_template(self,client_v_handler,template):
+        return self._get_template(template)
 
 #input in string encoded base64
     def check_update_of_dbs(self,client_v_handler,db_md5,field_md5):

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/ICMP echo request.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/ICMP echo request.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"ICMP echo request"},"packet":[{"id":"Ether","fields":[]},{"id":"IP","fields":[]},{"id":"ICMP","fields":[{"id":"type","value":"8"}]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv4/ICMP.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv4/ICMP.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"ICMP echo request"},"packet":[{"id":"Ether","fields":[{"id":"type","value":"2048"}]},{"id":"IP","fields":[]},{"id":"ICMP","fields":[]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv4/TCP.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv4/TCP.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"ICMP echo request"},"packet":[{"id":"Ether","fields":[{"id":"type","value":"2048"}]},{"id":"IP","fields":[]},{"id":"TCP","fields":[]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv4/UDP.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv4/UDP.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"ICMP echo request"},"packet":[{"id":"Ether","fields":[{"id":"type","value":"2048"}]},{"id":"IP","fields":[]},{"id":"UDP","fields":[]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv6/ICMP.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv6/ICMP.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"ICMP echo request"},"packet":[{"id":"Ether","fields":[{"id":"type","value":"34525"}]},{"id":"IPv6","fields":[]},{"id":"ICMPv6ND_Redirect","fields":[]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv6/TCP.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv6/TCP.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"ICMP echo request"},"packet":[{"id":"Ether","fields":[{"id":"type","value":"34525"}]},{"id":"IPv6","fields":[]},{"id":"TCP","fields":[]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv6/UDP.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/IPv6/UDP.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"ICMP echo request"},"packet":[{"id":"Ether","fields":[{"id":"type","value":"34525"}]},{"id":"IPv6","fields":[]},{"id":"UDP","fields":[]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/TCP-SYN.trp
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/templates/TCP-SYN.trp
@@ -1,0 +1,1 @@
+{"fileType":"trex-packet-editor","version":"1.0.0","metadata":{"caption":"TCP-SYN"},"packet":[{"id":"Ether","fields":[]},{"id":"IP","fields":[]},{"id":"TCP","fields":[{"id":"flags","value":""}]}],"fePrarameters":{"cache_size":"1000"},"feInstructions":[]}

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/basetest.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/basetest.py
@@ -88,3 +88,12 @@ def adapt_json_protocol_fields(protocols_array):
         # change structure for easier
         if protocol.get("fields"):
             protocol["fields"] = fields_to_map(protocol["fields"])
+
+def get_templates():
+    return pass_result(service.get_templates(v_handler))
+
+
+
+def get_template(t):
+    return pass_result(service.get_template(v_handler, t))
+

--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/unit_tests/test_scapy_service.py
@@ -289,3 +289,43 @@ def test_generate_vm_instructions():
     ttl_instruction = res['field_engine']['instructions']['instructions'][2]
     assert(ttl_instruction['min_value'] == 32)
     assert(ttl_instruction['max_value'] == 64)
+
+
+def test_get_templates():
+    tt = get_templates()
+    assert(tt[0]['id'])
+    assert(tt[7]["meta"]['name'])
+    try:
+        assert(tt[9]['id'])
+    except:
+        pass
+
+
+def test_get_template():
+    tt = get_templates()
+    t = tt[0]
+    res = get_template(t)
+    res2 = base64.b64decode(res)
+    obj = json.loads(res2)
+    assert(obj['packet'][0]['id'] == 'Ether')
+    assert(obj['packet'][1]['id'] == 'IP')
+    assert(obj['packet'][2]['id'] == 'ICMP')
+
+
+def test_get_template2():
+    tt = get_templates()
+    t = tt[7]
+    res = get_template(t)
+    res2 = base64.b64decode(res)
+    obj = json.loads(res2)
+    assert(obj['packet'][0]['id'] == 'Ether')
+    assert(obj['packet'][1]['id'] == 'IPv6')
+    assert(obj['packet'][2]['id'] == 'UDP')
+
+
+def test_get_template3():
+    tt = get_templates()
+    t = tt[7]
+    t["id"] = "../../" + t["id"]
+    res = get_template(t)
+    assert(res == '')


### PR DESCRIPTION
Added possibility to add predefined templates to scapy server which will be available in the stateless GUI.

Original issue in YouTrack: [STL_GUI-72](https://trex-tgn.cisco.com/youtrack/issue/STL_GUI-72)