### PR TITLE
Fixing bug for the ERROR trace of stl profile

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -1512,10 +1512,9 @@ class STLClient(TRexClient):
                 self.add_streams(profile.get_streams(), ports = port)
 
         except TRexError as e:
-            for line in e.brief().splitlines():
-                if ansi_len(line.strip()):
-                    error = line
-            raise TRexError(format_text("Error loading profile '{0}'".format(opts.file[0]), 'bold'))
+            s = format_text("\nError loading profile '{0}'\n".format(opts.file[0]), 'bold')
+            s += "\n" + e.brief()
+            raise TRexError(s)
 
         if opts.dry:
             self.validate(opts.ports, opts.mult, opts.duration, opts.total)


### PR DESCRIPTION
After big commit from trex-core v2.41, ERROR trace is not printed for stl profile ERROR.

Test results are as below.
1. Before changed
trex>start -f stl/bench.py -t size=imix,vm=size
Removing all streams from port(s) [0, 1]:                    [SUCCESS]
start - Error loading profile 'stl/bench.py'

2. After changed
trex>start -f stl/bench.py -t size=imix,vm=size
Removing all streams from port(s) [0, 1]:                    [SUCCESS]
start - 
Error loading profile 'stl/bench.py'

### Python Traceback follows:
  File "stl/bench.py", line 65, in get_streams
    raise STLError("Can't use VM of type 'size' with IMIX.")
TRexError: Can't use VM of type 'size' with IMIX.

trex>