### PR TITLE
Fix Python syntax in http_https.py

### DIFF
--- a/scripts/astf/http_https.py
+++ b/scripts/astf/http_https.py
@@ -14,8 +14,10 @@ class Prof1():
                            dist_server=ip_gen_s)
 
         return ASTFProfile(default_ip_gen=ip_gen,
-                            cap_list=[ASTFCapInfo(file="../avl/delay_10_http_browsing_0.pcap",cps=1),
-                            cap_list=[ASTFCapInfo(file="../avl/delay_10_https_0.pcap",cps=1)])
+                            cap_list=[
+                                ASTFCapInfo(file="../avl/delay_10_http_browsing_0.pcap",cps=1),
+                                ASTFCapInfo(file="../avl/delay_10_https_0.pcap",cps=1)
+                            ])
 
 
 def register():


### PR DESCRIPTION
Cryptic errors otherwise. This one is in the manual as the 2nd ASTF example.