### PR TITLE
Scapy server imports fixes (repeat)

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_service.py
@@ -2,6 +2,11 @@
 import os
 import sys
 
+scapy_service_dir = os.path.abspath(os.path.dirname(__file__))
+trex_dir = os.path.join(scapy_service_dir, os.pardir, os.pardir)
+
+sys.path.append(scapy_service_dir)
+sys.path.append(trex_dir)
 
 from trex.stl.api import *
 from trex import stl

--- a/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_zmq_server.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_zmq_server.py
@@ -5,11 +5,13 @@ import os
 import traceback
 import errno
 
-from ..stl.api import *
+try:
+    from scapy_service import *
+except:
+    from .scapy_service import *
 
 import zmq
 import inspect
-from .scapy_service import *
 from argparse import *
 import socket
 import logging


### PR DESCRIPTION
There was an issue [this PR](https://github.com/cisco-system-traffic-generator/trex-core/pull/120) merge 

this commit https://github.com/cisco-system-traffic-generator/trex-core/commit/9e70667dc663ff4c5e3081c03a2fa2f834da7ece
overwrote this Scapy imports fix https://github.com/cisco-system-traffic-generator/trex-core/commit/1d08e750dbc967f7d1f278fd3c128a8f401a99c0

Since there is `scapy_service_dir` variable used in `_get_templates` method, it would be nice to merge this import fix again
Also this fix helps to start scapy_server by different ways, and it fixes `unittests` start
