### PR TITLE
Enable Scapy server for ASTF

### DIFF
--- a/scripts/dpdk_setup_ports.py
+++ b/scripts/dpdk_setup_ports.py
@@ -710,7 +710,7 @@ Other network devices
 
 
     def run_scapy_server(self):
-        if not pa() or pa().no_scapy_server or not pa().interactive or pa().astf:
+        if not pa() or pa().no_scapy_server or not pa().interactive or (not pa().scapy_server and pa().astf):
             return
         try:
             master_core = self.m_cfg_dict[0]['platform']['master_thread_id']
@@ -1301,6 +1301,7 @@ def parse_parent_cfg (parent_cfg):
     parent_parser.add_argument('--dump-interfaces', nargs='*', default=None)
     parent_parser.add_argument('--no-ofed-check', action = 'store_true')
     parent_parser.add_argument('--no-scapy-server', action = 'store_true')
+    parent_parser.add_argument('--scapy-server', action = 'store_true')
     parent_parser.add_argument('--no-watchdog', action = 'store_true')
     parent_parser.add_argument('--astf', action = 'store_true')
     parent_parser.add_argument('--limit-ports', type = int)

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -195,6 +195,7 @@ enum {
        OPT_ARP_REF_PER,
        OPT_NO_OFED_CHECK,
        OPT_NO_SCAPY_SERVER,
+       OPT_SCAPY_SERVER,
        OPT_ACTIVE_FLOW,
        OPT_RT,
        OPT_TCP_MODE,
@@ -286,6 +287,7 @@ static CSimpleOpt::SOption parser_options[] =
         { OPT_ARP_REF_PER,            "--arp-refresh-period", SO_REQ_SEP },
         { OPT_NO_OFED_CHECK,          "--no-ofed-check",   SO_NONE    },
         { OPT_NO_SCAPY_SERVER,        "--no-scapy-server", SO_NONE    },
+        { OPT_SCAPY_SERVER,           "--scapy-server", SO_NONE    },
         { OPT_RT,                     "--rt",              SO_NONE    },
         { OPT_TCP_MODE,               "--astf",            SO_NONE},
         { OPT_ASTF_EMUL_DEBUG,        "--astf-emul-debug",  SO_NONE},
@@ -366,6 +368,7 @@ static int __attribute__((cold)) usage() {
     printf(" --no-key                   : Daemon mode, don't get input from keyboard \n");
     printf(" --no-ofed-check            : Disable the check of OFED version \n");
     printf(" --no-scapy-server          : Disable Scapy server implicit start at stateless \n");
+    printf(" --scapy-server             : Enable Scapy server implicit start at ASTF \n");
     printf(" --no-termio                : Do not use TERMIO. useful when using GDB and ctrl+c is needed. \n");
     printf(" --no-watchdog              : Disable watchdog \n");
     printf(" --rt                       : Run TRex DP/RX cores in realtime priority \n");
@@ -879,6 +882,8 @@ static int parse_options(int argc, char *argv[], bool first_time ) {
             case OPT_NO_OFED_CHECK:
                 break;
             case OPT_NO_SCAPY_SERVER:
+                break;
+            case OPT_SCAPY_SERVER:
                 break;
             case OPT_QUEUE_DROP:
                 CGlobalInfo::m_options.m_is_queuefull_retry = false;


### PR DESCRIPTION
Hi guys!

In our app, we use Scapy server for parsing/editing PCAP files from GUI. It would be really helpful if TRex could start in ASTF mode with Scapy server.

Thank you!