### PR TITLE
improvements to trex pkg download instructions

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -403,7 +403,7 @@ To obtain a specific version:
 ----
 [bash]>wget --no-cache ${TREX_WEB_URL}/release/vX.XX.tar.gz #<1>
 ----
- 1. (where X.XX = major.minor version number as per https://trex-tgn.cisco.com/trex/doc/release_notes.html)
+<1> where X.XX = major.minor version number as per https://trex-tgn.cisco.com/trex/doc/release_notes.html
 
 == First time Running
 

--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -372,36 +372,38 @@ Example: 4x 10Gb/sec TRex configuration (see output below):
 
 Use `ssh` to connect to the TRex machine and execute the commands described below.
 
-NOTE: Prerequisite: *$WEB_URL* is *{web_server_url}* or *{local_web_server_url}* (Cisco internal)
-
+NOTE: Prerequisite: *$TREX_WEB_URL* is *{web_server_url}* or *{local_web_server_url}* (Cisco internal)
 // Clarify the note above and probably should not have the Cisco internal part
 
-Latest release:
+TIP: For easier copy/paste, begin by assigning a temporary local variable to denote the appropriate TRex TREX_WEB_URL:
+[source,bash]
+----
+[bash]>TREX_WEB_URL=http://<AS PER ABOVE PRE-REQUISITE NOTE>
+----
 
-// want to call that "Latest stable release" ?
+Latest (stable) release:
 
 [source,bash]
 ----
-[bash]>mkdir trex
-[bash]>cd trex
-[bash]>wget --no-cache $WEB_URL/release/latest
+[bash]>mkdir -p /opt/trex
+[bash]>cd /opt/trex
+[bash]>wget --no-cache ${TREX_WEB_URL}/release/latest
 [bash]>tar -xzvf latest
 ----
 
 
-Bleeding edge version:
+Latest (bleeding edge) version:
 [source,bash]
 ----
-[bash]>wget --no-cache $WEB_URL/release/be_latest
+[bash]>wget --no-cache ${TREX_WEB_URL}/release/be_latest
 ----
 
 To obtain a specific version:
 [source,bash]
 ----
-[bash]>wget --no-cache $WEB_URL/release/vX.XX.tar.gz #<1>
+[bash]>wget --no-cache ${TREX_WEB_URL}/release/vX.XX.tar.gz #<1>
 ----
-
-<1> X.XX = Version number
+ 1. (where X.XX = major.minor version number as per https://trex-tgn.cisco.com/trex/doc/release_notes.html)
 
 == First time Running
 


### PR DESCRIPTION
 * improved copy/paste via $TREX_WEB_URL var in TIP
 * rather than assumption of CWD, proposal to download TRex to /opt/ (see https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)
 * clarified "latest" to be "latest stable" and "latest bleeding edge"
 * clarified "X.XX" note, to denote "major.minor", as well as a reference to TRex release notes documentation
----
Signed-off-by: Matt Callaghan <mcallaghan@sandvine.com>