### PR TITLE
TRex stateful interpretting latency/jitter output (taketwo)

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -736,7 +736,7 @@ After configuration is complete, use the following command to start basic TRex r
 (it will use the default config file name /etc/trex_cfg.yaml):
 [source,bash]
 ----
-[bash]>sudo ./t-rex-64 -f cap2/dns.yaml -c 4 -m 1 -d 10  -l 1000
+[bash]>sudo ./t-rex-64 -f cap2/dns.yaml -c 4 -m 1 -d 10
 ----
 
 ==== TRex output
@@ -745,7 +745,7 @@ After running TRex successfully, the output will be similar to the following:
 
 [source,python]
 ----
-$ sudo ./t-rex-64 -f cap2/dns.yaml -d 10 -l 1000
+$ sudo ./t-rex-64 -f cap2/dns.yaml -d 10
 Starting  TRex 2.09 please wait  ...
 zmq publisher at: tcp://*:4500
  number of ports found : 4
@@ -796,17 +796,17 @@ zmq publisher at: tcp://*:4500
  current time    : 5.3 sec
  test duration   : 94.7 sec
 
- -Latency stats enabled
- Cpu Utilization : 0.2 %  <12>
- if|   tx_ok , rx_ok  , rx   ,error,    average   ,   max         , Jitter ,  max window
-   |         ,        , check,     , latency(usec),latency (usec) ,(usec)  ,
- --------------------------------------------------------------------------------------------------
- 0 |     1002,    1002,         0,   0,         51  ,      69,       0      |   0  69  67    <13>
- 1 |     1002,    1002,         0,   0,         53  ,     196,       0      |   0  196  53
- 2 |     1002,    1002,         0,   0,         54  ,      71,       0      |   0  71  69
- 3 |     1002,    1002,         0,   0,         53  ,     193,       0      |   0  193  52
 ----
+
+==== startup
+
 <1> Link must be up for TRex to work.
+
+// ==== Interpretting per port stats
+// TODO
+
+==== global stats
+
 <2> Average CPU utilization of transmitters threads. For best results it should be lower than 80%.
 <3> Gb/sec generated per core of DP. Higher is better.
 <4> Total Tx must be the same as Rx at the end of the run.
@@ -817,12 +817,13 @@ zmq publisher at: tcp://*:4500
 <9> Number of TRex active "flows". Could be different than the number of router flows, due to aging issues. Usualy the TRex number of active flows is much lower than that of the router because the router ages flows slower.
 <10> Total number of TRex flows opened since startup (including active ones, and ones already closed).
 <11> Drop rate.
-<12> Rx and latency thread CPU utilization.
-<13> Tx_ok on port 0 should equal Rx_ok on port 1, and vice versa.
 
-// the formatting of the latency stats table in the output above is difficult to read
+==== latency stats
 
-==== Additional information about statistics in output
+Though not present in the above output, measuring latency and jitter is possible!
+See the xref:jitter_latency[Measuring Jittery/Latency] section for more details.
+
+==== additional information about statistics in output
 
 *socket*::  Same as the active flows.
 
@@ -831,20 +832,14 @@ zmq publisher at: tcp://*:4500
 *Socket-util*:: Estimate of number of L4 ports (sockets) used per client IP. This is approximately (100*active_flows/#clients)/64K, calculated as (average active flows per client*100/64K). Utilization of more than 50% means that TRex is generating too many flows per single client, and that more clients must be added in the generator configuration.
 // clarify above, especially the formula
 
-*Max window*:: Maximum latency within a time window of 500 msec. There are few values shown per port.
- The earliest value is on the left, and latest value (last 500msec) on the right. This can help in identifying spikes of high latency clearing after some time. Maximum latency is the total maximum over the entire test duration. To best understand this, run TRex with the latency option (-l) and watch the results with this section in mind.
-
-// clarify the values. in the table, it looks like there are 3 values: left, middle, right
-
 *Platform_factor*:: In some cases, users duplicate traffic using a splitter/switch. In this scenario, it is useful for all numbers displayed by TRex to be multiplied by this factor, so that TRex counters will match the DUT counters.
 
 // in the above "multiplied by this factor" - which factor? 2?
 
 WARNING: If you do not see Rx packets, review the MAC address configuration.
 
+// include the entirety of the "Basic usage" section
 include::trex_book_basic.asciidoc[]
-
-// not sure what the include thing above is for
 
 == Advanced features
 
@@ -1710,6 +1705,8 @@ access-list 8 permit 17.0.0.0 0.0.0.255
 
 === Flow order/latency verification
 
+anchor:rx_check[]
+
 In normal mode (without the feature enabled), received traffic is not checked by software. Hardware (Intel NIC) testing for dropped packets occurs at the end of the test. The only exception is the Latency/Jitter packets. This is one reason that with TRex, you *cannot* check features that terminate traffic (for example TCP Proxy).
 
 To enable this feature, add
@@ -1737,26 +1734,27 @@ This feature ensures that:
 ----
 Cpu Utilization : 0.1 %                                                                       <1>
  if|   tx_ok , rx_ok  , rx   ,error,    average   ,   max         , Jitter ,  max window
-   |         ,        , check,     , latency(usec),latency (usec) ,(usec)  ,
+   |         ,        , check,     , latency(usec),latency (usec) ,(usec)  ,                  <2>
  --------------------------------------------------------------------------------
  0 |     1002,    1002,      2501,   0,         61  ,      70,       3      |  60
  1 |     1002,    1002,      2012,   0,         56  ,      63,       2      |  50
  2 |     1002,    1002,      2322,   0,         66  ,      74,       5      |  68
  3 |     1002,    1002,      1727,   0,         58  ,      68,       2      |  52
 
- Rx Check stats enabled                                                                       <2>
+ Rx Check stats enabled                                                                       <3>
  -------------------------------------------------------------------------------------------
- rx check:  avg/max/jitter latency,       94  ,     744,       49      |  252  287  309       <3>
+ rx check:  avg/max/jitter latency,       94  ,     744,       49      |  252  287  309       <4>
 
- active flows: <6>      10, fif: <5>     308,  drop:        0, errors:        0                <4>
+ active flows: <7>      10, fif: <6>     308,  drop:        0, errors:        0                <5>
  -------------------------------------------------------------------------------------------
 ----
 <1> CPU% of the Rx thread. If it is too high, *increase* the sample rate.
-<2> Rx Check section. For more detailed info, press 'r' during the test or at the end of the test.
-<3> Average latency, max latency, jitter on the template flows in microseconds. This is usually *higher* than the latency check packet because the feature works more on this packet.
-<4> Drop counters and errors counter should be zero. If not, press 'r' to see the full report or view the report at the end of the test.
-<5> fif - First in flow. Number of new flows handled by the Rx thread.
-<6> active flows - number of active flows handled by rx thread
+<2> The latency-specific packet measurement section. See xref:jitter_latency[Measuring Jittery/Latency] section for detailed output interpretation.
+<3> Rx Check section. For more detailed info, press 'r' during the test or at the end of the test.
+<4> Average latency, max latency, jitter on the template flows in microseconds. This is usually *higher* than the latency check packet because the feature works more on this packet.
+<5> Drop counters and errors counter should be zero. If not, press 'r' to see the full report or view the report at the end of the test.
+<6> fif - First in flow. Number of new flows handled by the Rx thread.
+<7> active flows - number of active flows handled by rx thread
 
 .Press R to Display Full Report
 [source,python]

--- a/doc/trex_book_basic.asciidoc
+++ b/doc/trex_book_basic.asciidoc
@@ -3260,8 +3260,9 @@ This feature will give the user more flexibility in defining the IP generator.
 
 === Measuring Jitter/Latency
 
-To measure jitter/latency using independent flows (SCTP or ICMP), use `-l [Hz]` where Hz defines the number of packets to send from each port per second.
-This option measures latency and jitter. We can define the type of traffic used for the latency measurement using the `--l-pkt-mode` option. 
+anchor:jitter_latency[]
+
+To measure jitter/latency using independent flows (SCTP or ICMP), use `-l <Hz>` where Hz defines the number of packets to send from each port per second. This option measures latency and jitter. We can define the type of traffic used for the latency measurement using the `--l-pkt-mode <0-3>` option. 
 
 
 [options="header",cols="^1,10a"]
@@ -3281,26 +3282,31 @@ Send ICMP request packets with a constant 0 sequence number from both sides.
 |=================
 
 
-The shell output is similar to the following: 
+==== Interpretting Jitter/Latency Output
+
+The command output of the `t-rex` utility with latency stats enabled looks similar to the following: 
 
 [source,python]
 ----
- Cpu Utilization : 0.1 %  
- if|   tx_ok , rx_ok  , rx   ,error,    average   ,   max         , Jitter<1> ,max 
-   |         ,        , check,     , latency(usec),latency (usec) ,(usec)  ,   window           
- --------------------------------------------------------------------------------------
- 0 |     1002,    1002,      2501,   0,         61  ,      70,       3      |  60  60  
- 1 |     1002,    1002,      2012,   0,         56  ,      63,       2      |  50  51  
- 2 |     1002,    1002,      2322,   0,         66  ,      74,       5      |  68  59  
- 3 |     1002,    1002,      1727,   0,         58  ,      68,       2      |  52  49  
+ -Latency stats enabled
+ Cpu Utilization : 0.2 %  <1>               <5>         <6>         <7>          <8>
+ if|   tx_ok , rx_ok  , rx check ,error,      latency (usec) ,    Jitter       max window
+   |         ,    <2> ,     <3>  , <4> ,  average   ,   max  ,    (usec)
+ ------------------------------------------------------------------------------------------------------
+ 0 |     1002,    1002,         0,    0,        51  ,      69,       3      |   0  69  67   ... 
+ 1 |     1002,    1002,         0,    0,        53  ,     196,       2      |   0  196  53  ...
+ 2 |     1002,    1002,         0,    0,        54  ,      71,       5      |   0  71  69   ...
+ 3 |     1002,    1002,         0,    0,        53  ,     193,       2      |   0  193  52  ...
 
- Rx Check stats enabled 
- ---------------------------------------------------------------------------------------
- rx check:  avg/max/jitter latency,       94  ,     744,       49<1>      |  252  287  3 
- 
- active flows:       10, fif:      308,  drop:        0, errors:        0 
- ---------------------------------------------------------------------------------------
 ----
-<1> Jitter information
 
+<1> Rx check and latency thread CPU utilization.
+<2> `tx_ok` on port 0 should equal `rx_ok` on port 1, and vice versa, for all paired ports.
+<3> Rx check rate as per `--rx-check`. For more information on Rx check, see xref:rx_check[Flow order/latency verification] section.
+<4> Number of packet errors detected. (various reasons, see `stateful_rx_core.cpp`)
+<5> Average latency (in microseconds) across **all** samples since startup.
+<6> Maximum latency (in microseconds) across **all** samples since startup.
+<7> Jitter calculated as per RC3550 Appendix-A.8.
+<8> Maximum latency within a sliding window of 500 milliseconds. There are few values shown per port according to terminal width. The odlest value is on the left and most recent value (latest 500msec sample) on the right. This can help in identifying spikes of high latency clearing after some time. Maximum latency (<6>) is the total maximum over the entire test duration. To best understand this, run TRex with the latency option (-l) and watch the results. 
+ 
 


### PR DESCRIPTION
 1. remove duplicate/incomplete latency output interpretation that was in doc/trex_book.asciidoc
 2. various cross-refs added for doc/trex_book.asciidoc into the latency/jitter section
 3. merged and improved the latency/jitter section in doc/trex_book_basic.asciidoc
----
Signed-off-by: Matt Callaghan <mcallaghan@sandvine.com>
----
(take two, from first attempt in https://github.com/cisco-system-traffic-generator/trex-core/pull/99 which had some disastrous squash failure)