### PR TITLE
Check maximum size of value_list in flow variable

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_packet_builder_scapy.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_packet_builder_scapy.py
@@ -844,7 +844,10 @@ class STLVmFlowVar(CTRexVmDescBase):
             valid_fv_init(self.init_value, self.min_value, self.max_value)
             valid_fv_cycle(self.min_value, self.max_value, self.step, self.op)
 
-        else :
+        else:
+            if len(value_list) > get_max_by_size(2):
+                raise CTRexPacketBuildException(-11,("value_list size %d bigger than %d") % (len(value_list), get_max_by_size(2)));
+
             self.init_value = None
             self.min_value  = None
             self.max_value  = None

--- a/src/stx/stl/trex_stl_rpc_cmds.cpp
+++ b/src/stx/stl/trex_stl_rpc_cmds.cpp
@@ -575,6 +575,12 @@ TrexRpcCmdAddStream::check_value_list(uint8_t flow_var_size,
         generate_parse_err(result, "VM: step cannot be bigger than list size");
     }
 
+    if (value_list.size() > UINT16_MAX) {
+        std::stringstream ss;
+        ss << "VM: value_list size is bigger than " << UINT16_MAX;
+        generate_parse_err(result, ss.str());
+    }
+
     for (int i = 0; i < (int)value_list.size(); i++) {
         if (flow_var_size == 1 && value_list[i] > UINT8_MAX) {
             std::stringstream ss;


### PR DESCRIPTION
Hi,

The number of element in value_list should be smaller than 65535.
Therefore, I added exception handling routine in case of exceeding maximum size on both client and server side.

BR,
Yonghwan