### PR TITLE
[Client Implementation][New feature]Dynamic streams add/delete at run-time #181 

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -383,11 +383,9 @@ class TRexClient(object):
         for port in port_list:
 
             port_id = port
-            if isinstance(port, STL_PORT_INFO):
-                port_id =  port.port_id
-
             profile_id = None
             if isinstance(port, STL_PORT_INFO):
+                port_id =  port.port_id
                 profile_id = port.profile_id
 
             # get port specific

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_psv.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_psv.py
@@ -7,7 +7,7 @@ Author:
 """
 
 from .trex_exceptions import TRexError, TRexTypeError
-from .trex_types import listify_if_int
+from .trex_types import listify, STL_PORT_INFO
 from ..utils.common import *
 
 
@@ -34,18 +34,20 @@ class PortState(object):
     '''
     
     def validate (self, client, cmd_name, ports, custom_err_msg = None):
+        ports = parse_physical_port_ids(ports)
         invalid_ports = list_difference(ports, self.get_valid_ports(client))
         if invalid_ports:
-            err_msg = self.def_err_msg()
-            if custom_err_msg:
-                err_msg = '{0} - {1}'.format(err_msg, custom_err_msg)
-            
-            raise TRexError('port(s) {0}: {1}'.format(invalid_ports, err_msg))
-        
+            self.print_err_msg(invalid_ports, custom_err_msg)
             
     def get_valid_ports (self, client):
         raise NotImplementedError
         
+    def print_err_msg (self, invalid_ports, custom_err_msg = None):
+        err_msg = self.def_err_msg()
+        if custom_err_msg:
+            err_msg = '{0} - {1}'.format(err_msg, custom_err_msg)
+        raise TRexError('port(s) {0}: {1}'.format(invalid_ports, err_msg))
+
 
 class PortStateAll(PortState):
     def def_err_msg (self):
@@ -72,14 +74,77 @@ class PortStateAcquired(PortState):
   
           
 class PortStateIdle(PortState):
+    def validate (self, client, cmd_name, ports, custom_err_msg = None):
+        invalid_ports = []
+        dup_port = []
+
+        for port in ports:
+            port_name = port
+            port_id = port
+            profile_id = "_"
+
+            if port_id in dup_port:
+                print_err_msg(ports, "Cannot use * with other profile_ids")
+
+            if isinstance(port, STL_PORT_INFO):
+                port_name = port.port_name
+                port_id = port.port_id
+                profile_id = port.profile_id
+
+            is_idle = False
+            if profile_id == "*":
+                dup_port.append(port_id)
+                profile_state_list = client.ports[port_id].profile_manager.get_all_profiles()
+                for pid in profile_state_list:
+                    if not client.ports[port_id].profile_manager.is_active(pid):
+                        is_idle = True
+            else:
+                if not client.ports[port_id].profile_manager.is_active(profile_id):
+                    is_idle = True
+
+            if not is_idle :
+                invalid_ports.append(str(port_name))
+
+        if invalid_ports:
+            self.print_err_msg (invalid_ports, custom_err_msg)
+
     def def_err_msg (self):
         return 'are active'
 
     def get_valid_ports (self, client):
         return [port_id for port_id in client.get_all_ports() if not client.ports[port_id].is_active()]
-  
 
 class PortStateTX(PortState):
+    def validate (self, client, cmd_name, ports, custom_err_msg = None):
+        invalid_ports = []
+        dup_port = []
+
+        for port in ports:
+            port_name = port
+            port_id = port
+            profile_id = "_"
+
+            if port_id in dup_port:
+                print_err_msg(ports, "Cannot use * with other profile_ids")
+
+            if isinstance(port, STL_PORT_INFO):
+                port_name = port.port_name
+                port_id = port.port_id
+                profile_id = port.profile_id
+
+            is_active = False
+            if profile_id == "*":
+                dup_port.append(port_id)
+                is_active = client.ports[port_id].profile_manager.has_active()
+            else:
+                is_active = client.ports[port_id].profile_manager.is_active(profile_id)
+
+            if not is_active :
+                invalid_ports.append(str(port_name))
+
+        if invalid_ports:
+            self.print_err_msg (invalid_ports, custom_err_msg)
+
     def def_err_msg (self):
         return 'are not active'
 
@@ -87,6 +152,36 @@ class PortStateTX(PortState):
         return [port_id for port_id in client.get_all_ports() if client.ports[port_id].is_active()]
 
 class PortStatePaused(PortState):
+    def validate (self, client, cmd_name, ports, custom_err_msg = None):
+        invalid_ports = []
+        dup_port = []
+
+        for port in ports:
+            port_name = port
+            port_id = port
+            profile_id = "_"
+
+            if port_id in dup_port:
+                print_err_msg(ports, "Cannot use * with other profile_ids")
+
+            if isinstance(port, STL_PORT_INFO):
+                port_name = port.port_name
+                port_id = port.port_id
+                profile_id = port.profile_id
+
+            is_paused = False
+            if profile_id == "*":
+                dup_port.append(port_id)
+                is_paused = client.ports[port_id].profile_manager.has_paused()
+            else:
+                is_paused = client.ports[port_id].profile_manager.is_paused(profile_id)
+
+            if not is_paused :
+                invalid_ports.append(str(port_name))
+
+        if invalid_ports:
+            self.print_err_msg (invalid_ports, custom_err_msg)
+
     def def_err_msg (self):
         return 'are not paused'
 
@@ -159,7 +254,7 @@ class PortStateValidator(object):
         '''
         
         # listify
-        ports = listify_if_int(ports)
+        ports = listify(ports)
 
         if not isinstance(ports, (set, list, tuple)):
             raise TRexTypeError('ports', type(ports), list)

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_psv.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_psv.py
@@ -83,18 +83,22 @@ class PortStateIdle(PortState):
             port_id = port
             profile_id = "_"
 
-            if port_id in dup_port:
-                print_err_msg(ports, "Cannot use * with other profile_ids")
-
             if isinstance(port, STL_PORT_INFO):
                 port_name = port.port_name
                 port_id = port.port_id
                 profile_id = port.profile_id
 
+            if port_id in dup_port:
+                self.print_err_msg(ports, "Cannot use * with other profile_ids")
+
             is_idle = False
             if profile_id == "*":
                 dup_port.append(port_id)
                 profile_state_list = client.ports[port_id].profile_manager.get_all_profiles()
+
+                if not profile_state_list:
+                    is_idle = True
+
                 for pid in profile_state_list:
                     if not client.ports[port_id].profile_manager.is_active(pid):
                         is_idle = True
@@ -114,6 +118,7 @@ class PortStateIdle(PortState):
     def get_valid_ports (self, client):
         return [port_id for port_id in client.get_all_ports() if not client.ports[port_id].is_active()]
 
+
 class PortStateTX(PortState):
     def validate (self, client, cmd_name, ports, custom_err_msg = None):
         invalid_ports = []
@@ -124,13 +129,13 @@ class PortStateTX(PortState):
             port_id = port
             profile_id = "_"
 
-            if port_id in dup_port:
-                print_err_msg(ports, "Cannot use * with other profile_ids")
-
             if isinstance(port, STL_PORT_INFO):
                 port_name = port.port_name
                 port_id = port.port_id
                 profile_id = port.profile_id
+
+            if port_id in dup_port:
+                self.print_err_msg(ports, "Cannot use * with other profile_ids")
 
             is_active = False
             if profile_id == "*":
@@ -161,13 +166,13 @@ class PortStatePaused(PortState):
             port_id = port
             profile_id = "_"
 
-            if port_id in dup_port:
-                print_err_msg(ports, "Cannot use * with other profile_ids")
-
             if isinstance(port, STL_PORT_INFO):
                 port_name = port.port_name
                 port_id = port.port_id
                 profile_id = port.profile_id
+
+            if port_id in dup_port:
+                self.print_err_msg(ports, "Cannot use * with other profile_ids")
 
             is_paused = False
             if profile_id == "*":

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_types.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_types.py
@@ -17,6 +17,15 @@ except NameError:
 __all__ = ["RC", "RC_OK", "RC_ERR", "RC_WARN", "listify", "listify_if_int", "validate_type", "is_integer", "basestring", "LRU_cache"]
 
 
+
+class STL_PORT_INFO:
+    #Full name
+    port_name = ""
+    #Physical port
+    port_id = 0
+    #Logical profile
+    profile_id = ""
+
 class RpcResponseStatus(namedtuple('RpcResponseStatus', ['success', 'id', 'msg'])):
         __slots__ = ()
         def __str__(self):

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
@@ -28,13 +28,13 @@ class STLProfileManager(object):
         self.stream_list = {}
         self.state_list = {}
 
-    def add_profile_stream (self, stream_id, profile_id = "_", state = STATE_STREAMS):
+    def set_stream_id (self, stream_id, profile_id = "_", state = STATE_STREAMS):
         self.stream_list.setdefault(profile_id, [])
         self.stream_list[profile_id].append(stream_id)
         self.state_list.setdefault(profile_id, state)
         return self.stream_list.get(profile_id)
 
-    def update_profile_state (self, state, profile_id = "_"):
+    def set_state (self, state, profile_id = "_"):
         if state:
             if profile_id == "*":
                 for key in self.stream_list.keys():
@@ -56,33 +56,29 @@ class STLProfileManager(object):
         elif stream_ids:
             del self.stream_list[profile_id]
             del self.state_list[profile_id]
+        #no profile_id found
         else:
             stream_ids = []
 
         return stream_ids
 
+    def delete_stream (self, stream_id, profile_id = "_"):
+        if self.stream_list.get(profile_id):
+            self.stream_list[profile_id].remove(stream_id)
+
+        #if empty, make it idle
+        if not self.stream_list.get(profile_id):
+            del self.stream_list[profile_id]
+            del self.state_list[profile_id]
+
     def get_all_profiles(self):
         return self.state_list.keys()
 
-    def get_profiles (self, state = None):
-        profile_list = []
-        for profile_id, profile_state in self.state_list.items():
-            if profile_state == state:
-                profile_list.append(profile_id)
-        #returns list of profiles with the state
-        return profile_list
-
-    def get_all_profile_streams (self):
+    def get_all_streams (self):
         return self.stream_list.values()
 
-    def get_profile_streams (self, profile_id = "_"):
+    def get_stream_ids (self, profile_id = "_"):
         return self.stream_list.get(profile_id)
-
-    def get_profile_state_list (self):
-        return self.state_list
-
-    def get_all_profile_state (self):
-        return self.state_list.values()
 
     def get_profile_state (self, profile_id = "_"):
         return self.state_list.get(profile_id)
@@ -100,6 +96,13 @@ class STLProfileManager(object):
             return self.STATE_IDLE
         else:
             raise Exception("port {0}: bad state received from server".format(self.port_id))
+
+    def get_profiles_from_state (self, state):
+        result = []
+        for pid, pstate in self.state_list.items():
+            if pstate == state:
+                result.append(pid)
+        return result
 
     def has_state(self, state):
         if not self.state_list and state == self.STATE_IDLE:

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
@@ -43,8 +43,7 @@ class STLProfileManager(object):
                  for key in profile_id:
                      self.state_list[key] = state
             else:
-                if self.state_list.get(profile_id):
-                    self.state_list[profile_id] = state
+                 self.state_list[profile_id] = state
         #return None if not found
         return self.state_list
 

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
@@ -1,0 +1,116 @@
+from collections import OrderedDict, defaultdict
+from ..common.trex_types import listify
+from .trex_stl_streams import STLStream
+
+class STLProfileManager(object):
+    (STATE_IDLE,
+    STATE_STREAMS,
+    STATE_TX,
+    STATE_PAUSE,
+    STATE_PCAP_TX,
+    STATE_ASTF_LOADED,
+    STATE_ASTF_PARSE,
+    STATE_ASTF_BUILD,
+    STATE_ASTF_CLEANUP) = range(9)
+
+    STATES_MAP = {STATE_IDLE:         'IDLE',
+                  STATE_STREAMS:      'IDLE',
+                  STATE_TX:           'TRANSMITTING',
+                  STATE_PAUSE:        'PAUSE',
+                  STATE_PCAP_TX :     'TRANSMITTING',
+                  STATE_ASTF_LOADED:  'LOADED',
+                  STATE_ASTF_PARSE:   'PARSING',
+                  STATE_ASTF_BUILD:   'BUILDING',
+                  STATE_ASTF_CLEANUP: 'CLEANUP'}
+
+    def __init__ (self, port_id):
+        self.port_id = port_id
+        self.stream_list = {}
+        self.state_list = {}
+
+    def add_profile_stream (self, stream_id, profile_id = "_", state = STATE_STREAMS):
+        self.stream_list.setdefault(profile_id, [])
+        self.stream_list[profile_id].append(stream_id)
+        self.state_list.setdefault(profile_id, state)
+        return self.stream_list.get(profile_id)
+
+    def update_profile_state (self, state, profile_id = "_"):
+        if state:
+            if profile_id == "*":
+                for key in self.stream_list.keys():
+                    self.state_list[key] = state
+            elif type(profile_id) == list:
+                 for key in profile_id:
+                     self.state_list[key] = state
+            else:
+                if self.state_list.get(profile_id):
+                    self.state_list[profile_id] = state
+        #return None if not found
+        return self.state_list
+
+    def delete_profile (self, profile_id = "_"):
+        stream_ids = self.stream_list.get(profile_id)
+        if profile_id == "*":
+            stream_ids = self.stream_list.keys()
+            self.stream_list.clear()
+            self.state_list.clear()
+        elif stream_ids:
+            del self.stream_list[profile_id]
+            del self.state_list[profile_id]
+        else:
+            stream_ids = []
+
+        return stream_ids
+
+    def get_all_profiles(self):
+        return self.state_list.keys()
+
+    def get_profiles (self, state = None):
+        profile_list = []
+        for profile_id, profile_state in self.state_list.items():
+            if profile_state == state:
+                profile_list.append(profile_id)
+        #returns list of profiles with the state
+        return profile_list
+
+    def get_all_profile_streams (self):
+        return self.stream_list.values()
+
+    def get_profile_streams (self, profile_id = "_"):
+        return self.stream_list.get(profile_id)
+
+    def get_profile_state_list (self):
+        return self.state_list
+
+    def get_all_profile_state (self):
+        return self.state_list.values()
+
+    def get_profile_state (self, profile_id = "_"):
+        return self.state_list.get(profile_id)
+
+    def has_active (self):
+        result = False
+        for profile_id in self.state_list.keys():
+            if self.is_active(profile_id):
+                result = True
+        return result
+
+    def has_paused (self):
+        result = False
+        for profile_id in self.state_list.keys():
+            if self.is_paused(profile_id):
+                result = True
+        return result
+
+    def is_active (self, profile_id = "_"):
+        profile_state = self.get_profile_state(profile_id)
+        if profile_state == None:
+            return False
+        return (profile_state == self.STATE_TX ) or (profile_state == self.STATE_PAUSE) or (profile_state == self.STATE_PCAP_TX)
+
+    def is_paused (self, profile_id = "_"):
+        profile_state = self.get_profile_state(profile_id)
+        if profile_state == None:
+            return False
+        return (profile_state == self.STATE_PAUSE)
+

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_profile_manager.py
@@ -88,6 +88,25 @@ class STLProfileManager(object):
     def get_profile_state (self, profile_id = "_"):
         return self.state_list.get(profile_id)
 
+    def get_port_state (self):
+        if self.has_state(self.STATE_PCAP_TX):
+            return self.STATE_PCAP_TX
+        elif self.has_state(self.STATE_TX):
+            return self.STATE_TX
+        elif self.has_state(self.STATE_PAUSE):
+            return self.STATE_PAUSE
+        elif self.has_state(self.STATE_STREAMS):
+            return self.STATE_STREAMS
+        elif self.has_state(self.STATE_IDLE):
+            return self.STATE_IDLE
+        else:
+            raise Exception("port {0}: bad state received from server".format(self.port_id))
+
+    def has_state(self, state):
+        if not self.state_list and state == self.STATE_IDLE:
+            return True
+        return state in self.state_list.values()
+
     def has_active (self):
         result = False
         for profile_id in self.state_list.keys():

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
@@ -49,12 +49,13 @@ def parse_physical_port_ids (ports):
                 port_name = str(port)
                 port_id = int(port)
 
-            port_name_list.append(port_name)
+            if port_name not in port_name_list:
+                port_name_list.append(port_name)
+            else:
+                raise TRexError('Duplicate port(s) are not allowed')
+
             if port_id not in port_id_list:
                 port_id_list.append(port_id)
-
-        if has_dup(port_name_list):
-            raise TRexError('duplicate port(s) are not allowed')
 
     except ValueError:
         raise TRexTypeError('Wrong value for the port parameter', type(ports))
@@ -77,7 +78,7 @@ def parse_logical_port_ids (ports):
             if port_name not in port_name_list:
                 port_name_list.append(port_name)
             else:
-                raise TRexError('duplicate port(s) are not allowed')
+                raise TRexError('Duplicate port(s) are not allowed')
 
     except ValueError:
         raise TRexTypeError('Wrong value for the port parameter', type(ports))

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
@@ -33,6 +33,17 @@ def user_input():
         # using python version 2
         return raw_input()
 
+def parse_all_profiles_from_port_ids (ports):
+    all_profiles_list = []
+    port_id_list = parse_physical_port_ids(ports)
+    for port_id in port_id_list:
+        port = STL_PORT_INFO()
+        port.port_name = str(port_id) + ".*"
+        port.port_id = int(port_id)
+        port.profile_id = str("*")
+        all_profiles_list.append(port)
+    return all_profiles_list
+
 def parse_physical_port_ids (ports):
     port_list = listify(ports)
     port_name_list = []
@@ -73,7 +84,7 @@ def parse_logical_port_ids (ports):
             if isinstance(port, STL_PORT_INFO):
                 port_name = port.port_name
             else:
-                port_name = str(port) + "._"
+                port_name = str(port)
 
             if port_name not in port_name_list:
                 port_name_list.append(port_name)
@@ -88,7 +99,7 @@ def parse_logical_port_ids (ports):
 def parse_a_dual_port (port):
     slave_port = None
     if isinstance(port, STL_PORT_INFO):
-        slave_port = STL_PORT_INFO
+        slave_port = STL_PORT_INFO()
         slave_port.port_id = port.port_id ^ 0x1
         slave_port.profile_id = port.profile_id
         slave_port.port_name = str(slave_port.port_id) + "." + str(slave_port.profile_id)

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
@@ -9,7 +9,7 @@ import cProfile, pstats
 
 from scapy.utils import *
 from scapy.utils6 import *
-from ..common.trex_types import validate_type
+from ..common.trex_types import listify, validate_type, STL_PORT_INFO
 
 try:
     import pwd
@@ -32,6 +32,85 @@ def user_input():
     else:
         # using python version 2
         return raw_input()
+
+def parse_physical_port_ids (ports):
+    port_list = listify(ports)
+    port_name_list = []
+    port_id_list = []
+
+    try:
+        for port in port_list :
+            port_name = ""
+            port_id = 0
+            if isinstance(port, STL_PORT_INFO):
+                port_name = port.port_name
+                port_id = port.port_id
+            else:
+                port_name = str(port)
+                port_id = int(port)
+
+            port_name_list.append(port_name)
+            if port_id not in port_id_list:
+                port_id_list.append(port_id)
+
+        if has_dup(port_name_list):
+            raise TRexError('duplicate port(s) are not allowed')
+
+    except ValueError:
+        raise TRexTypeError('Wrong value for the port parameter', type(ports))
+
+    return port_id_list
+
+def parse_logical_port_ids (ports):
+    port_list = listify(ports)
+    port_name_list = []
+
+    try:
+        for port in port_list :
+            port_name = ""
+            port_id = 0
+            if isinstance(port, STL_PORT_INFO):
+                port_name = port.port_name
+            else:
+                port_name = str(port) + "._"
+
+            if port_name not in port_name_list:
+                port_name_list.append(port_name)
+            else:
+                raise TRexError('duplicate port(s) are not allowed')
+
+    except ValueError:
+        raise TRexTypeError('Wrong value for the port parameter', type(ports))
+
+    return port_name_list
+
+def parse_a_dual_port (port):
+    slave_port = None
+    if isinstance(port, STL_PORT_INFO):
+        slave_port = STL_PORT_INFO
+        slave_port.port_id = port.port_id ^ 0x1
+        slave_port.profile_id = port.profile_id
+        slave_port.port_name = str(slave_port.port_id) + "." + str(slave_port.profile_id)
+    else:
+        slave_port = port ^ 0x1
+    return slave_port
+
+def parse_dual_ports (ports):
+    port_list = listify(ports)
+    slave_port_list = []
+
+    try:
+        for port in port_list :
+            slave_port = parse_a_dual_port(port)
+            if slave_port not in slave_port_list:
+                slave_port_list.append(slave_port)
+            else:
+                raise TRexError('duplicate port(s) are not allowed')
+
+    except ValueError:
+        raise TRexTypeError('Wrong value for the port parameter', type(ports))
+
+    return slave_port_list
 
 
 class random_id_gen:

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -69,6 +69,7 @@ match_multiplier_help = """Multiplier should be passed in the following format:
 logical_ports_help = """A list of ports on which to apply the command.
                         Logical port concept supports multiple profiles dynamically on the same port.
                         Logical port expression is used as <physical port number>.<logical port name>.
+                        Default logical port name is \"_\" when not specified.
                      """
 
 # decodes multiplier

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -5,6 +5,7 @@ from .text_opts import format_text
 
 from ..common.trex_vlan import VLAN
 from ..common.trex_types import *
+from ..common.trex_types import STL_PORT_INFO
 from ..common.trex_exceptions import TRexError, TRexConsoleNoAction, TRexConsoleError
 from ..common.trex_psv import PSV_ACQUIRED
 
@@ -320,6 +321,23 @@ def decode_tunables (tunable_str):
 
     return tunables
 
+def decode_port (port_str):
+    port_info = port_str.split(".")
+    port_result = None
+
+    if len(port_info) == 1 :
+        port_result =  int(port_str)
+    elif len(port_info) == 2 :
+#        port_result = [str(port_str), int(port_info[0]), str(port_info[1])]
+        port_result = STL_PORT_INFO()
+        port_result.port_name = str(port_str)
+        port_result.port_id = int(port_info[0])
+        port_result.profile_id = str(port_info[1])
+    else:
+        raise argparse.ArgumentTypeError("Wrong port value %s" % port_str)
+
+    return port_result
+
 class OPTIONS_DB_ARGS:
     MULTIPLIER = ArgumentPack(
         ['-m', '--multiplier'],
@@ -524,7 +542,7 @@ class OPTIONS_DB_ARGS:
          'dest':'ports',
          'metavar': 'PORTS',
          'action': 'merge',
-         'type': int,
+         'type': decode_port,
          'help': "A list of ports on which to apply the command",
          'default': []})
 
@@ -534,13 +552,13 @@ class OPTIONS_DB_ARGS:
          'dest':'ports_no_default',
          'metavar': 'PORTS',
          'action': 'merge',
-         'type': int,
+         'type': decode_port,
          'help': "A list of ports on which to apply the command"})
 
     SINGLE_PORT = ArgumentPack(
         ['-p', '--port'],
         {'dest':'ports',
-         'type': int,
+         'type': decode_port,
          'metavar': 'PORT',
          'help': 'source port for the action',
          'required': True})
@@ -1131,6 +1149,7 @@ class CCmdArgParser(argparse.ArgumentParser):
         return hasattr(opts, "all_ports") or hasattr(opts, "ports")
 
     def parse_args(self, args=None, namespace=None, default_ports=None, verify_acquired=False, allow_empty=True):
+
         try:
             opts = super(CCmdArgParser, self).parse_args(args, namespace)
             if opts is None:
@@ -1153,10 +1172,13 @@ class CCmdArgParser(argparse.ArgumentParser):
             
             # validate the ports state
             if verify_acquired:
-                self.client.psv.validate(self.cmd_name, opts.ports, PSV_ACQUIRED, allow_empty = allow_empty)
+                #JH : Ignored for now
+                #self.client.psv.validate(self.cmd_name, opts.ports, PSV_ACQUIRED, allow_empty = allow_empty)
+                pass
             else:
-                self.client.psv.validate(self.cmd_name, opts.ports, allow_empty = allow_empty)
-
+                #JH : Ignored for now
+                #self.client.psv.validate(self.cmd_name, opts.ports, allow_empty = allow_empty)
+                pass
             return opts
 
         except ValueError as e:

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -328,7 +328,6 @@ def decode_port (port_str):
     if len(port_info) == 1 :
         port_result =  int(port_str)
     elif len(port_info) == 2 :
-#        port_result = [str(port_str), int(port_info[0]), str(port_info[1])]
         port_result = STL_PORT_INFO()
         port_result.port_name = str(port_str)
         port_result.port_id = int(port_info[0])
@@ -1172,13 +1171,9 @@ class CCmdArgParser(argparse.ArgumentParser):
             
             # validate the ports state
             if verify_acquired:
-                #JH : Ignored for now
-                #self.client.psv.validate(self.cmd_name, opts.ports, PSV_ACQUIRED, allow_empty = allow_empty)
-                pass
+                self.client.psv.validate(self.cmd_name, opts.ports, PSV_ACQUIRED, allow_empty = allow_empty)
             else:
-                #JH : Ignored for now
-                #self.client.psv.validate(self.cmd_name, opts.ports, allow_empty = allow_empty)
-                pass
+                self.client.psv.validate(self.cmd_name, opts.ports, allow_empty = allow_empty)
             return opts
 
         except ValueError as e:

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -66,6 +66,10 @@ match_multiplier_help = """Multiplier should be passed in the following format:
 
                           """
 
+logical_ports_help = """A list of ports on which to apply the command.
+                        Logical port concept supports multiple profiles dynamically on the same port.
+                        Logical port expression is used as <physical port number>.<logical port name>.
+                     """
 
 # decodes multiplier
 # if allow_update - no +/- is allowed
@@ -539,27 +543,27 @@ class OPTIONS_DB_ARGS:
         ['-p', '--port'],
         {"nargs": '+',
          'dest':'ports',
-         'metavar': 'PORTS',
+         'metavar': 'PORT[.PROFILE]',
          'action': 'merge',
          'type': decode_port,
-         'help': "A list of ports on which to apply the command",
+         'help': logical_ports_help,
          'default': []})
 
     PORT_LIST_NO_DEFAULT = ArgumentPack(
         ['-p', '--port'],
         {"nargs": '+',
          'dest':'ports_no_default',
-         'metavar': 'PORTS',
+         'metavar': 'PORT[.PROFILE]',
          'action': 'merge',
          'type': decode_port,
-         'help': "A list of ports on which to apply the command"})
+         'help': logical_ports_help})
 
     SINGLE_PORT = ArgumentPack(
         ['-p', '--port'],
         {'dest':'ports',
          'type': decode_port,
-         'metavar': 'PORT',
-         'help': 'source port for the action',
+         'metavar': 'PORT[.PROFILE]',
+         'help': logical_ports_help,
          'required': True})
 
     PING_IP = ArgumentPack(


### PR DESCRIPTION
https://github.com/cisco-system-traffic-generator/trex-core/issues/181

Hello. Cisco team
@Cyborn-Minjae-Lee @egwakim @ejangle @JaeyongYu @jsmoon @JunsubHan4rmEricsson @taewoonyun @yonghwan007 @youngjun1
I have implemented the client side of trex-core regarding issue #181 

Here is the description of the files modified

trex_types.py
	- STL_PORT_INFO class has been added to track logical port information "port_id"."profile_id" (ex, 0.logical_0, 0.logical_1, 1.logical_2)
	
parsing_opts.py
	- port parameter can be either int or STL_PORT_INFO instance

trex_client.py
	- _for_each_port has been modified to be used for each logical port instead of physical (ex, 0.logical_0, 0.logical_1, 1.logical_2)

trex_stl_client.py
	- Console APIs	**Ones that allow logical port functionality
		- push_line
		- start_line
		- stop_line
		- update_line
		- pause_line
		- resume_line
	- Client APIs	**Ones that allow logical port functionality
		- remove_all_streams
		- add_streams
		- start
		- stop
		- udpate
		- update_streams
		- pause
		- pause_streams
		- resume
		- resume_streams
		- push_remote
		- push_pcap
	
trex_stl_port.py
	- STL Port APIs	**Ones that allow logical port functionality
		- paused_streams
		- resume_streams
		- update_streams
		- add_streams
		- remove_all_streams
		- start
		- stop
		- pause
		- resume
		- update
		- push_remote
		- sync (get_port_status)
		- sync_streams (get_all_streams)
		
trex_stl_profile_manager.py
	- STLProfileManager
		- Used in STLPort to manage logical port state and streams

trex_psv.py
	- port validation of IDLE/TX/PAUSED has been modified for logical port as well
	
common.py
	**Commonly used functions in new imeplementations
	- parse_phyiscal_port_ids
		- Return physical ports ids from the list of any port list
	- parse_logical_port_ids
		- Return logical ports names in string from the list of any port list
	- parse_a_dual_port
		- Return a dual port from any port
	- parse_dual_ports
		- Return a list of dual port  from any port list

I'm still working on code refinement and testing.
Therefore, please feel free to provide feedback and let me know which part could be improved.