### PR TITLE
doc: add common keyword prefixes for commit summary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,14 @@ by the project. In the absence of such guidelines, mimic the styles and patterns
 in the existing codebase.
 
 Commit Notes:
+ - Prefix the summary with a single keyword identifying the high level "area" that the change applies to.
+   Common keywords include: `doc`, `stl`, `tcp`, `astf`, `tui`, `arm`, ...
+   - General format:
+   > keyword: succinct summary of change
+   - Example:
+   > doc: fixed a typo
  - Always use git's `-s (--signoff)` flag to append the legal sign off required.
-This applies to all pull requests. If making documentation changes directly in
+This applies to all pull requests. See `man git-commit` for more details. If making documentation changes directly in
 gitlab, you can manually append the signoff note in the commit message.
 > Signed-off-by: Full Name \<e-mail\>
- - See `man git-commit` for more details.
+ - Version tags have a commit summary of simply `v<major>.<minor>`


### PR DESCRIPTION
I noticed several contributors adding a "keyword" prefix to their commit summaries. Presumably we would desire consistency across all contributors. Amending the CONTRIBUTING.md accordingly. (if there are other specific keywords the project owners would like to denote here, they can expand upon the list at their leisure)

Signed-off-by: Matt Callaghan <mcallaghan@sandvine.com>