### PR TITLE
Update proper softlinks when '-o OUT' option used

### DIFF
--- a/linux/ws_main.py
+++ b/linux/ws_main.py
@@ -640,10 +640,12 @@ def build_info(bld):
     pass;
       
 def install_single_system (bld, exec_p, build_obj):
-    o='build/linux/';
+    o=bld.out_dir+'/linux/';
     src_file =  os.path.realpath(o+build_obj.get_target())
     if os.path.exists(src_file):
         dest_file = exec_p +build_obj.get_target()
+        if os.path.islink(dest_file):
+            os.unlink(dest_file)
         if not os.path.lexists(dest_file):
             relative_path = os.path.relpath(src_file, exec_p)
             os.symlink(relative_path, dest_file);

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -1362,6 +1362,9 @@ def do_create_link (src, name, where):
 
         full_link = os.path.join(where, name)
 
+        if os.path.islink(full_link):
+            os.unlink(full_link)
+
         if not os.path.lexists(full_link):
             rel_path = os.path.relpath(src, where)
             print('{0} --> {1}'.format(name, rel_path))
@@ -1371,7 +1374,7 @@ def do_create_link (src, name, where):
 
 def install_single_system (bld, exec_p, build_obj):
 
-    o = 'build_dpdk/linux_dpdk/'
+    o = bld.out_dir+'/linux_dpdk/'
 
     # executable
     do_create_link(src = os.path.realpath(o + build_obj.get_target()),
@@ -1468,7 +1471,7 @@ def build_test(bld):
     create_version_files ()
 
 def _copy_single_system (bld, exec_p, build_obj):
-    o='build_dpdk/linux_dpdk/';
+    o=bld.out_dir+'/linux_dpdk/';
     src_file =  os.path.realpath(o+build_obj.get_target())
     print(src_file)
     if os.path.exists(src_file):
@@ -1606,6 +1609,8 @@ def release(bld, custom_dir = None):
     print("copy images and libs")
     os.system(' mkdir -p '+exec_p);
 
+    # get build context to refer the build output dir
+    bld=Build.Context.create_context('build')
     for obj in build_types:
         copy_single_system(bld,exec_p,obj)
         copy_single_system1(bld,exec_p,obj)


### PR DESCRIPTION
When I specified '-o OUT' option during configuration by ./b configure in linux/ and linux_dpdk/, built targets were located at given 'OUT' directory.
But I found that softlinks of the built targets were not generated properly in the scripts/. I investigated the reason and found that post_build routine in ws_main.py uses dedicated location to search built targets. It should refer to the specified 'OUT' directory from configuration.

This change will update the softlinks properly. So pkg and release can collect recent built targets also.

(cd linux && ./b configure -o ../../build/linux && ./b build)
(cd linux_dpdk && ./b configure -o ../../build/linux_dpdk && ./b build)
ls -l scripts/bp-sim*
ls -l scripts/_t-rex*