### PR TITLE
doc improvements for CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Guidance on how to contribute
+# Guidance on how to Contribute
 
 > All contributions to this project will be released under the Apache 2.0 License.
 > By submitting a pull request or filing a bug, issue, or
@@ -6,32 +6,62 @@
 > Details can be found in our [LICENCE](LICENSE).
 
 
-There are two primary ways to help:
- - Using the issue tracker, and
- - Changing the code-base.
+There are several ways to help:
+ - ask questions and participate in discussions in our google group
+ - use the issue tracker to submit issues and enhancements
+ - change the codebase for code and documentation fixes or improvements
 
 
-## Using the issue tracker
+## Asking Questions and Participating in Discussions
 
-Use the issue tracker to suggest feature requests, report bugs, and ask questions.
-This is also a great way to connect with the developers of the project as well
-as others who are interested in this solution.
+Use the TRex traffic generator group to ask and answer questions. Feel free to
+participate! This is a great way to connect with the developers of the project
+as well as others who are interested in this solution.
+ - https://groups.google.com/forum/#!forum/trex-tgn
 
-Use the issue tracker to find ways to contribute. Find a bug or a feature, mention in
-the issue that you will take on that effort, then follow the _Changing the code-base_
-guidance below.
+If you prefer using e-mail, the mailer is:
+ - trex-tgn@googlegroups.com
 
-youTrack web can be found here http://trex-tgn.cisco.com/youtrack/
+## Using the Issue Tracker
+
+We have two issue trackers:
+ 1. github (https://github.com/cisco-system-traffic-generator/trex-core/issues) [PREFERRED]
+ 2. youtrack (https://trex-tgn.cisco.com/youtrack/issues) [LEGACY]
+
+Use the github issue tracker to suggest new feature requests and report bugs.
+This is our preferred issue tracker going forward.
+
+There is a backlog of issues and enhancements in the youtrack issue tracker.
+
+Check either issue tracker to find ways to contribute. Find a bug or a feature,
+mention in the issue that you will take on that effort, then follow the
+_Changing the Codebase_ guidance below.
 
 
-## Changing the code-base
+## Changing the Codebase
 
-Generally speaking, you should fork this repository, make changes in your
-own fork, and then submit a pull-request. All new code should have associated unit
-tests that validate implemented features and the presence or lack of defects.
-Additionally, the code should follow any stylistic and architectural guidelines
-prescribed by the project. In the absence of such guidelines, mimic the styles
-and patterns in the existing code-base.
-mailer is  trex-tgn@googlegroups.com
+Make code and documentation changes directly in this git repository.
 
+General Best Practices:
+ 1. fork this repository
+ 2. make changes in your own fork on a narrowly focussed branch
+ 3. squash commits
+ 4. submit a pull-request
 
+Active developers assigned to the project will triage and moderate pull requests.
+
+Test Coverage:
+ - All new code should have associated unit tests that validate implemented
+features and the presence or lack of defects.
+
+Style:
+ - Code should follow any stylistic and architectural guidelines prescribed
+by the project. In the absence of such guidelines, mimic the styles and patterns
+in the existing codebase.
+
+Commit Notes:
+ - Always use git's `-s (--signoff)` flag to append the legal sign off required.
+This applies to all pull requests. If making documentation changes directly in
+gitlab, you can manually append the signoff note in the commit message.
+> Signed-off-by: Full Name \<e-mail\>
+ - See `man git-commit` for more details.

--- a/doc/trex_faq.asciidoc
+++ b/doc/trex_faq.asciidoc
@@ -151,8 +151,10 @@ There is good answer in the mailing list link:https://groups.google.com/forum/#!
 ==== I want to contribute to the project
 You have several ways you can help: +
 1. Download the product, use it, and report issues (If no issues, we will be very happy to also hear success stories). +
-2. If you use the product and have improvment suggestions (for the product or documentation) we will be happy to hear. +
-3. If you fix a bug, or develop new feature, you are more than welcome to create pool request in GitHub.
+2. If you use the product and have improvement suggestions (for the product or documentation) we will be happy to hear. +
+3. If you fix a bug, or develop new feature, you are more than welcome to create pull request in GitHub.
+
+See link:https://github.com/cisco-system-traffic-generator/trex-core/blob/master/CONTRIBUTING.md[CONTRIBUTING] for more details.
 
 ==== What is the release process? How do I know when a new release is available?
 It is a continuous integration. The latest internal version is under 24/7 regression on few setups in our lab. Once we have enough content we release it to GitHub (Usually every few weeks).

--- a/doc/trex_index.asciidoc
+++ b/doc/trex_index.asciidoc
@@ -89,8 +89,8 @@ See Stateless Manual
 link:https://github.com/cisco-system-traffic-generator/trex-core[GitHub]
 | Wiki    | 
 link:https://github.com/cisco-system-traffic-generator/trex-core/wiki[Wiki]
-| Defect manager    | 
-link:http://trex-tgn.cisco.com/youtrack/dashboard[youtrack]
+| Issue Trackers    | 
+link:https://github.com/cisco-system-traffic-generator/trex-core/issues[GitHub], link:http://trex-tgn.cisco.com/youtrack/dashboard[youtrack]
 | Release pkgs    | 
 link:../release/[pkgs]
 | Windows Stateful GUI v0.6   | 
@@ -110,6 +110,7 @@ link:trex_vm_bench.html[sr_iov_bench]
 [options="header",cols="<4,a"]
 |=================
 | Description  |    Name 
+| Contributing | link:https://github.com/cisco-system-traffic-generator/trex-core/blob/master/CONTRIBUTING.md[CONTRIBUTING]
 | Stateless server RPC specification    | 
 link:trex_rpc_server_spec.html[stl_rpc_server.html] 
 | Scapy server RPC specification    | 
@@ -125,8 +126,6 @@ link:https://github.com/cisco-system-traffic-generator/trex-core/wiki[Wiki]
 | Description  |    Name 
 | TRex community     | 
 link:https://groups.google.com/forum/#!forum/trex-tgn[Gmail TRex Forum] 
-| Report a defect  | 
-link:http://trex-tgn.cisco.com/youtrack/dashboard[youtrack]
 | Cisco TRex Devnet community   | 
 link:https://communities.cisco.com/community/developer/trex[Jive]
 |=================


### PR DESCRIPTION
as per #96 , as a new user, improving various documentation bits related to contributing to the project and issue tracking (GitHub vs. youtrack)

- significantly reworked CONTRIBUTING.md for a 2018 refresh
- updated doc/index.html (a likely landing page for new users) to reflect contrib+trackers
- updated the FAQ section for "contributing" to reference the more detailed CONTRIBUTING.md (+few typos fixed)
----
Signed-off-by: Matt Callaghan <mcallaghan@sandvine.com>