### PR TITLE
Add value_list in flow variable of vm instruction

### DIFF
--- a/doc/trex_rpc_server_spec.asciidoc
+++ b/doc/trex_rpc_server_spec.asciidoc
@@ -797,6 +797,7 @@ Fix TCP/UDP and IPv4 headers using hardware assit engine
 | init_value  | uint64_t as string          | init value for the field
 | min_value   | uint64_t as string          | minimum value for the field
 | max_value   | uint64_t as string          | maximum value for the field
+| value_list  | array of uint64_t as string | fixed list of values instead of init_value, min_value, max_value
 | step        | uint64_t as string          | step, how much to inc or dec. 1 is the default (in case of 'random' this field is not used) 
 |=================
 

--- a/scripts/stl/udp_1pkt_simple_list_test.py
+++ b/scripts/stl/udp_1pkt_simple_list_test.py
@@ -1,0 +1,43 @@
+from trex_stl_lib.api import *
+
+def generate_payload(length):
+      word = ''
+      alphabet_size = len(string.ascii_letters)
+      for i in range(length):
+          word += string.ascii_letters[(i % alphabet_size)]
+      return word
+
+
+class STLS1(object):
+
+    def create_stream (self):
+        fsize_no_fcs = 129
+        base_pkt_a = Ether()/IP(dst="48.0.0.1",options=IPOption(b'\x01\x01\x01\x00'))/UDP(dport=12,sport=1025)
+        ipaddr_list = ["16.0.0.1","16.0.0.4","16.0.0.5","16.0.0.2","16.0.0.3","16.0.0.6"]
+        vm1 = STLScVmRaw([
+                          STLVmFlowVar(name="src",value_list=ipaddr_list, op="dec"),
+                          STLVmWrFlowVar(fv_name="src",pkt_offset= "IP.src"),
+                           # checksum
+                         STLVmFixIpv4(offset = "IP")
+
+                         ]
+                         ) # split to cores base on the tuple generator
+
+        #
+        pkt_a = STLPktBuilder(pkt=base_pkt_a/generate_payload(fsize_no_fcs-len(base_pkt_a)), vm=vm1)
+
+
+        return STLStream( packet = pkt_a ,
+                          mode = STLTXCont() )
+
+    def get_streams (self, direction = 0, **kwargs):
+        # create 1 stream
+        return [ self.create_stream() ]
+
+
+# dynamic load - used for trex console or simulator
+def register():
+    return STLS1()
+
+
+

--- a/scripts/stl/udp_inc_len_list.py
+++ b/scripts/stl/udp_inc_len_list.py
@@ -1,0 +1,47 @@
+from trex_stl_lib.api import *
+
+class STLS1(object):
+
+    def __init__ (self):
+        self.max_pkt_size_l3  =9*1024;
+
+    def create_stream (self):
+        # pkt
+        p_l2  = Ether();
+        p_l3  = IP(src="16.0.0.1",dst="48.0.0.1")
+        p_l4  = UDP(dport=12,sport=1025)
+        pyld_size = max(0, self.max_pkt_size_l3 - len(p_l3/p_l4));
+        base_pkt = p_l2/p_l3/p_l4/('\x55'*(pyld_size))
+
+        l3_len_fix =-(len(p_l2));
+        l4_len_fix =-(len(p_l2/p_l3));
+
+        base_pkt_list = [256,512,64,128,4096,8192,1024,2048,9216]
+        # vm
+        vm = STLScVmRaw( [ STLVmFlowVar(name="fv_rand", value_list=base_pkt_list, size=2, op="inc"),
+                           STLVmTrimPktSize("fv_rand"), # total packet size
+                           STLVmWrFlowVar(fv_name="fv_rand", pkt_offset= "IP.len", add_val=l3_len_fix), # fix ip len
+                           STLVmFixIpv4(offset = "IP"), # fix checksum
+                           STLVmWrFlowVar(fv_name="fv_rand", pkt_offset= "UDP.len", add_val=l4_len_fix) # fix udp len
+                          ]
+                       )
+
+        pkt = STLPktBuilder(pkt = base_pkt,
+                            vm = vm)
+
+        return STLStream(packet = pkt,
+                         mode = STLTXCont())
+
+
+
+    def get_streams (self, direction = 0, **kwargs):
+        # create 1 stream
+        return [ self.create_stream() ]
+
+
+# dynamic load - used for trex console or simulator
+def register():
+    return STLS1()
+
+
+

--- a/scripts/stl/udp_multi_simple_list_test.py
+++ b/scripts/stl/udp_multi_simple_list_test.py
@@ -1,0 +1,86 @@
+from trex_stl_lib.api import *
+
+def generate_payload(length):
+      word = ''
+      alphabet_size = len(string.ascii_letters)
+      for i in range(length):
+          word += string.ascii_letters[(i % alphabet_size)]
+      return word
+
+
+class STLS1(object):
+
+    def create_stream1 (self):
+        fsize_no_fcs = 129
+        base_pkt_a = Ether()/IP(dst="48.0.0.1",options=IPOption(b'\x01\x01\x01\x00'))/UDP(dport=12,sport=1025)
+        ipaddr_list = ["16.0.0.1","16.0.0.4","16.0.0.5","16.0.0.2","16.0.0.3","16.0.0.6"]
+        vm1 = STLScVmRaw([
+                          STLVmFlowVar(name="src",value_list=ipaddr_list, op="inc"),
+                          STLVmWrFlowVar(fv_name="src",pkt_offset= "IP.src"),
+                           # checksum
+                         STLVmFixIpv4(offset = "IP")
+
+                         ]
+                         ) # split to cores base on the tuple generator
+
+        #
+        pkt_a = STLPktBuilder(pkt=base_pkt_a/generate_payload(fsize_no_fcs-len(base_pkt_a)), vm=vm1)
+
+
+        return STLStream( packet = pkt_a ,
+                          mode = STLTXCont() )
+
+
+    def create_stream2 (self):
+        fsize_no_fcs = 129
+        base_pkt_a = Ether()/IP(dst="48.0.0.1",options=IPOption(b'\x01\x01\x01\x00'))/UDP(dport=12,sport=1025)
+        ipaddr_list = ["17.0.0.1","17.0.0.4","17.0.0.5","17.0.0.2","17.0.0.3","17.0.0.6"]
+        vm1 = STLScVmRaw([
+                          STLVmFlowVar(name="src",value_list=ipaddr_list, op="dec"),
+                          STLVmWrFlowVar(fv_name="src",pkt_offset= "IP.src"),
+                           # checksum
+                         STLVmFixIpv4(offset = "IP")
+
+                         ]
+                         ) # split to cores base on the tuple generator
+
+        #
+        pkt_a = STLPktBuilder(pkt=base_pkt_a/generate_payload(fsize_no_fcs-len(base_pkt_a)), vm=vm1)
+
+
+        return STLStream( packet = pkt_a ,
+                          mode = STLTXCont() )
+
+
+    def create_stream3 (self):
+        fsize_no_fcs = 129
+        base_pkt_a = Ether()/IP(dst="48.0.0.1",options=IPOption(b'\x01\x01\x01\x00'))/UDP(dport=12,sport=1025)
+        ipaddr_list = ["18.0.0.1","18.0.0.4","18.0.0.5","18.0.0.2","18.0.0.3","18.0.0.6"]
+        vm1 = STLScVmRaw([
+                          STLVmFlowVar(name="src",value_list=ipaddr_list, op="random"),
+                          STLVmWrFlowVar(fv_name="src",pkt_offset= "IP.src"),
+                           # checksum
+                         STLVmFixIpv4(offset = "IP")
+
+                         ]
+                         ) # split to cores base on the tuple generator
+
+        #
+        pkt_a = STLPktBuilder(pkt=base_pkt_a/generate_payload(fsize_no_fcs-len(base_pkt_a)), vm=vm1)
+
+
+        return STLStream( packet = pkt_a ,
+                          mode = STLTXCont() )
+
+
+    def get_streams (self, direction = 0, **kwargs):
+        # create 1 stream
+        return [ self.create_stream1(),self.create_stream2(),self.create_stream3() ]
+
+
+# dynamic load - used for trex console or simulator
+def register():
+    return STLS1()
+
+
+


### PR DESCRIPTION
Hi,
As I discussed with you, I merged my code again with your latest big commit.

**1. Summary**
The current flow variable in field engine only support 3 types: inc, dec and random with init_value, min_value, max_value.
Frequently user want to set a list values for specified field, like udp port [4001, 4005. 5003], the values are defined by use case without regular rules.
So, I have implemented 'value_list' of flow variable which controls array of values.

| value_list  | array of uint64_t as string | fixed list of values instead of init_value, min_value, max_value

**2. Example**
ipaddr_list = ["16.0.0.1","16.0.0.4","16.0.0.5","16.0.0.2","16.0.0.3","16.0.0.6"]

"vm": {
    "instructions": [
        {   
            "name": "src",                                                                                    
            "op": "dec",
            "size": 4,
            "step": 1,
            "type": "flow_var",
            "value_list": [
                268435457,
                268435460,
                268435461,
                268435458,
                268435459,
                268435462
            ]   
        }, 

**3. multi core test result**
List = [1,4,5,2,3,6]
Cores = 3
Output = 1,4,5,2,3,6,1,4,,,,,

BR,
Yonghwan