### PR TITLE
add stateful + stateless cross refs in FAQ

### DIFF
--- a/doc/trex_faq.asciidoc
+++ b/doc/trex_faq.asciidoc
@@ -57,9 +57,11 @@ Cisco systems, Intel, Imperva, Melanox, Vasona networks and much more.
 
 ==== What are the Stateful and Stateless modes of operation?
 
-``Stateful'' mode is meant for testing networking gear which save state per flow (5 tuple). Usually, this is done by injecting pre recorded cap files on pairs of interfaces of the device under test, changing src/dst IP/port. 
-``Stateless'' mode is meant to test networking gear, not saving state per flow (doing the decision on per packet bases). This is usually done by injecting customed packet streams to the device under test.
-See link:trex_stateless.html#_stateful_vs_stateless[here] for more details.
+``link:trex_manual.html[Stateful]'' mode is meant for testing networking gear which saves state per flow (5 tuple). Usually this is done by injecting pre-recorded capture files on pairs of interfaces of the device under test, and dynamically changing src/dst IP/port.
+
+``link:trex_stateless.html[Stateless]'' mode is meant to test networking gear that does not manage any state per flow (instead operating on a per packet basis). This is usually done by injecting customized packet streams to the device under test.
+
+See this link:trex_stateless.html#_stateful_vs_stateless[in-depth comparisson] for more details.
 
 ==== Can TRex run on an hypervisor with virtual NICS?
 


### PR DESCRIPTION
in reading the "stateful vs. stateless" section in the FAQ, it's good to reference:
 1. the stateful manual (was missing)
 2. the stateless manual (was missing)
 3. the stateful_vs_stateless more details feature matrix (already there at the end)
 4. a few minor refinements/tweaks
----
Signed-off-by: Matt Callaghan mcallaghan@sandvine.com