### PR TITLE
dp_core supports per profile operation

### DIFF
--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -3065,6 +3065,7 @@ inline bool CNodeGenerator::handle_stl_node(CGenNode * node,
             /* count before handle - node might be destroyed */
             #ifdef TREX_SIM
             uint8_t port_id = node_sl->get_port_id();
+            uint32_t profile_id = node_sl->get_profile_id();
             update_stl_stats(node_sl);
             #endif
 
@@ -3073,7 +3074,7 @@ inline bool CNodeGenerator::handle_stl_node(CGenNode * node,
 
             #ifdef TREX_SIM
             if (has_limit_reached()) {
-                ((TrexStatelessDpCore *)thread->m_dp_core)->stop_traffic(port_id, false, 0);
+                ((TrexStatelessDpCore *)thread->m_dp_core)->stop_traffic(port_id, profile_id, false, 0);
             }
             #endif
         }

--- a/src/stx/stl/trex_stl_dp_core.h
+++ b/src/stx/stl/trex_stl_dp_core.h
@@ -71,13 +71,13 @@ public:
 
     void create(CFlowGenListPerThread   *  core);
 
-    bool pause_traffic(uint8_t port_id);
+    bool pause_traffic(uint8_t port_id, uint32_t profile_id);
     bool pause_streams(uint8_t port_id, stream_ids_t &stream_ids); // filter by stream IDs, slower
 
-    bool resume_traffic(uint8_t port_id);
+    bool resume_traffic(uint8_t port_id, uint32_t profile_id);
     bool resume_streams(uint8_t port_id, stream_ids_t &stream_ids); // filter by stream IDs, slower
 
-    bool update_traffic(uint8_t port_id, double factor);
+    bool update_traffic(uint8_t port_id, uint32_t profile_id, double factor);
     bool update_streams(uint8_t port_id, stream_ipgs_map_t &ipg_per_stream); // filter by stream IDs, slower
 
     bool push_pcap(uint8_t port_id,
@@ -89,6 +89,7 @@ public:
                    bool is_dual);
 
     bool stop_traffic(uint8_t port_id,
+                      uint32_t profile_id,
                       bool stop_on_id, 
                       int event_id);
 
@@ -115,6 +116,7 @@ public:
     state_e                     m_state;
 
     uint32_t                    m_active_streams; /* how many active streams on this port  */
+    uint32_t                    m_paused_streams; /* how many paused streams on this port  */
                                                 
     std::vector<CDpOneStream>   m_active_nodes;   /* holds the current active nodes */
     CGenNodePCAP*               m_active_pcap_node;
@@ -155,13 +157,13 @@ public:
 
 
     /* pause the streams, work only if all are continues  */
-    void pause_traffic(uint8_t port_id);
+    void pause_traffic(uint8_t port_id, uint32_t profile_id);
     void pause_streams(uint8_t port_id, stream_ids_t &stream_ids);
 
 
     void set_need_to_rx(bool enable);
 
-    void resume_traffic(uint8_t port_id);
+    void resume_traffic(uint8_t port_id, uint32_t profile_id);
     void resume_streams(uint8_t port_id, stream_ids_t &stream_ids);
 
 
@@ -186,7 +188,7 @@ public:
      * @author imarom (25-Nov-15)
      * 
      */
-    void update_traffic(uint8_t port_id, double factor);
+    void update_traffic(uint8_t port_id, uint32_t profile_id, double factor);
     void update_streams(uint8_t port_id, stream_ipgs_map_t &ipg_per_stream);
 
     /**
@@ -194,8 +196,7 @@ public:
      * stop all traffic for this core
      * 
      */
-    void stop_traffic(uint8_t port_id,bool stop_on_id, int event_id);
-
+    void stop_traffic(uint8_t port_id, uint32_t profile_id, bool stop_on_id, int event_id);
 
     /* return if all ports are idle */
     bool are_all_ports_idle();

--- a/src/stx/stl/trex_stl_messaging.cpp
+++ b/src/stx/stl/trex_stl_messaging.cpp
@@ -82,7 +82,7 @@ TrexStatelessDpStop::handle(TrexDpCore *dp_core) {
 
     TrexStatelessDpCore *stl_core = dynamic_cast<TrexStatelessDpCore *>(dp_core);
     
-    stl_core->stop_traffic(m_port_id,m_stop_only_for_event_id,m_event_id);
+    stl_core->stop_traffic(m_port_id, m_profile_id, m_stop_only_for_event_id, m_event_id);
     return true;
 }
 
@@ -97,7 +97,7 @@ void TrexStatelessDpStop::on_node_remove(){
 
 TrexCpToDpMsgBase * TrexStatelessDpPause::clone(){
 
-    TrexStatelessDpPause *new_msg = new TrexStatelessDpPause(m_port_id);
+    TrexStatelessDpPause *new_msg = new TrexStatelessDpPause(m_port_id, m_profile_id);
     return new_msg;
 }
 
@@ -106,7 +106,7 @@ bool TrexStatelessDpPause::handle(TrexDpCore *dp_core){
     
     TrexStatelessDpCore *stl_core = dynamic_cast<TrexStatelessDpCore *>(dp_core);
     
-    stl_core->pause_traffic(m_port_id);
+    stl_core->pause_traffic(m_port_id, m_profile_id);
     return (true);
 }
 
@@ -127,7 +127,7 @@ bool TrexStatelessDpPauseStreams::handle(TrexDpCore *dp_core){
 
 
 TrexCpToDpMsgBase * TrexStatelessDpResume::clone(){
-    TrexStatelessDpResume *new_msg = new TrexStatelessDpResume(m_port_id);
+    TrexStatelessDpResume *new_msg = new TrexStatelessDpResume(m_port_id, m_profile_id);
     return new_msg;
 }
 
@@ -135,7 +135,7 @@ bool TrexStatelessDpResume::handle(TrexDpCore *dp_core){
 
     TrexStatelessDpCore *stl_core = dynamic_cast<TrexStatelessDpCore *>(dp_core);
     
-    stl_core->resume_traffic(m_port_id);
+    stl_core->resume_traffic(m_port_id, m_profile_id);
     return (true);
 }
 
@@ -160,7 +160,7 @@ bool TrexStatelessDpResumeStreams::handle(TrexDpCore *dp_core){
  */
 TrexCpToDpMsgBase *
 TrexStatelessDpStop::clone() {
-    TrexStatelessDpStop *new_msg = new TrexStatelessDpStop(m_port_id);
+    TrexStatelessDpStop *new_msg = new TrexStatelessDpStop(m_port_id, m_profile_id);
 
     new_msg->set_event_id(m_event_id);
     new_msg->set_wait_for_event_id(m_stop_only_for_event_id);
@@ -179,14 +179,14 @@ TrexStatelessDpUpdate::handle(TrexDpCore *dp_core) {
     
     TrexStatelessDpCore *stl_core = dynamic_cast<TrexStatelessDpCore *>(dp_core);
     
-    stl_core->update_traffic(m_port_id, m_factor);
+    stl_core->update_traffic(m_port_id, m_profile_id, m_factor);
 
     return true;
 }
 
 TrexCpToDpMsgBase *
 TrexStatelessDpUpdate::clone() {
-    TrexCpToDpMsgBase *new_msg = new TrexStatelessDpUpdate(m_port_id, m_factor);
+    TrexCpToDpMsgBase *new_msg = new TrexStatelessDpUpdate(m_port_id, m_profile_id, m_factor);
 
     return new_msg;
 }

--- a/src/stx/stl/trex_stl_messaging.h
+++ b/src/stx/stl/trex_stl_messaging.h
@@ -61,7 +61,10 @@ private:
 class TrexStatelessDpPause : public TrexCpToDpMsgBase {
 public:
 
-    TrexStatelessDpPause(uint8_t port_id) : m_port_id(port_id) {
+    TrexStatelessDpPause(uint8_t port_id, uint32_t profile_id) : m_port_id(port_id), m_profile_id(profile_id) {
+    }
+
+    TrexStatelessDpPause(uint8_t port_id) : TrexStatelessDpPause(port_id, 0) {
     }
 
 
@@ -73,6 +76,7 @@ public:
 
 private:
     uint8_t m_port_id;
+    uint32_t m_profile_id;
 };
 
 class TrexStatelessDpPauseStreams : public TrexCpToDpMsgBase {
@@ -98,7 +102,10 @@ private:
 class TrexStatelessDpResume : public TrexCpToDpMsgBase {
 public:
 
-    TrexStatelessDpResume(uint8_t port_id) : m_port_id(port_id) {
+    TrexStatelessDpResume(uint8_t port_id, uint32_t profile_id) : m_port_id(port_id), m_profile_id(profile_id) {
+    }
+
+    TrexStatelessDpResume(uint8_t port_id) : TrexStatelessDpResume(port_id, 0) {
     }
 
 
@@ -110,6 +117,7 @@ public:
 
 private:
     uint8_t m_port_id;
+    uint32_t m_profile_id;
 };
 
 class TrexStatelessDpResumeStreams : public TrexCpToDpMsgBase {
@@ -139,10 +147,13 @@ private:
 class TrexStatelessDpStop : public TrexCpToDpMsgBase {
 public:
 
-    TrexStatelessDpStop(uint8_t port_id) : m_port_id(port_id) {
+    TrexStatelessDpStop(uint8_t port_id, uint32_t profile_id) : m_port_id(port_id), m_profile_id(profile_id) {
         m_stop_only_for_event_id=false;
         m_event_id = 0;
         m_core = NULL;
+    }
+
+    TrexStatelessDpStop(uint8_t port_id) : TrexStatelessDpStop(port_id, 0) {
     }
 
     virtual TrexCpToDpMsgBase * clone();
@@ -180,6 +191,7 @@ public:
 
 private:
     uint8_t                   m_port_id;
+    uint32_t                  m_profile_id;
     bool                      m_stop_only_for_event_id;
     int                       m_event_id;
     CFlowGenListPerThread   * m_core ;
@@ -194,9 +206,13 @@ private:
 class TrexStatelessDpUpdate : public TrexCpToDpMsgBase {
 public:
 
-    TrexStatelessDpUpdate(uint8_t port_id, double factor)  {
+    TrexStatelessDpUpdate(uint8_t port_id, uint32_t profile_id, double factor)  {
         m_port_id = port_id;
+        m_profile_id = profile_id;
         m_factor  = factor;
+    }
+
+    TrexStatelessDpUpdate(uint8_t port_id, double factor): TrexStatelessDpUpdate(port_id, 0, factor) {
     }
 
     virtual bool handle(TrexDpCore *dp_core);
@@ -205,6 +221,7 @@ public:
 
 private:
     uint8_t  m_port_id;
+    uint32_t m_profile_id;
     double   m_factor;
 };
 

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -133,13 +133,14 @@ private:
     uint16_t             m_cache_size;   /*RO*/ /* the size of the mbuf array */
     uint8_t              m_batch_size;   /*RO*/ /* the batch size */
     uint8_t              m_port_id;
+    uint32_t             m_profile_id;
 
     uint16_t             m_pad5; 
 
     /* End Fast Field VM Section */
 
     /* pad to match the size of CGenNode */
-    uint8_t             m_pad_end[12];
+    uint8_t             m_pad_end[8];
 
     /* CACHE_LINE */
     uint64_t            m_pad3[8];
@@ -151,6 +152,9 @@ public:
         return (m_port_id);
     }
 
+    uint32_t            get_profile_id() {
+        return (m_profile_id);
+    }
 
     /**
      * calculate the time offset based 
@@ -618,7 +622,7 @@ public:
                             
         } else {
             TrexStatelessDpCore *stl_dp_core = (TrexStatelessDpCore *)thread->get_dp_core();
-            stl_dp_core->stop_traffic(get_port_id(), false, 0);
+            stl_dp_core->stop_traffic(get_port_id(), 0, false, 0);
         }
     }
 

--- a/src/stx/stl/trex_stl_streams_compiler.cpp
+++ b/src/stx/stl/trex_stl_streams_compiler.cpp
@@ -146,8 +146,9 @@ private:
 /**************************************
  * stream compiled object
  *************************************/
-TrexStreamsCompiledObj::TrexStreamsCompiledObj(uint8_t port_id) {
+TrexStreamsCompiledObj::TrexStreamsCompiledObj(uint8_t port_id, uint32_t profile_id) {
     m_port_id = port_id;
+    m_profile_id = profile_id;
     m_all_continues = false;
 }
 
@@ -173,7 +174,7 @@ TrexStreamsCompiledObj::add_compiled_stream(TrexStream *stream){
 TrexStreamsCompiledObj *
 TrexStreamsCompiledObj::clone() {
 
-    TrexStreamsCompiledObj *new_compiled_obj = new TrexStreamsCompiledObj(m_port_id);
+    TrexStreamsCompiledObj *new_compiled_obj = new TrexStreamsCompiledObj(m_port_id, m_profile_id);
 
     /**
      * clone each element

--- a/src/stx/stl/trex_stl_streams_compiler.h
+++ b/src/stx/stl/trex_stl_streams_compiler.h
@@ -108,7 +108,9 @@ class TrexStreamsCompiledObj {
 
 public:
 
-    TrexStreamsCompiledObj(uint8_t port_id);
+    TrexStreamsCompiledObj(uint8_t port_id, uint32_t profile_id);
+    TrexStreamsCompiledObj(uint8_t port_id) : TrexStreamsCompiledObj(port_id, 0) {
+    }
     ~TrexStreamsCompiledObj();
 
     struct obj_st {
@@ -121,6 +123,10 @@ public:
 
     uint8_t get_port_id(){
         return (m_port_id);
+    }
+
+    uint8_t get_profile_id(){
+        return (m_profile_id);
     }
 
     bool get_all_streams_continues(){
@@ -155,6 +161,7 @@ private:
 
     bool    m_all_continues;
     uint8_t m_port_id;
+    uint8_t m_profile_id;
 };
 
 class TrexStreamsCompiler {


### PR DESCRIPTION
I've implemented code for per profile operation supporting in DP side.

Change summary:
- CP to DP messages should carry profile_id. (default value is 0 which means all, the same as legacy operation)
- TrexStreamsCompiledObj contains profile_id instead of TrexStatelessDpStart.
- added m_paused_streams to make TrexStatelessDpPerPort state reasonable during per profile operation. (one of streams is active, the state would be TrexStatelessDpPerPort::ppSTATE_TRANSMITTING)
- added compatible constructors which have 0 value profile_id to reduce code changes in CP side. (After CP side changes to use profile_id, it can be removed)

I've tested simple unit tests (bp-sim-64 --ut and run_regression --func) and passed with this changes.
