### PR TITLE
BPF Filter : IPv6 BPF filter did not work before. Now it works with I…

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -1295,7 +1295,7 @@ def build_prog (bld, build_obj):
     # build the BPF as a shared library
     bld.shlib(features = 'c',
               includes = bpf_includes_path,
-              cflags   = cflags + ['-DSLJIT_CONFIG_AUTO=1'],
+              cflags   = cflags + ['-DSLJIT_CONFIG_AUTO=1','-DINET6'],
               source   = bpf.file_list(top),
               target   = build_obj.get_bpf_target())
 

--- a/scripts/automation/regression/functional_tests/bpf_test.py
+++ b/scripts/automation/regression/functional_tests/bpf_test.py
@@ -50,6 +50,21 @@ class BPF_Test(functional_general_test.CGeneralFunctional_Test):
     
         finally:
             libbpf.bpf_destroy(bpf_h)
+
+    def test_bpf_ipv6 (self):
+
+        pattern = c_buffer(b'ip6 src host 2001:0db8:85a3:0042:0000:8a2e:0371:7334')
+        bpf_h = libbpf.bpf_compile(pattern)
+        assert(bpf_h)
+
+        try:
+            c_ip6 = bytes(Ether()/IPv6(src='2001:0db8:85a3:0042:0000:8a2e:0371:7334'))
+
+            rc = libbpf.bpf_run(bpf_h, c_ip6, len(c_ip6) - 1)
+            assert(rc != 0)
+
+        finally:
+            libbpf.bpf_destroy(bpf_h)
     
             
     def test_bpf_multiple_matches (self):
@@ -79,8 +94,8 @@ class BPF_Test(functional_general_test.CGeneralFunctional_Test):
                 
         finally:
             libbpf.bpf_destroy(bpf_h)
-            
-        
+
+       
             
     def test_bpf_vlan (self):
         


### PR DESCRIPTION
https://github.com/cisco-system-traffic-generator/trex-core/issues/107

Previously, IPv6 BPF filter did not work when capturing packet. 
This is because "INET6" was not defined in the TRex libbpf.
Now build flag, "-DINET6" has been added to solve this problem. 

Please check and provide feedback. 