### PR TITLE
doc: clarify -k option behaviour

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -2162,7 +2162,7 @@ Flag that specifies interactive mode. Currently used for stateless (WIP adding a
 *-k <num>*::
    Run ``warm up'' traffic for num seconds before starting the test. This is needed if TRex is connected to switch running
    spanning tree. You want the switch to see traffic from all relevant source MAC addresses before starting to send real
-   data. Traffic sent is the same used for the latency test (-l option) +
+   data. Works only with the latency test (-l option). Traffic sent is the same used for the latency test. +
    Current limitation (holds for TRex version 1.82): does not work properly on VM.
 
 *-l <rate>*::

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -345,7 +345,8 @@ static int __attribute__((cold)) usage() {
     printf(" --hops <hops>              : If rx check is enabled, the hop number can be assigned. See manual for details \n");
     printf(" --iom  <mode>              : IO mode  for server output [0- silent, 1- normal , 2- short] \n");
     printf(" --ipv6                     : Work in ipv6 mode \n");
-    printf(" -k  <num>                  : Run 'warm up' traffic for num seconds before starting the test. \n");
+    printf(" -k  <num>                  : Run 'warm up' traffic for num seconds before starting the test.\n");
+    printf("                               Works only with the latency test (-l option)\n");
     printf(" -l <rate>                  : In parallel to the test, run latency check, sending packets at rate/sec from each interface \n");
     printf(" --l-pkt-mode <0-3>         : Set mode for sending latency packets \n");
     printf("      0 (default)    send SCTP packets  \n");


### PR DESCRIPTION
warm up traffic (-k option) only works in conjunction with the
latency test (-l option), but the documentation doesn't say it.

Issue #160

Signed-off-by: Matteo Croce <mcroce@redhat.com>