### PR TITLE
Fix includes in sim_event_driven.cpp

### DIFF
--- a/src/common/sim_event_driven.cpp
+++ b/src/common/sim_event_driven.cpp
@@ -20,6 +20,8 @@ limitations under the License.
 */
 
 #include "sim_event_driven.h"
+#include <stdio.h>
+#include <stdint.h>
 
 
 


### PR DESCRIPTION
Without that it doesn't build (at least on Fedora 26) since it can't find "stderr" and "uint32_t"