### PR TITLE
TCP UDP checksum by SW.

### DIFF
--- a/src/dpdk/lib/librte_net/rte_ip.h
+++ b/src/dpdk/lib/librte_net/rte_ip.h
@@ -126,7 +126,7 @@ __rte_raw_cksum(const void *buf, size_t len, uint32_t sum)
 
 	/* if length is in odd bytes */
 	if (len == 1)
-		sum += *((const uint8_t *)u16_buf);
+		sum += *((const uint8_t *)u16_buf) & rte_be_to_cpu_16(0xff00);
 
 	return sum;
 }
@@ -221,8 +221,10 @@ rte_raw_cksum_mbuf(const struct rte_mbuf *m, uint32_t off, uint32_t len,
 	done = 0;
 	for (;;) {
 		tmp = __rte_raw_cksum(buf, seglen, 0);
-		if (done & 1)
+		if (done & 1) {
+			tmp = __rte_raw_cksum_reduce(tmp);
 			tmp = rte_bswap16((uint16_t)tmp);
+                }
 		sum += tmp;
 		done += seglen;
 		if (done == len)


### PR DESCRIPTION
Hi,

I have implemented checksum support by SW where HW does not support TX checksum offload.
Since HW may not support TX checksum offloads (like as virtio in Cloud), checksum cannot be filled when STLVmFixChecksumHw specified in STL stream VM.

Although HW does not support TX checksum offloads, I think users expect to send packets with normal checksum when they set to update checksum.

And I found that there is a bug in DPDK code. I fixed it also as you can see.

Please review my Pull Request as soon as possible.