### PR TITLE
Fixed Scapy unreachable on python3

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_zmq_server.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_zmq_server.py
@@ -130,7 +130,9 @@ class Scapy_server():
         try:
             while True:
                 try:
-                    message = self.socket.recv_string()
+                    message = self.socket.recv()
+                    message = message.decode()
+
                     self.logger.info('Received Message: %s' % message)
                 except zmq.ZMQError as e:
                     if e.errno != errno.EINTR:


### PR DESCRIPTION
- When Scapy server is started on python3, recv_string method of ZMQ
  socket returns byte sequence instead of decoded string, fixed this for both
  scapy server and scapy client implementation
- Edited Scapy client, to be able to work with python3
- Tested with python 2 and 3
- Replaced `send_string` by supported `send` method with `encode` call in scapy_zmq_client

Signed-off-by: Egor Blagov <e.m.blagov@gmail.com>