### PR TITLE
Support "RSS" mode with virtio

### DIFF
--- a/src/drivers/trex_driver_virtual.cpp
+++ b/src/drivers/trex_driver_virtual.cpp
@@ -39,7 +39,7 @@ int CTRexExtendedDriverVirtBase::get_min_sample_rate(void){
 }
 
 void CTRexExtendedDriverVirtBase::get_dpdk_drv_params(CTrexDpdkParams &p) {
-    p.rx_data_q_num = 1;
+    p.rx_data_q_num = CGlobalInfo::m_options.preview.getCores();
     p.rx_drop_q_num = 0;
     p.rx_desc_num_data_q = RX_DESC_NUM_DATA_Q_VM;
     p.rx_desc_num_drop_q = RX_DESC_NUM_DROP_Q;
@@ -96,7 +96,7 @@ void CTRexExtendedDriverMlnx4::update_configuration(port_cfg_t * cfg) {
 }
 
 CTRexExtendedDriverVirtio::CTRexExtendedDriverVirtio() {
-    CGlobalInfo::set_queues_mode(CGlobalInfo::Q_MODE_ONE_QUEUE);
+    CGlobalInfo::set_queues_mode(CGlobalInfo::Q_MODE_RSS);
     m_cap = /*TREX_DRV_CAP_DROP_Q  | TREX_DRV_CAP_MAC_ADDR_CHG */ 0;
 }
 

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -5169,7 +5169,7 @@ const static uint8_t client_rss_key[] = {
 
 
 void CPhyEthIF::configure_rss_astf(bool is_client,
-                                   uint16_t numer_of_queues,
+                                   uint16_t number_of_queues,
                                    uint16_t skip_queue){ 
 
     struct rte_eth_dev_info dev_info;
@@ -5193,7 +5193,7 @@ void CPhyEthIF::configure_rss_astf(bool is_client,
         reta_conf[j].mask = ~0ULL;
         for (int i = 0; i < RTE_RETA_GROUP_SIZE; i++) {
             while (true) {
-                q=(indx + skip) % numer_of_queues;
+                q=(indx + skip) % number_of_queues;
                 if (q != skip_queue) {
                     break;
                 }
@@ -5372,7 +5372,8 @@ void CPhyEthIF::conf_queues() {
         } else {
             // no drop q. Many rcv queues. RSS mode.
             // rss on all rcv queues. Do not skip any q.
-            configure_rss_redirect_table(dpdk_p.rx_data_q_num, 0xff);
+	    if (false) //This is the default RSS configuration
+	            configure_rss_redirect_table(dpdk_p.rx_data_q_num, 0xff);
             g_trex.m_rx_core_tx_q_id = g_trex.get_rx_core_tx_queue_id();
             for (int queue = 0; queue < dpdk_p.rx_data_q_num; queue++) {
                 rx_queue_setup(queue, dpdk_p.rx_desc_num_data_q, socket_id,


### PR DESCRIPTION
This allows to use multi-queue (and therefore multiple cores) to handle a single dp.

This patch is not ready to be merged. It seems to work but I'd like feedback. 

Any reason configure_rss_redirect_table(dpdk_p.rx_data_q_num, 0xff); is called if there is no drop queue? That is the default of RSS, and does not work with virtio that will keep the TX queue from the other side of the virtual device if I'm not mistaken. So this is not technically RSS and maybe a new Q_MODE should be used...

And maybe I should only set rx_data_q_num to the number of cores if the device is indeed in RSS mode.

Thanks for the feedback.


