### PR TITLE
Fix typos, bash formatting

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -123,8 +123,8 @@ TRex curretly works on x86 architecture and can operate well on Cisco UCS hardwa
 
 [IMPORTANT]
 =====================================
-In all bare metal cases, it's important to have 4 DRAM channels. less channels will impose a performance issue.
-to test it you can run `sudo dmidecode -t memory | grep CHANNEL` and check CHANNEL x 
+In all bare metal cases, it's important to have 4 DRAM channels. Fewer channels will impose a performance issue.
+To test it you can run `sudo dmidecode -t memory | grep CHANNEL` and check CHANNEL x 
 =====================================
  
 .Supported NICs
@@ -278,7 +278,7 @@ To check whether a kernel is 64-bit, verify that the ouput of the following comm
 
 [source,bash]
 ----
-$uname -m
+$ uname -m
 x86_64 
 ----
 
@@ -312,7 +312,7 @@ Choose: "Fedora Linux http" -> releases -> <version number> -> Server -> x86_64 
 
 [source,bash]
 ----
-$sha256sum Fedora-18-x86_64-DVD.iso
+$ sha256sum Fedora-18-x86_64-DVD.iso
 91c5f0aca391acf76a047e284144f90d66d3d5f5dcd26b01f368a43236832c03 
 ----
 
@@ -370,23 +370,23 @@ Latest release:
 
 [source,bash]
 ----
-$mkdir trex
-$cd trex
-$wget --no-cache $WEB_URL/release/latest 
-$tar -xzvf latest 
+$ mkdir trex
+$ cd trex
+$ wget --no-cache $WEB_URL/release/latest 
+$ tar -xzvf latest 
 ----
 
 
 Bleeding edge version:
 [source,bash]
 ----
-$wget --no-cache $WEB_URL/release/be_latest 
+$ wget --no-cache $WEB_URL/release/be_latest 
 ----
 
 To obtain a specific version:
 [source,bash]
 ----
-$wget --no-cache $WEB_URL/release/vX.XX.tar.gz #<1>
+$ wget --no-cache $WEB_URL/release/vX.XX.tar.gz #<1>
 ----
 
 <1> X.XX = Version number
@@ -415,7 +415,7 @@ Use the following command to identify ports.
 
 [source,bash]
 ----
- $>sudo ./dpdk_setup_ports.py -s
+ $ sudo ./dpdk_setup_ports.py -s
 
  Network devices using DPDK-compatible driver
  ============================================
@@ -450,7 +450,7 @@ For many purposes, it is convenient to begin with a copy of the basic configurat
 
 [source,bash]
 ----
-$cp  cfg/simple_cfg.yaml /etc/trex_cfg.yaml
+$ cp  cfg/simple_cfg.yaml /etc/trex_cfg.yaml
 ----
 
 Next, edit the configuration file, adding the interface and IP address details.
@@ -591,7 +591,7 @@ After configuration is complete, use the following command to start basic TRex r
 (it will use the default config file name /etc/trex_cfg.yaml):
 [source,bash]
 ----
-$sudo ./t-rex-64 -f cap2/dns.yaml -c 4 -m 1 -d 10  -l 1000
+$ sudo ./t-rex-64 -f cap2/dns.yaml -c 4 -m 1 -d 10  -l 1000
 ----
 
 ==== TRex output
@@ -881,7 +881,7 @@ There is IPv6 support for all plugins.
 *Example:*::
 [source,bash]
 ----
-$sudo ./t-rex-64 -f cap2l/sfr_delay_10_1g.yaml -c 4 -p -l 100 -d 100000 -m 30  --ipv6
+$ sudo ./t-rex-64 -f cap2l/sfr_delay_10_1g.yaml -c 4 -p -l 100 -d 100000 -m 30  --ipv6
 ----
 
 *Limitations:*::
@@ -955,7 +955,7 @@ In the following example, a profile defines a client generator.
 
 [source,bash]
 ----
-$cat cap2/dns.yaml 
+$ cat cap2/dns.yaml 
 - duration : 10.0
   generator :  
           distribution : "seq"           
@@ -1154,14 +1154,14 @@ This mode can provide better connections-per-second performance than mode 1. But
 
 [source,bash]
 ----
-$sudo ./t-rex-64 -f cap2/http_simple.yaml -c 4  -l 1000 -d 100000 -m 30  --learn-mode 1
+$ sudo ./t-rex-64 -f cap2/http_simple.yaml -c 4  -l 1000 -d 100000 -m 30  --learn-mode 1
 ----
 
 *SFR traffic without bundling/ALG support*
 
 [source,bash]
 ----
-$sudo ./t-rex-64 -f avl/sfr_delay_10_1g_no_bundling.yaml -c 4  -l 1000 -d 100000 -m 10  --learn-mode 2
+$ sudo ./t-rex-64 -f avl/sfr_delay_10_1g_no_bundling.yaml -c 4  -l 1000 -d 100000 -m 10  --learn-mode 2
 ----
 
 *NAT terminal counters:*::
@@ -1265,7 +1265,7 @@ This feature ensures that:
 .Full example 
 [source,bash]
 ----
-$sudo ./t-rex-64 -f avl/sfr_delay_10_1g.yaml -c 4 -p -l 100 -d 100000 -m 30  --rx-check 128
+$ sudo ./t-rex-64 -f avl/sfr_delay_10_1g.yaml -c 4 -p -l 100 -d 100000 -m 30  --rx-check 128
 ----
 
 [source,python]
@@ -1486,7 +1486,7 @@ To find out which interfaces (NIC ports) can be used, perform the following:
 
 [source,bash]
 ----
- $>sudo ./dpdk_setup_ports.py --show
+ $ sudo ./dpdk_setup_ports.py --show
 
  Network devices using DPDK-compatible driver
  ============================================
@@ -1786,7 +1786,7 @@ you can create output pcap file from input of traffic YAML.
 [source,bash]
 ----
 
-$./bp-sim-64-debug -f avl/sfr_delay_10_1g.yaml -v 1
+$ ./bp-sim-64-debug -f avl/sfr_delay_10_1g.yaml -v 1
 
  -- loading cap file avl/delay_10_http_get_0.pcap 
  -- loading cap file avl/delay_10_http_post_0.pcap 
@@ -1853,10 +1853,10 @@ To upgrade the firmware  follow  this
 
 [source,bash]
 ----
-$tar -xvzf i40e-1.3.47
-$cd i40e-1.3.47/src
-$make 
-$sudo insmod  i40e.ko
+$ tar -xvzf i40e-1.3.47
+$ cd i40e-1.3.47/src
+$ make 
+$ sudo insmod  i40e.ko
 ----
 
 
@@ -1866,7 +1866,7 @@ In this stage we bind the NIC to Linux (take it from DPDK)
 
 [source,bash]
 ----
-$sudo ./dpdk_nic_bind.py --status # show the ports 
+$ sudo ./dpdk_nic_bind.py --status # show the ports 
 
 Network devices using DPDK-compatible driver
 ============================================
@@ -1875,11 +1875,11 @@ Network devices using DPDK-compatible driver
 0000:87:00.0 'Device 1583' drv=igb_uio unused=
 0000:87:00.1 'Device 1583' drv=igb_uio unused=
 
-$sudo dpdk_nic_bind.py -u 02:00.0  02:00.1          #<3> 
+$ sudo dpdk_nic_bind.py -u 02:00.0  02:00.1          #<3> 
 
-$sudo dpdk_nic_bind.py -b i40e 02:00.0 02:00.1      #<4>
+$ sudo dpdk_nic_bind.py -b i40e 02:00.0 02:00.1      #<4>
 
-$ethtool -i p1p2                                    #<5>  
+$ ethtool -i p1p2                                    #<5>  
 
 driver: i40e
 version: 1.3.47
@@ -1892,8 +1892,8 @@ supports-register-dump: yes
 supports-priv-flags: yes
 
    
-$ethtool -S p1p2 
-$lspci -s 02:00.0 -vvv                              #<7>
+$ ethtool -S p1p2 
+$ lspci -s 02:00.0 -vvv                              #<7>
 
 
 ----
@@ -1915,7 +1915,7 @@ Run this:
 
 [source,bash]
 ----
-$sudo ./nvmupdate64e  
+$ sudo ./nvmupdate64e  
 ----
 
 You might need a power cycle and to run this command a few times to get the latest firmware  
@@ -2070,7 +2070,7 @@ Using these commands the configuration is:
 *Simple HTTP:*::
 [source,bash]
 ----
-$sudo ./t-rex-64 -f cap2/http_simple.yaml -d 1000 -l 1000 --l-pkt-mode 2 -m 1000  --learn-mode 1 -k 1
+$ sudo ./t-rex-64 -f cap2/http_simple.yaml -d 1000 -l 1000 --l-pkt-mode 2 -m 1000  --learn-mode 1 -k 1
 ----
 
 This is more realistic traffic for enterprise (we removed from SFR file the bidirectional UDP traffic templates, which (as described above), are not supported in this mode).
@@ -2078,7 +2078,7 @@ This is more realistic traffic for enterprise (we removed from SFR file the bidi
 *Enterprise profile:*::
 [source,bash]
 ----
-$sudo ./t-rex-64 -f avl/sfr_delay_10_1g_asa_nat.yaml -d 1000 -l 1000 --l-pkt-mode 2 -m 4 --learn-mode 1 -k 1
+$ sudo ./t-rex-64 -f avl/sfr_delay_10_1g_asa_nat.yaml -d 1000 -l 1000 --l-pkt-mode 2 -m 4 --learn-mode 1 -k 1
 ----
 
 The TRex output
@@ -2311,12 +2311,12 @@ sudo ifconfig eth2 up mtu 9000
 TRex stateful performance::
 
 Using the following command, running on x710 card with VF driver, we can see that TRex can reach 30GBps, using only one core. We can also see that the average latency is around 20 usec, which is pretty much the same value we get on loopback ports with x710 physical function without VF.
-$sudo ./t-rex-64 -f cap2/http_simple.yaml -m 40000 -l 100 -c 1 -p
+$ sudo ./t-rex-64 -f cap2/http_simple.yaml -m 40000 -l 100 -c 1 -p
 
 [source,python]
 ----
 
-$sudo ./t-rex-64 -f cap2/http_simple.yaml -m 40000 -l 100 -c 1 -p
+$ sudo ./t-rex-64 -f cap2/http_simple.yaml -m 40000 -l 100 -c 1 -p
 
   -Per port stats table
       ports |               0 |               1
@@ -2361,7 +2361,7 @@ TRex stateless performance::
 [source,python]
 ----
 
-$sudo ./t-rex-64 -i -c 1
+$ sudo ./t-rex-64 -i -c 1
 
 trex>portattr
 Port Status
@@ -2463,21 +2463,21 @@ Make sure you have an internet connection without firewalls for HTTPS/HTTP - req
 .Verify md5
 [source,bash]
 ----
-$md5sum md5sum MLNX_OFED_LINUX-4.0.0.0.0-rhel7.2-x86_64.tgz
+$ md5sum md5sum MLNX_OFED_LINUX-4.0.0.0.0-rhel7.2-x86_64.tgz
 58b9fb369d7c62cedbc855661a89a9fd  MLNX_OFED_LINUX-4.0-xx.0.0.0-rhel7.2-x86_64.tgz
 ----
 
 .Open the tar
 [source,bash]
 ----
-$tar -xvzf MLNX_OFED_LINUX-4.0-x.0.0.0-rhel7.2-x86_64.tgz
-$cd MLNX_OFED_LINUX-4.0-x.0.0.0-rhel7.2-x86_64
+$ tar -xvzf MLNX_OFED_LINUX-4.0-x.0.0.0-rhel7.2-x86_64.tgz
+$ cd MLNX_OFED_LINUX-4.0-x.0.0.0-rhel7.2-x86_64
 ----
 
 .Run Install script
 [source,bash]
 ----
-$sudo ./mlnxofedinstall  
+$ sudo ./mlnxofedinstall  
 
 
 Log: /tmp/ofed.build.log
@@ -2695,14 +2695,14 @@ To load the new driver, run:
 .Reboot 
 [source,bash]
 ----
-$sudo  reboot 
+$ sudo  reboot 
 ----
 
 
 .After reboot 
 [source,bash]
 ----
-$ibv_devinfo 
+$ ibv_devinfo 
 hca_id: mlx5_1
         transport:                      InfiniBand (0)
         fw_ver:                         12.17.1010             << 12.17.00
@@ -2748,7 +2748,7 @@ hca_id: mlx5_0
 .ibdev2netdev
 [source,bash]
 -----
-$ibdev2netdev
+$ ibdev2netdev
 mlx5_0 port 1 ==> eth6 (Down)
 mlx5_1 port 1 ==> eth7 (Down)
 -----
@@ -2757,7 +2757,7 @@ mlx5_1 port 1 ==> eth7 (Down)
 [source,bash]
 -----
 
-        $sudo ./dpdk_setup_ports.py -t
+        $ sudo ./dpdk_setup_ports.py -t
   +----+------+---------++---------------------------------------------
   | ID | NUMA |   PCI   ||                      Name     |  Driver   | 
   +====+======+=========++===============================+===========+=
@@ -2859,13 +2859,13 @@ There is a task to automate the production of thess reports
 
 * Before running TRex make sure the commands    `ibv_devinfo` and  `ibdev2netdev` present the NICS
 * `ifconfig` should work too, you need to be able to ping from those ports
-* run TRex server with '-v 7' for example `$sudo ./t-rex-64 -i -v 7`
+* run TRex server with '-v 7' for example `sudo ./t-rex-64 -i -v 7`
 * In case the link_layer is not set to *Ethernet* you should run this command
 
 [source,bash]
 ----
-$sudo mlxconfig -d /dev/mst/mt4115_pciconf0 set LINK_TYPE_P1=2 LINK_TYPE_P2=2
-$sudo mlxconfig -d /dev/mst/mt4115_pciconf1 set LINK_TYPE_P1=2 LINK_TYPE_P2=2
+$ sudo mlxconfig -d /dev/mst/mt4115_pciconf0 set LINK_TYPE_P1=2 LINK_TYPE_P2=2
+$ sudo mlxconfig -d /dev/mst/mt4115_pciconf1 set LINK_TYPE_P1=2 LINK_TYPE_P2=2
 ----
 
 see link:https://community.mellanox.com/docs/DOC-2294[ConnectX-4 getting Started]
@@ -2876,14 +2876,14 @@ for example to change to 50Gb speed
 
 [source,bash]
 ----
-$sudo ethtool -s enp135s0f1 speed 50000 autoneg off
+$ sudo ethtool -s enp135s0f1 speed 50000 autoneg off
 ----
 
 * Check how many DRAM channels are installed. Less than 4 will impose latency and performance issue 
 
 [source,bash]
 ----
-$sudo dmidecode -t memory | grep CHANNEL
+$ sudo dmidecode -t memory | grep CHANNEL
 Bank Locator: NODE 0 CHANNEL 0 DIMM 0
 Bank Locator: NODE 0 CHANNEL 0 DIMM 1
 Bank Locator: NODE 0 CHANNEL 0 DIMM 2
@@ -2905,12 +2905,12 @@ Bank Locator: NODE 0 CHANNEL 3 DIMM 2
 [source,bash]
 ----
 
-$sudo lspci | grep  Mellanox
+$ sudo lspci | grep  Mellanox
 87:00.0 Ethernet controller: Mellanox Technologies MT27700 Family [ConnectX-4]  #<1>
 87:00.1 Ethernet controller: Mellanox Technologies MT27700 Family [ConnectX-4]
 
 
-$sudo lspci -vv -s 87:00.0                                                         #<2>     
+$ sudo lspci -vv -s 87:00.0                                                         #<2>     
 87:00.0 Ethernet controller: Mellanox Technologies MT27700 Family [ConnectX-4]
         Subsystem: Mellanox Technologies Device 0008
         Physical Slot: 0-9
@@ -2981,7 +2981,7 @@ $sudo lspci -vv -s 87:00.0                                                      
         Kernel driver in use: mlx5_core
         
 
-$sudo lspci -vt | grep Mellanox                                                       #<5>  
+$ sudo lspci -vt | grep Mellanox                                                       #<5>  
 +-[0000:80]-+-00.0-[81]--
  |           +-01.0-[82]--
  |           +-01.1-[83]--
@@ -2993,7 +2993,7 @@ $sudo lspci -vt | grep Mellanox                                                 
 
 
 
-$sudo lspci -vv -s 0000:80:03.0                                                     #<6>            
+$ sudo lspci -vv -s 0000:80:03.0                                                     #<6>            
 80:03.0 PCI bridge: Intel Corporation Xeon E7 v3/Xeon E5 v3/Core i7 PCI Express Root Port 3 (rev 02) (prog-if 00 [Normal decode])
         Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
         Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
@@ -3213,7 +3213,7 @@ running it with verbose mode with CLI  `-v 7`
 
 [source,bash]
 ----
-$sudo ./t-rex-64 -f cap2/dns.yaml -c 1 -m 1 -d 10  -l 1000 -v 7
+$ sudo ./t-rex-64 -f cap2/dns.yaml -c 1 -m 1 -d 10  -l 1000 -v 7
 ----
 
 will give move info 
@@ -3327,7 +3327,7 @@ There is a  special config file to enlarge the number of flows. This tutorial  p
 .command 
 [source,bash]
 ----
-$sudo ./t-rex-64 -f cap2/cur_flow_single.yaml -m 30000 -c 7 -d 40 -l 1000 --active-flows 5000000 -p --cfg cfg/trex_08_5mflows.yaml
+$ sudo ./t-rex-64 -f cap2/cur_flow_single.yaml -m 30000 -c 7 -d 40 -l 1000 --active-flows 5000000 -p --cfg cfg/trex_08_5mflows.yaml
 ----
 
 The number of active flows can be change using `--active-flows` CLI. in this example it is set to 5M flows


### PR DESCRIPTION
There were some minor typos that I found.
Also in the web version of the documentation, any word that starts with the '$' symbol is highlighted as a variable. Many of the code examples used the '$' as the PS1 prompt, which caused the command to be highlighted as if it was a variable. Adding spaces after all of the PS1 prompts should fix this problem.