### PR TITLE
fix crash during capture

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -9,7 +9,7 @@ import time
 import base64
 from collections import OrderedDict, defaultdict
 
-from ..utils.common import get_current_user, list_remove_dup, is_valid_ipv4, is_valid_ipv6, is_valid_mac, list_difference, list_intersect, PassiveTimer
+from ..utils.common import get_current_user, list_remove_dup, is_valid_ipv4, is_valid_ipv6, is_valid_mac, list_difference, list_intersect, PassiveTimer, sec_split_usec
 from ..utils import parsing_opts, text_tables
 from ..utils.text_opts import format_text, format_num
 from ..utils.text_tables import TRexTextTable


### PR DESCRIPTION

 **fix python crash during capture stop**

#here is the log
trex(service)>capture record start --tx 1

Starting packet capturing up to 1000 packets [SUCCESS]

*** Capturing ID is set to '9' ***
*** Please call 'capture record stop --id 9 -o <out.pcap>' when done ***

trex(service)>capture record stop --id 9 -o out.pcap

Stopping packet capture 9 [SUCCESS]

Writing up to 12 packets to 'out.pcap' Traceback (most recent call last):
File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
"main", fname, loader, pkg_name)
File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
exec code in run_globals
File "/root/trex/automation/trex_control_plane/interactive/trex/console/trex_console.py", line 900, in 
main()
File "/root/trex/automation/trex_control_plane/interactive/trex/console/trex_console.py", line 889, in main
console.start()
File "/root/trex/automation/trex_control_plane/interactive/trex/console/trex_console.py", line 609, in start
self.cmdloop()
...
....
File "/root/trex/automation/trex_control_plane/interactive/trex/common/trex_api_annotators.py", line 51, in wrap2
ret = f(*args, **kwargs)
File "/root/trex/automation/trex_control_plane/interactive/trex/common/trex_client.py", line 965, in fetch_capture_packets
ts_sec, ts_usec = sec_split_usec(ts)
NameError: global name 'sec_split_usec' is not defined
root@ubuntu:~/trex#