### PR TITLE
prevent zero pkts request from single_burst and multi_burst mode

### DIFF
--- a/doc/trex_rpc_server_spec.asciidoc
+++ b/doc/trex_rpc_server_spec.asciidoc
@@ -729,7 +729,7 @@ mode object can be 'one' of the following objects:
 | Field         | Type        | Description
 | type          | string      | ''single_burst''
 | rate          | object      |  rate object
-| total pkts    | int         | total packets in the burst
+| total pkts    | uint32_t    | total packets to be sent. It should be bigger than 0.
 |=================
 
 .Object type 'mode - multi_burst' 
@@ -738,9 +738,9 @@ mode object can be 'one' of the following objects:
 | Field          | Type        | Description
 | type           | string      | ''multi_burst''
 | rate           | object      |  rate object
-| pkts_per_burst | int         | packets in a single burst
+| pkts_per_burst | uint32_t    | number of packets to be sent in a single burst. It should be bigger than 0.
 | ibg            | double      | ['usec'] inter burst gap. delay between bursts in usec
-| count          | int         | number of bursts. ''0'' means loop forever, ''1'' will fall back to single burst
+| count          | uint32_t    | number of bursts. ''0'' means loop forever, ''1'' will fall back to single burst
 |=================
 
 ==== vm

--- a/src/stx/stl/trex_stl_rpc_cmds.cpp
+++ b/src/stx/stl/trex_stl_rpc_cmds.cpp
@@ -360,6 +360,9 @@ TrexRpcCmdAddStream::allocate_new_stream(const Json::Value &section, uint8_t por
 
         uint32_t total_pkts      = parse_uint32(mode, "total_pkts", result);
 
+        if (total_pkts == 0) {
+            generate_parse_err(result, type + ": 'total_pkts' cannot be zero.");
+        }
         stream.reset(new TrexStream(TrexStream::stSINGLE_BURST, port_id, stream_id));
         stream->set_single_burst(total_pkts);
 
@@ -370,6 +373,9 @@ TrexRpcCmdAddStream::allocate_new_stream(const Json::Value &section, uint8_t por
         uint32_t  num_bursts       = parse_uint32(mode, "count", result);
         uint32_t  pkts_per_burst   = parse_uint32(mode, "pkts_per_burst", result);
 
+        if (pkts_per_burst == 0) {
+            generate_parse_err(result, type + ": 'pkts_per_burst' cannot be zero.");
+        }
         stream.reset(new TrexStream(TrexStream::stMULTI_BURST,port_id, stream_id));
         stream->set_multi_burst(pkts_per_burst,num_bursts,ibg_usec);
 


### PR DESCRIPTION
When single_burst or multi_burst mode used, total_pkts and pkts_per_burst can be set by zero.
This causes continuous sending pkts unexpectedly.
This change prevents zero value request from single_burst and multi_burst mode.

Following messages are part of rpc respond when zero value is used.

"error": {
    "code": -32000,
    "message": "Failed To Execute Method",
    "specific_err": "single_burst: 'total_pkts' cannot be zero."
},

"error": {
    "code": -32000,
    "message": "Failed To Execute Method",
    "specific_err": "multi_burst: 'pkts_per_burst' cannot be zero."
},