### PR TITLE
fix for missed parent module that leds to SimpleJSONRPCServer error

### DIFF
--- a/scripts/automation/trex_control_plane/server/trex_server.py
+++ b/scripts/automation/trex_control_plane/server/trex_server.py
@@ -424,7 +424,7 @@ class CTRexServer(object):
             trex_state = self.trex.get_status()
             if trex_state != TRexStatus.Starting:
                 return
-            sleep(0.1)
+            time.sleep(0.1)
         return Fault(-12, 'TimeoutError: TRex initiation outcome could not be obtained, since TRex stays at Starting state beyond defined timeout.') # raise at client TRexWarning
 
     def get_running_info (self):


### PR DESCRIPTION
```
01-15 14:23:04 SimpleJSONRPCServer  ERROR    Server-side exception: <Fault -32603: Server error: File "/home/cisco/trex/v2.35/automation/trex_control_plane/server/trex_server.py", line 427, in wait_until_kickoff_finish | NameError: name 'sleep' is not defined
>
Traceback (most recent call last):
  File "/home/cisco/trex/v2.35/external_libs/jsonrpclib-pelix-0.2.5/jsonrpclib/SimpleJSONRPCServer.py", line 366, in _dispatch
    return func(*params)
  File "/home/cisco/trex/v2.35/automation/trex_control_plane/server/trex_server.py", line 427, in wait_until_kickoff_finish
    sleep(0.1)
NameError: name 'sleep' is not defined
```

missed parent module added: sleep(0.1) --> time.sleep(0.1)