### PR TITLE
Improved scapy parameters verification

### DIFF
--- a/src/stx/stl/trex_stl_rpc_cmds.cpp
+++ b/src/stx/stl/trex_stl_rpc_cmds.cpp
@@ -621,6 +621,12 @@ TrexRpcCmdAddStream::check_min_max(uint8_t flow_var_size,
         generate_parse_err(result, ss.str());
     }
 
+    if (init_value < min_value || init_value > max_value) {
+        std::stringstream ss;
+        ss << "VM: requested flow var init value: '" << init_value << "' should be in range from min value '" << min_value << "' to max value '" << max_value << "'";
+        generate_parse_err(result, ss.str());
+    }
+
     if (flow_var_size == 1 ) {
         if ( (init_value > UINT8_MAX) || (min_value > UINT8_MAX) || (max_value > UINT8_MAX) || (step >UINT8_MAX) )  {
             std::stringstream ss;


### PR DESCRIPTION
- Some flow variables parameters are verified inside src/stx/stl/trex_stl_rpc_cmds.cpp, but it also
could be verified earlier, inside scapy packet building routine, so Packet Editor also could display
these error properly, implemented errors:
    - step >= 0
    - limit >= 0
    - values fit their sizes (0xff for 1, 0xffff for 2, etc.)
    - init value is between min and max (this error could cause trex crash)
    - range padding to provide true cycle '(max_value - min_value + 1) % step'