### PR TITLE
DOC: clarify dummy ports single interface support matrix

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -731,9 +731,9 @@ Consider the following if using dummy ports for a single interface TRex generato
 | Configuration | Mode | Support Status | Comments
 | Single TRex Generator, Single Interface | Stateless | functional | unidirectional
 | | Stateful | semi-functional | will only send unidirectional side of the flows
-| | ASTF | unsupported | will not work due to requiring bidirectional TCP stack
+| | ASTF | depends on remote | requires bidirectional TCP stack, if remote supports TCP stack, will work, otherwise will not work
 | Two TRex Generators ,Single Interface | Stateless | functional | bidirectional
-| | Stateful | semi-functional | will "work", but flows will not be in sync
+| | Stateful | semi-functional | will "work", however flows will not be in sync
 | | ASTF | functional | full TCP stack
 |=================
 

--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -693,11 +693,9 @@ Under the hood it's being replaced with following (this full syntax can also be 
 
 === Dummy ports
 
-(Starting from version 2.38)
+Dummy ports are available to solve 2 issues:
 
-Dummy ports can solve 2 issues:
-
-* Odd number of interfaces. For example, TRex with one interface only.
+* Odd number of interfaces. For example, TRex with only one interface.
 * Performance degradation when adjacent interfaces belong to different NUMAs.
 
 Configuration example:
@@ -721,10 +719,23 @@ Incorrect configuration example:
 
 [NOTE]
 =====================================
+1. Supported in TRex as of v2.38+.
 1. Currently GUI does not work with dummy ports. Will update as soon as it will.
 2. Client (Python API, trex-console) older than v2.38 will not work with dummy ports. Update your client to v2.38 or later.
+3. Dummy ports are available for all TRex modes (stateless, statefull, and ASTF).
 =====================================
 
+[SINGLE PORT CONSIDERATIONS]
+Consider the following if using dummy ports for a single interface TRex generator:
+|=================
+| Configuration | Mode | Support Status | Comments
+| Single TRex Generator, Single Interface | Stateless | functional | unidirectional
+| | Stateful | semi-functional | will only send unidirectional side of the flows
+| | ASTF | unsupported | will not work due to requiring bidirectional TCP stack
+| Two TRex Generators ,Single Interface | Stateless | functional | bidirectional
+| | Stateful | semi-functional | will "work", but flows will not be in sync
+| | ASTF | functional | full TCP stack
+|=================
 
 === Configuring for running with router (or other L3 device) as DUT
 


### PR DESCRIPTION
As per #125, we identified confusion and clarified whether or not single interfaces are viable for anything other than stateless. This change adds the necessary clarity to distinguish "dummy ports" in general vs. "single interface" support across each TRex mode and single vs. dual generator scenarios.

----
Signed-off-by: Matt Callaghan (mcallaghan@sandvine.com)