### PR TITLE
trex_console: fix help for pkt and service commands

### DIFF
--- a/scripts/automation/trex_control_plane/stl/console/trex_console.py
+++ b/scripts/automation/trex_control_plane/stl/console/trex_console.py
@@ -583,8 +583,8 @@ class TRexConsole(TRexGeneralCmd):
     def do_service (self, line):
         '''Sets port(s) service mode state'''
         self.stateless_client.service_line(line)
-        
-    def help_service (self, line):
+
+    def help_service (self):
         self.do_service("-h")
 
     @verify_connected
@@ -592,7 +592,7 @@ class TRexConsole(TRexGeneralCmd):
         '''Sends a scapy notation packet'''
         self.stateless_client.pkt_line(line)
 
-    def help_pkt (self, line):
+    def help_pkt (self):
         self.do_pkt("-h")
 
     def help_clear(self):


### PR DESCRIPTION
Fix the following issues:

trex>help service
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/root/trex/v2.23/automation/trex_control_plane/stl/console/trex_console.py", line 957, in <module>
    main()
  File "/root/trex/v2.23/automation/trex_control_plane/stl/console/trex_console.py", line 946, in main
    console.start()
  File "/root/trex/v2.23/automation/trex_control_plane/stl/console/trex_console.py", line 710, in start
    self.cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 141, in cmdloop
    line = self.precmd(line)
  File "/root/trex/v2.23/automation/trex_control_plane/stl/console/trex_console.py", line 221, in precmd
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/root/trex/v2.23/automation/trex_control_plane/stl/console/trex_console.py", line 680, in do_help
    func()
TypeError: help_service() takes exactly 2 arguments (1 given)