### PR TITLE
scapy_server: do not fail on uninitialized/unsupported scapy fields

### DIFF
--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/scapy_service.py
@@ -644,8 +644,11 @@ class Scapy_service(Scapy_service_api):
             for field_desc in pkt.fields_desc:
                 field_id = field_desc.name
                 ignored = field_id not in layer_full.fields
-                offset = field_desc._offset
-                protocol_offset = pkt._offset
+                # scapy offset/length calculation doesn't support dynamic size structures
+                # since PktClass.fields_desc is a singletone,
+                # _offset/size can be missing, uninitialized or contain values from the previous runs
+                offset = getattr(field_desc, '_offset', None)
+                protocol_offset = getattr(pkt, '_offset', None)
                 field_sz = field_desc.get_size_bytes()
                 # some values are unavailable in pkt(original model)
                 # at the same time,
@@ -708,7 +711,7 @@ class Scapy_service(Scapy_service_api):
                 fields.append(field_data)
             layer_data = {
                     "id": layer_id,
-                    "offset": pkt._offset,
+                    "offset": protocol_offset,
                     "fields": fields,
                     "real_id": real_layer_id,
                     "valid_structure": valid_struct,


### PR DESCRIPTION
Scapy doesn't support dynamic size structures and can leave _offset field uninitialized.
This PR fixes scapy_server to continue reading the packet, leaving offset None it if is not available.

In order to properly support reading on dynamic structures, significant changes on scapy side needs to be done(don't store length/offsets in singletones - Packet.field_desc[x]._offset) and support their updating

Attached file breaks parsing. corresponding test is added
[dns_query_response.zip](https://github.com/cisco-system-traffic-generator/trex-core/files/840449/dns_query_response.zip)
