### PR TITLE
Dockerfile using 16.04 LTS

### DIFF
--- a/docker/ubuntu/16.04/Dockerfile
+++ b/docker/ubuntu/16.04/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+MAINTAINER imarom@cisco.com
+
+LABEL RUN docker run --privileged --cap-add=ALL -v /mnt/huge:/mnt/huge -v /lib/modules:/lib/modules:ro -v /sys/bus/pci/devices:/sys/bus/pci/devices -v /sys/devices/system/node:/sys/devices/system/node -v /dev:/dev --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
+
+COPY trex_cfg.yaml /etc/trex_cfg.yaml
+
+RUN apt-get update
+RUN apt-get install -y sudo gcc g++ python git zlib1g-dev pciutils vim kmod strace wget
+RUN mkdir /scratch
+
+WORKDIR /scratch
+RUN git clone https://github.com/cisco-system-traffic-generator/trex-core.git 
+
+WORKDIR /scratch/trex-core
+
+CMD ["/bin/bash"]
+

--- a/docker/ubuntu/16.04/trex_cfg.yaml
+++ b/docker/ubuntu/16.04/trex_cfg.yaml
@@ -1,0 +1,15 @@
+- port_limit    : 4         
+  version       : 2
+  c             : 8
+  interfaces    : ["0b:00.0", "0b:00.1", "13:00.0", "13:00.1"]   # list of the interfaces to bind run ./dpdk_nic_bind.py --status 
+  port_info     :  # set eh mac addr 
+ 
+                 - ip         : 1.1.1.1
+                   default_gw : 4.4.4.4
+                 - ip         : 2.2.2.2
+                   default_gw : 3.3.3.3
+                 - ip         : 3.3.3.3
+                   default_gw : 2.2.2.2
+                 - ip         : 4.4.4.4
+                   default_gw : 1.1.1.1
+


### PR DESCRIPTION
Adding a new Dockerfile based on Ubuntu 16.04 LTS, the included 16.10
is EOL and was throwing errors when building through docker
build (can't find Yakkety Yak base layer).

Confirmed this gets you a docker image capable of building trex master and simulator.