### PR TITLE
VLAN and ARP related bug fixes

### DIFF
--- a/src/common/Network/Packet/VLANHeader.h
+++ b/src/common/Network/Packet/VLANHeader.h
@@ -47,7 +47,7 @@ class VLANHeader
 ////////////////////////////////////////////////////////////////////////////////////////
 public:
 
-    // Sets the complete tag field without sub fields manipulation
+    // Sets the complete tag field without sub fields manipulation, host byte order
     void    setVlanTag          (uint16_t data);
     uint16_t  getVlanTag          ();
 

--- a/src/common/Network/Packet/VLANHeader.inl
+++ b/src/common/Network/Packet/VLANHeader.inl
@@ -23,54 +23,54 @@ inline  void   VLANHeader::setVlanTag(uint16_t data)
 
 inline  uint16_t VLANHeader::getVlanTag()
 {
-    return(PKT_HTONS(myTag));
+    return(PKT_NTOHS(myTag));
 }
 
 inline  void  VLANHeader::setTagUserPriorty(uint8_t   argUserPriority)
 {
-    uint16_t  tempTag = myTag;
+    uint16_t  tempTag = PKT_NTOHS(myTag);
     setMaskBit16(tempTag, 0, 2, argUserPriority);
-    myTag = tempTag;
+    myTag = PKT_HTONS(tempTag);
 }
 
 inline  uint8_t VLANHeader::getTagUserPriorty()
 {
-    return (uint8_t)(getMaskBit16(myTag, 0, 2));
+    return (uint8_t)(getMaskBit16(PKT_NTOHS(myTag), 0, 2));
 }
 
 
 inline  void  VLANHeader::setTagCFI(bool    isSet)
 {
-    uint16_t  tempTag = myTag;
+    uint16_t  tempTag = PKT_NTOHS(myTag);
     setMaskBit16(tempTag, 3, 3, isSet? 1 : 0);
-    myTag = tempTag;
+    myTag = PKT_HTONS(tempTag);
 }
 
 inline  bool  VLANHeader::getTagCFI()
 {
-    return (getMaskBit16(myTag, 3, 3) == 1);
+    return (getMaskBit16(PKT_NTOHS(myTag), 3, 3) == 1);
 }
 
 // This returns host order
 inline  uint16_t VLANHeader::getTagID(void)
 {
-    return  getMaskBit16(myTag, 4, 15);
+    return  getMaskBit16(PKT_NTOHS(myTag), 4, 15);
 }
 
 inline  void    VLANHeader::setTagID(uint16_t argNewTag)
 {
-    uint16_t  tempTag = myTag;
+    uint16_t  tempTag = PKT_NTOHS(myTag);
     setMaskBit16(tempTag, 4, 15, argNewTag);
-    myTag = tempTag;
+    myTag = PKT_HTONS(tempTag);
 }
 
 inline void  VLANHeader::incrementTagID(uint16_t inc_value)
 {
-    uint16_t  tempTag_Host   = myTag;
+    uint16_t  tempTag_Host   = PKT_NTOHS(myTag);
     uint16_t  curTagID_Host  = getTagID();
     uint16_t  newTagId_Host  = (0xfff & (curTagID_Host + (0xfff & inc_value))); // addition with 12 LSBits
     setMaskBit16(tempTag_Host, 4, 15, newTagId_Host);
-    myTag = tempTag_Host;
+    myTag = PKT_HTONS(tempTag_Host);
 }
 
 inline  uint16_t VLANHeader::getNextProtocolNetOrder()
@@ -80,7 +80,7 @@ inline  uint16_t VLANHeader::getNextProtocolNetOrder()
 
 inline  uint16_t VLANHeader::getNextProtocolHostOrder()
 {
-    return (PKT_HTONS(myNextProtocol));
+    return (PKT_NTOHS(myNextProtocol));
 }
 
 inline  void    VLANHeader::setNextProtocolFromHostOrder(uint16_t  argNextProtocol)
@@ -96,13 +96,13 @@ inline  void    VLANHeader::setNextProtocolFromNetOrder(uint16_t  argNextProtoco
 inline void     VLANHeader::setFromPkt          (uint8_t* data)
 {
     // set the tag from the data
-    setVlanTag(*(uint16_t*)data);
+    myTag = *(uint16_t*)data;
     setNextProtocolFromNetOrder(*((uint16_t*)(data + 2))); // next protocol is after the vlan tag
 }
 
 inline uint8_t    VLANHeader::reconstructPkt      (uint8_t* destBuff)
 {
-    *(uint16_t*)destBuff     = getVlanTag();
+    *(uint16_t*)destBuff     = myTag;
     *(uint16_t*)(destBuff+2) = getNextProtocolNetOrder();
     return sizeof(VLANHeader);
 }

--- a/src/pre_test.cpp
+++ b/src/pre_test.cpp
@@ -391,9 +391,9 @@ void CPretest::send_grat_arp_all() {
     }
 }
 
-bool CPretest::is_arp(const uint8_t *p, uint16_t pkt_size, ArpHdr *&arp, uint16_t &vlan_tag) {
+bool CPretest::is_arp(const uint8_t *p, uint16_t pkt_size, ArpHdr *&arp, uint16_t &vlan_id) {
     EthernetHeader *m_ether = (EthernetHeader *)p;
-    vlan_tag = 0;
+    vlan_id = 0;
     uint16_t min_size = sizeof(EthernetHeader);
     VLANHeader *vlan;
 
@@ -415,7 +415,7 @@ bool CPretest::is_arp(const uint8_t *p, uint16_t pkt_size, ArpHdr *&arp, uint16_
         if (vlan->getNextProtocolHostOrder() != EthernetHeader::Protocol::ARP) {
             return false;
         } else {
-            vlan_tag = vlan->getVlanTag();
+            vlan_id = vlan->getTagID();
             arp = (ArpHdr *)(p + 14 + sizeof(VLANHeader));
         }
         min_size += sizeof(ArpHdr);
@@ -449,8 +449,8 @@ int CPretest::handle_rx(int port_id, int queue_id) {
             int pkt_size = rte_pktmbuf_pkt_len(m);
             uint8_t *p = rte_pktmbuf_mtod(m, uint8_t *);
             ArpHdr *arp;
-            uint16_t vlan_tag;
-            if (is_arp(p, pkt_size, arp, vlan_tag)) {
+            uint16_t vlan_id;
+            if (is_arp(p, pkt_size, arp, vlan_id)) {
                 port->m_stats.m_rx_arp++;
                 if (arp->m_arp_op == htons(ArpHdr::ARP_HDR_OP_REQUEST)) {
                     if (verbose >= 3) {
@@ -463,21 +463,21 @@ int CPretest::handle_rx(int port_id, int queue_id) {
                                 , port_id, queue_id
                                 , ip_to_str(ntohl(arp->m_arp_sip)).c_str()
                                 , ip_to_str(ntohl(arp->m_arp_tip)).c_str()
-                                , vlan_tag);
+                                , vlan_id);
                         if (verbose >= 7)
                             utl_DumpBuffer(stdout, p, rte_pktmbuf_pkt_len(m), 0);
                     }
                     // is this request for our IP?
                     COneIPv4Info *src_addr;
                     COneIPv4Info *rcv_addr;
-                    if ((src_addr = port->find_ip(ntohl(arp->m_arp_tip), vlan_tag))) {
+                    if ((src_addr = port->find_ip(ntohl(arp->m_arp_tip), vlan_id))) {
                         // If our request(i.e. we are connected in loopback)
                         // , do a shortcut, and write info directly to asking port
                         uint8_t magic[5] = {0x1, 0x3, 0x5, 0x7, 0x9};
                         if (! memcmp((uint8_t *)&arp->m_arp_tha.data, magic, 5)) {
                             uint8_t sent_port_id = arp->m_arp_tha.data[5];
                             if ((sent_port_id < m_max_ports) &&
-                                (rcv_addr = m_port_info[sent_port_id].find_next_hop(ntohl(arp->m_arp_tip), vlan_tag))) {
+                                (rcv_addr = m_port_info[sent_port_id].find_next_hop(ntohl(arp->m_arp_tip), vlan_id))) {
                                 uint8_t mac[ETHER_ADDR_LEN];
                                 src_addr->get_mac(mac);
                                 rcv_addr->set_mac(mac);
@@ -516,22 +516,23 @@ int CPretest::handle_rx(int port_id, int queue_id) {
                     } else {
                         // ARP request not to our IP. Check if this is gratitues ARP for something we need.
                         if ((arp->m_arp_tip == arp->m_arp_sip)
-                            && (rcv_addr = port->find_next_hop(ntohl(arp->m_arp_tip), vlan_tag))) {
+                            && (rcv_addr = port->find_next_hop(ntohl(arp->m_arp_tip), vlan_id))) {
                             rcv_addr->set_mac((uint8_t *)&arp->m_arp_sha);
                         }
                     }
                 } else {
                     if (arp->m_arp_op == htons(ArpHdr::ARP_HDR_OP_REPLY)) {
                         if (verbose >= 3) {
-                            fprintf(stdout, "RX ARP reply on port %d queue %d sip:%s tip:%s\n"
+                            fprintf(stdout, "RX ARP reply on port %d queue %d sip:%s tip:%s vlan:%d\n"
                                     , port_id, queue_id
                                     , ip_to_str(ntohl(arp->m_arp_sip)).c_str()
-                                    , ip_to_str(ntohl(arp->m_arp_tip)).c_str());
+                                    , ip_to_str(ntohl(arp->m_arp_tip)).c_str()
+                                    , vlan_id);
                         }
 
                         // If this is response to our request, update our tables
                         COneIPv4Info *addr;
-                        if ((addr = port->find_next_hop(ntohl(arp->m_arp_sip), vlan_tag))) {
+                        if ((addr = port->find_next_hop(ntohl(arp->m_arp_sip), vlan_id))) {
                             addr->set_mac((uint8_t *)&arp->m_arp_sha);
                         }
                     }

--- a/src/stateful_rx_core.cpp
+++ b/src/stateful_rx_core.cpp
@@ -702,6 +702,7 @@ void CLatencyManager::send_one_grat_arp() {
     case COneIPInfo::IP4_VER:
         sip = ((COneIPv4Info *)ip_info)->get_ip();
         CTestPktGen::create_arp_req(p, sip, sip, src_mac, port_id, vlan);
+        m->l2_len = 14 + (vlan ? 4 : 0);
         if (CGlobalInfo::m_options.preview.getVMode() >= 3) {
             printf("Sending gratuitous ARP on port %d vlan:%d, sip:%s\n", port_id, vlan
                    , ip_to_str(sip).c_str());


### PR DESCRIPTION
While using trex on a network with VLANs, I came across two bugs:

- ARP replies from the router were ignored because of an incorrect interpretation of the VLAN header in CPretest::handle_rx(): the complete VLAN tag was matched against the VLAN ID of the port instead of only the VLAN ID in the packet, so it didn't work if the priority field was non-zero. Using the right utility method of VLANHeader to get the VLAN ID revealed that the endianness conversions in VLANHeader were not consistent so I cleaned that up too.

- Assertion failure when sending out a gratuitous ARP during a test, but the assertion was on a member variable that was never used elsewhere so I removed the variable.