### PR TITLE
[Client Implementation] Dynamic streams add/delete at run-time #181 #198

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -22,6 +22,7 @@ from .trex_conn import Connection
 from .trex_ns import NSCmds,NSCmd,NSCmdResult
 from .trex_logger import ScreenLogger
 from .trex_types import *
+from .trex_types import PortProfileID
 from .trex_exceptions import *
 from .trex_psv import *
 from .trex_vlan import VLAN
@@ -115,6 +116,9 @@ class TRexClient(object):
 
         # port state checker
         self.psv = PortStateValidator(self)
+
+        # server version check for dynamic port addition
+        self.is_dynamic = False
 
 
     def get_mode (self):
@@ -359,9 +363,8 @@ class TRexClient(object):
     def _transmit(self, method_name, params = None):
         return self.conn.rpc.transmit(method_name, params)
 
-
     # execute 'method' for a port list
-    def _for_each_port (self, method, port_id_list = None, *args, **kwargs):
+    def _for_each_port (self, method, port_list = None, *args, **kwargs):
 
         # specific port params
         pargs = {}
@@ -372,14 +375,21 @@ class TRexClient(object):
 
 
         # handle single port case
-        port_id_list = listify_if_int(port_id_list)
+        if port_list is not None:
+            port_list = listify(port_list)
 
         # none means all
-        port_id_list = port_id_list if port_id_list is not None else self.get_all_ports()
+        port_list = port_list if port_list is not None else self.get_all_ports()
         
         rc = RC()
 
-        for port_id in port_id_list:
+        for port in port_list:
+
+            port_id = int(port)
+            profile_id = None
+            if isinstance(port, PortProfileID):
+                profile_id = port.profile_id
+
             # get port specific
             pkwargs = pargs.get(port_id, {})
             if pkwargs:
@@ -387,8 +397,12 @@ class TRexClient(object):
             else:
                 pkwargs = kwargs
 
+            if profile_id:
+                pkwargs.update({'profile_id': profile_id})
+
             func = getattr(self.ports[port_id], method)
             rc.add(func(*args, **pkwargs))
+
 
         return rc
 
@@ -422,6 +436,9 @@ class TRexClient(object):
         rc = self._transmit("get_supported_cmds")
         if not rc:
             return rc
+
+        # server version check for dynamic port addition
+        self.is_dynamic = 'get_profile_list' in rc.data()
 
         self.supported_cmds = sorted(rc.data())
 

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
@@ -153,6 +153,13 @@ class ServerEventsIDs(object):
     EVENT_PORT_ERROR     = 7
     EVENT_PORT_ATTR_CHG  = 8
 
+    EVENT_PROFILE_STARTED       = 10
+    EVENT_PROFILE_STOPPED       = 11
+    EVENT_PROFILE_PAUSED        = 12
+    EVENT_PROFILE_RESUMED       = 13
+    EVENT_PROFILE_FINISHED_TX   = 14
+    EVENT_PROFILE_ERROR         = 17
+
     EVENT_ASTF_STATE_CHG = 50
 
     EVENT_SERVER_STOPPED = 100
@@ -447,6 +454,48 @@ class TRexSubscriber():
             attr    = data['attr']
 
             self.ctx.event_handler.on_event("port attr chg", port_id, attr)
+
+
+        # profile started
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_STARTED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile started", port_id, profile_id)
+
+
+        # profile stopeed
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_STOPPED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile stopped", port_id, profile_id)
+
+
+        # profile paused
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_PAUSED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile paused", port_id, profile_id)
+
+
+        # profile resumed
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_RESUMED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile resumed", port_id, profile_id)
+
+
+        # profile finised tx
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_FINISHED_TX:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile finished tx", port_id, profile_id)
+
+
+        # profile error
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_ERROR:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile error", port_id, profile_id)
 
 
         # ASTF state changed

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_types.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_types.py
@@ -16,6 +16,46 @@ except NameError:
 
 __all__ = ["RC", "RC_OK", "RC_ERR", "RC_WARN", "listify", "listify_if_int", "validate_type", "is_integer", "basestring", "LRU_cache"]
 
+DEFAULT_PROFILE_ID = "_"
+ALL_PROFILE_ID = "*"
+
+# class to represent a profile that belongs to a port
+# used for dynamic port allocation in STL
+class PortProfileID(object):
+    def __init__ (self, port_str):
+        try:
+            port_str = str(port_str)
+            port_info = port_str.split(".")
+            if len(port_info) == 1 :
+                 self.port_id =  int(port_str)
+                 self.profile_id = DEFAULT_PROFILE_ID
+            elif len(port_info) == 2 :
+                 self.port_id = int(port_info[0])
+                 self.profile_id = str(port_info[1])
+                 if not self.profile_id:
+                     self.profile_id = DEFAULT_PROFILE_ID
+            else:
+                 raise TRexTypeError("Wrong profile value %s. Should be in the format PORT[.PROFILE]" % port_str)
+        except ValueError:
+            raise TRexTypeError("Wrong profile value %s. Should be in the format PORT[.PROFILE]" % port_str)
+        self.profile_name = str(self.port_id)  + "." + str(self.profile_id)
+
+    def __index__(self):
+        return self.port_id
+
+    def __int__(self):
+        return self.port_id
+
+    def __repr__(self):
+        return self.profile_name
+
+    def __str__(self):
+        return self.profile_name
+
+    def __eq__(self, other):
+        if not isinstance(other, PortProfileID):
+            return False
+        return (self.port_id, self.profile_id) == (other.port_id, other.profile_id)
 
 class RpcResponseStatus(namedtuple('RpcResponseStatus', ['success', 'id', 'msg'])):
         __slots__ = ()

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
@@ -9,7 +9,7 @@ import cProfile, pstats
 
 from scapy.utils import *
 from scapy.utils6 import *
-from ..common.trex_types import validate_type
+from ..common.trex_types import listify, validate_type
 
 try:
     import pwd
@@ -33,6 +33,20 @@ def user_input():
         # using python version 2
         return raw_input()
 
+def parse_ports_from_profiles(ports):
+    """
+    Parse distinct port ids from profiles
+
+    :parameters:
+        ports : list
+            list of profiles(PortProfileID)
+
+    :return:
+        list of port ids(int)
+    """
+    ports = listify(ports)
+    port_id_list = list(set([int(port) for port in ports]))
+    return port_id_list
 
 class random_id_gen:
     """

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -5,6 +5,7 @@ from .text_opts import format_text
 
 from ..common.trex_vlan import VLAN
 from ..common.trex_types import *
+from ..common.trex_types import PortProfileID
 from ..common.trex_exceptions import TRexError, TRexConsoleNoAction, TRexConsoleError
 from ..common.trex_psv import PSV_ACQUIRED
 
@@ -65,6 +66,11 @@ match_multiplier_help = """Multiplier should be passed in the following format:
 
                           """
 
+dynamic_profile_help = """A list of profiles on which to apply the command.
+                          Multiple profile IDs are allocated dynamically on the same port.
+                          Profile expression is used as <port id>.<profile id>.
+                          Default profile id is \"_\" when not specified.
+                       """
 
 # decodes multiplier
 # if allow_update - no +/- is allowed
@@ -320,6 +326,7 @@ def decode_tunables (tunable_str):
 
     return tunables
 
+
 class OPTIONS_DB_ARGS:
     MULTIPLIER = ArgumentPack(
         ['-m', '--multiplier'],
@@ -517,6 +524,17 @@ class OPTIONS_DB_ARGS:
          'default': {},
          'action': 'merge',
          'type': decode_tunables})
+
+    PROFILE_LIST = ArgumentPack(
+        ['-p', '--port'],
+        {"nargs": '+',
+         'dest':'ports',
+         'metavar': 'PORT[.PROFILE]',
+         'action': 'merge',
+         'type': PortProfileID,
+         'help': dynamic_profile_help,
+         'default': []})
+
 
     PORT_LIST = ArgumentPack(
         ['-p', '--port'],

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -615,6 +615,12 @@ class OPTIONS_DB_ARGS:
          'default': False,
          'help': "Set if you want to stop active ports before appyling command."})
 
+    REMOVE = ArgumentPack(
+        ['--remove'],
+        {"action": "store_true",
+         'default': False,
+         'help': "Set if you want to remove the active profiles after stopping them."})
+
     READONLY = ArgumentPack(
         ['-r'],
         {'action': 'store_true',


### PR DESCRIPTION
Hello.
@Cyborn-Minjae-Lee @egwakim @ejangle @JaeyongYu @jsmoon @JunsubHan4rmEricsson @taewoonyun @yonghwan007 @youngjun1

I have implemented the client side of trex-core regarding issue #181
Here are short descriptions of what changes have been made

**1) trex_client.py**
- _for_each_port has been modified to be used for each profile instead of port

**2) trex_psv.py**
- modified to validate for each profile instead of port

**3) trex_types.py**
- PortProfileID class has been added

**4) trex_stl_client.py**
- Console APIs and Client APIs modified to accept profile instead of port
- New STL command (profiles_line) has been added to provide profile information (let me know what you think)

**5) trex_stl_port.py**
- Modified to send JSON RPC for each profile instead of port

**6) common.py**
- Simple function (parse_ports_from_profiles) added to filter port information from profiles

**7) parsing_opts.py**
- PortProfileID are used for console APIs (start_line, stop_line ...)

Please take a look at it and let me your feedback