### PR TITLE
Fixed typo in template name

### DIFF
--- a/scripts/automation/trex_control_plane/stl/services/scapy_server/field_engine.json
+++ b/scripts/automation/trex_control_plane/stl/services/scapy_server/field_engine.json
@@ -254,7 +254,7 @@
     {
       "id": "rep_rand_var",
       "name": "Repeatable random",
-      "instructionIds": ["STLVmFlowVarRepetableRandom", "STLVmWrFlowVar"]
+      "instructionIds": ["STLVmFlowVarRepeatableRandom", "STLVmWrFlowVar"]
     }
   ],
   "global_params_meta":[


### PR DESCRIPTION
- The typo was causing to incorrect RepeatableRandom template behaviour in Packet editor due to mismatch with presented RepeatableRandom instruction