### PR TITLE
Add hltapi interface_config procedure support

### DIFF
--- a/scripts/automation/trex_control_plane/stl/trex_stl_lib/trex_stl_hltapi.py
+++ b/scripts/automation/trex_control_plane/stl/trex_stl_lib/trex_stl_hltapi.py
@@ -28,6 +28,7 @@ interface_config_kwargs = {
 
     'gateway': [],
     'intf_ip_addr': [],
+    'dst_mac_addr': [],
 
     'vlan': [],
     'vlan_id': [],
@@ -225,6 +226,20 @@ def merge_kwargs(default_kwargs, user_kwargs):
             print("Warning: provided parameter '%s' is not supported" % key)
     return kwargs
 
+# change MAC from formats 01-23-45-67-89-10 or 0123.4567.8910 or {01 23 45 67 89 10} to Scapy format 01:23:45:67:89:10
+def correct_mac(mac):
+    if type(mac) is not str: raise STLError('Argument %s should be str' % mac)
+    updated_mac = mac.replace('{', '').replace('}', '').strip().replace('-', ' ').replace(':', ' ').replace('.',
+                                                                                                                ' ')
+    if updated_mac[4] == ' ' and updated_mac[9] == ' ':
+        updated_mac = ' '.join([updated_mac[0:2], updated_mac[2:7], updated_mac[7:12], updated_mac[12:14]])
+    updated_mac = ':'.join(updated_mac.split())
+    try:
+        mac2str(updated_mac)  # verify we are ok
+        return updated_mac
+    except:
+        return None
+
 # change MACs from formats 01-23-45-67-89-10 or 0123.4567.8910 or {01 23 45 67 89 10} to Scapy format 01:23:45:67:89:10
 def correct_macs(kwargs):
     list_of_mac_args = ['mac_src', 'mac_dst', 'mac_src2', 'mac_dst2']
@@ -234,15 +249,11 @@ def correct_macs(kwargs):
             mac_value = kwargs[mac_arg]
             if is_integer(mac_value) and mac_arg in list_of_mac_steps: # step can be number
                 continue
-            if type(mac_value) is not str: raise STLError('Argument %s should be str' % mac_arg)
-            mac_value = mac_value.replace('{', '').replace('}', '').strip().replace('-', ' ').replace(':', ' ').replace('.', ' ')
-            if mac_value[4] == ' ' and mac_value[9] == ' ':
-                mac_value = ' '.join([mac_value[0:2], mac_value[2:7], mac_value[7:12], mac_value[12:14]])
-            mac_value = ':'.join(mac_value.split())
-            try:
-                mac2str(mac_value)                                # verify we are ok
-                kwargs[mac_arg] = mac_value
-            except:
+
+            corrected_mac = correct_mac(mac_value)
+            if corrected_mac is not None:
+                kwargs[mac_arg] = corrected_mac
+            else:
                 raise STLError('Incorrect MAC %s=%s, please use 01:23:45:67:89:10 or 01-23-45-67-89-10 or 0123.4567.8910 or {01 23 45 67 89 10}' % (mac_arg, kwargs[mac_arg]))
 
 def is_true(input):
@@ -460,6 +471,14 @@ class CTRexHltApi(object):
         kwargs['port_handle'] = self._parse_port_list(kwargs['port_handle'])
         kwargs['intf_ip_addr'] = self._parse_string_list(kwargs['intf_ip_addr'])
         kwargs['gateway'] = self._parse_string_list(kwargs['gateway'])
+
+        try:
+            kwargs['dst_mac_addr'] = list(map(correct_mac, self._parse_mac_list(kwargs['dst_mac_addr'])))
+            if None in kwargs['dst_mac_addr']:
+                return HLT_ERR('dst_mac_addr contains incorrect mac')
+        except:
+            return HLT_ERR('dst_mac_addr contains incorrect mac')
+
         kwargs['vlan'] = self._parse_string_list(kwargs['vlan'], is_true)
         kwargs['vlan_id'] = self._parse_string_list(kwargs['vlan_id'], lambda x: int(x))
         kwargs['vlan_id_list'] = self._parse_string_list(kwargs['vlan_id_list'], lambda x: int(x))
@@ -471,7 +490,6 @@ class CTRexHltApi(object):
             return HLT_ERR('Error enabling service mode: %s' % e)
 
         try:
-
             for i, port_id in enumerate(kwargs['port_handle']):
                 port = self.trex_client.get_port(port_id)
                 if kwargs['vlan'] and kwargs['vlan'][i]:
@@ -480,6 +498,8 @@ class CTRexHltApi(object):
 
                     self.trex_client.set_vlan([port_id], vlan_id)
 
+                if kwargs['dst_mac_addr']:
+                    port.set_l2_mode(kwargs['dst_mac_addr'][i])
                 if kwargs['intf_ip_addr'] or kwargs['gateway']:
                     config = port.get_layer_cfg()
                     src = (kwargs['intf_ip_addr'] and kwargs['intf_ip_addr'][i]) or config['ipv4']['src']
@@ -487,7 +507,7 @@ class CTRexHltApi(object):
 
                     port.set_l3_mode(src, dst)
 
-            if (is_true(kwargs['arp']) and is_true(kwargs['arp_send_req'])) or kwargs['intf_ip_addr'] or kwargs['gateway']:
+            if (is_true(kwargs['arp']) and is_true(kwargs['arp_send_req'])):
                 for i, port_id in enumerate(kwargs['port_handle']):
                     vlan_id = None
 
@@ -875,6 +895,13 @@ class CTRexHltApi(object):
             return list(map(modifier, strs.replace('{', '').replace('}', '').strip().split()))
 
         return strs
+
+    @staticmethod
+    def _parse_mac_list(mac_list):
+        if type(mac_list) is str:
+            return re.findall('\{[ \w]+\}', mac_list) or mac_list.split()
+
+        return mac_list
 
 def STLHltStream(**user_kwargs):
     kwargs = merge_kwargs(traffic_config_kwargs, user_kwargs)


### PR DESCRIPTION
For now, it's possible to configure port source and destination addresses, VLAN, and also user can force arp resolving process.
I didn't find hltapi commands for changing l2 parameters like destination mac (at least in ixia hltapi documentation I found related commands only for some *static_endpoint* mode, not sure TRex supports such mode).

If there is something that can be implemented without client changing please let me know, I'll extend implementation within this PR.

Output sample:
```python
{  
  'config':{  
    'layer_config':{  
      0:{  
        'ipv4':{  
          'dst':'1.2.3.4',
          'state':'resolved',
          'src':'4.3.2.1'
        },
        'ether':{  
          'dst':'08:00:27:23:21:dc',
          'state':'configured',
          'src':'08:00:27:d5:ac:98'
        }
      },
      1:{  
        'ipv4':{  
          'dst':'4.3.2.1',
          'state':'resolved',
          'src':'1.2.3.4'
        },
        'ether':{  
          'dst':'08:00:27:d5:ac:98',
          'state':'configured',
          'src':'08:00:27:23:21:dc'
        }
      }
    },
    'vlan_config':{  
      0:[  
        1,
        2
      ],
      1:[  
        1,
        2
      ]
    }
  },
  'status':1,
  'log':None
}
```