### PR TITLE
Client code refined from "Dynamic streams add/delete at run-time #181 #198 #218"

### DIFF
--- a/doc/trex_rpc_server_spec.asciidoc
+++ b/doc/trex_rpc_server_spec.asciidoc
@@ -525,6 +525,7 @@ Example:
 * *Description* - Queries the server for status
 * *Parameters* -
 ** *port_id* ['int'] - port id to query for owner
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile id'] associated with this stream
 * *Result* ['object'] - see below
 
 [source,bash]
@@ -563,6 +564,49 @@ Example:
         "owner": "",
         "speed": 10000,
         "state": "TX"
+    }
+}
+
+'Request':
+
+{
+    "id": "oveilf0n",
+    "jsonrpc": "2.0",
+    "method": "get_port_status",
+    "params": {
+        "api_h": "VGDJwdiY",
+        "port_id": 1,
+        "profile_id": "*"
+    }
+}
+
+'Response':
+
+{
+    "id": "oveilf0n",
+    "jsonrpc": "2.0",
+    "result": {
+        "attr": {
+            "fc": {
+                "mode": 0
+            },
+            "link": {
+                "up": true
+            },
+            "promiscuous": {
+                "enabled": false
+            }
+        },
+        "max_stream_id": 3,
+        "owner": "",
+        "profile_count": 3,
+        "speed": 10000,
+        "state": "TX",
+        "state_profile": {
+            "_" : "TX",
+            "imix" : "STREAMS",
+            "udp1pkt" : "IDLE"
+        }
     }
 }
 
@@ -1144,6 +1188,21 @@ Request example:
 
 == RPC commands STL
 
+In RPC commands, Port ID indicates the port number of interface.
+
+As an optional field, the profile ID allows TRex server to run multiple profiles dynamically on a single port ID.
+The profile ID is used as the identifier of profile on the port.
+
+The string type 'profile_id' anchor:profile_id[]
+
+.String type 'profile_id'
+[options="header",cols="1,3"]
+|=================
+| Expression  | Description
+| "<string>"  | The specified profile id such as "udp1pkt", "imix"
+| "_"         | Underscore means default profile. If profile_id is not specified, it is used as the default between JSON-RPC client and server.
+| "*"         | Asterisk means all profiles in the port
+|=================
 
 === Add Stream
 
@@ -1153,7 +1212,8 @@ Request example:
 * *Description* - Adds a stream to a port
 * *Parameters* 
 ** *handler* ['string'] - unique connection handler
-** *port_id* ['int'] - port id associated with this stream
+** *port_id* ['int'] - port id associated with this profile and stream
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile id'] associated with this stream
 ** *stream_id* ['int'] - stream id associated with the stream object
 ** *stream* - object of type xref:stream_obj['stream']
 * *Result* ['object'] - {}
@@ -1529,7 +1589,7 @@ This could be stream_id different from the stream object which contains the rx_s
 	"api_h": "SPhoCDIV",
         "handler": "37JncCHr",
         "port_id": 1,
-	"stream_id": 502
+        "stream_id": 502,
         "stream": {
             "enabled": true,
             "isg": 4.3,
@@ -1567,6 +1627,55 @@ This could be stream_id different from the stream object which contains the rx_s
     "result": {}
 }
 
+'Request':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "add_stream",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "port_id": 1,
+        "profile_id": "udp1pkt",
+        "stream": {
+            "action_count": 0,
+            "core_id": -1,
+            "enabled": true,
+            "flags": 0,
+            "flow_stats": {
+                "enabled": false
+            },
+            "isg": 0.0,
+            "mode": {
+                "rate": {
+                    "type": "pps",
+                    "value": 1.0
+                },
+                "type": "continuous"
+            },
+            "next_stream_id": -1,
+            "packet": {
+                "binary": "AAAAAQAAAAAAAgAACABFAAAuAAEAAEAROr0QAAABMAAAAQQBAAwAGn9veHh4eHh4eHh4eHh4eHh4eHh4",
+                "meta": ""
+            },
+            "self_start": true,
+            "start_paused": false,
+            "vm": {
+                "instructions": []
+            }
+        },
+        "stream_id": 18
+    }
+}
+
+'Response':
+
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {}
+}
 
 ----
 
@@ -1582,7 +1691,8 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 * *Description* - Removes a stream from a port
 * *Parameters*
 ** *handler* ['string'] - unique connection handler
-** *port_id* ['int'] - port assosicated with the stream.
+** *port_id* ['int'] - port id associated with the profile and stream
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile id'] associated with this stream
 ** *stream_id* ['int'] - stream to remove
 
 * *Result* ['object'] - {}
@@ -1604,6 +1714,28 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     }
 }
 
+'Response':
+
+{
+    "id": 1
+    "jsonrpc": "2.0",
+    "result": {}
+}
+
+'Request':
+
+{
+    "id": 1
+    "jsonrpc": "2.0",
+    "method": "remove_stream",
+    "params": {
+	"api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "port_id": 1,
+        "profile_id": "udp1pkt",
+        "stream_id": 18
+    }
+}
 
 'Response':
 
@@ -1615,6 +1747,49 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 
 ----
 
+=== Get Profile ID List
+* *Name* - 'get_profile_list'
+* *API Class* - 'core'
+* *Valid States* - 'unowned', 'owned', 'active'
+* *Description* - fetch all the associated profiles for a port
+* *Parameters*
+** *handler* ['string'] - unique connection handler
+** *port_id* ['int'] - port id to query for registered profiles
+** *profile_id* ['string'] - xref:profile_id['profile id'] to query for registered profiles
+
+* *Result* ['array'] - array of 'profile_id'
+
+[source,bash]
+----
+
+'Request':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "get_profile_list",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "port_id": 1,
+        "profile_id": "*"
+    }
+}
+
+
+'Response':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "result": [
+        "udp1pkt",
+        "imix"
+    ]
+}
+
+----
+
 === Get Stream ID List
 * *Name* - 'get_stream_list'
 * *API Class* - 'core'
@@ -1622,7 +1797,8 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 * *Description* - fetch all the assoicated streams for a port
 * *Parameters*
 ** *handler* ['string'] - unique connection handler
-** *port_id* ['int'] - port to query for registered streams
+** *port_id* ['int'] - port to query for registered profiles
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] to query for registered streams
 
 * *Result* ['array'] - array of 'stream_id'
 
@@ -1648,11 +1824,38 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     "id": 1,
     "jsonrpc": "2.0",
     "result": [
-        502,
-        18
+        502
     ]
 }
 
+'Request':
+
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "get_stream_list",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "port_id": 1,
+        "profile_id": "*"
+    }
+}
+
+'Response':
+
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+        "_" : [
+            502
+        ],
+        "udp1pkt" : [
+            18
+        ]
+    }
+}
 
 ----
 
@@ -1663,7 +1866,8 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 * *Description* - get a specific stream object
 * *Parameters*
 ** *handler* ['string'] - unique connection handler
-** *port_id* ['int'] - port for the associated stream
+** *port_id* ['int'] - port for the associated profile
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] for the associated stream
 ** *stream_id* ['int'] - the requested stream id
 
 * *Result* ['object'] - object xref:stream_obj['stream']
@@ -1678,9 +1882,10 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     "jsonrpc": "2.0",
     "method": "get_stream",
     "params": {
-	"api_h": "SPhoCDIV",
+        "api_h": "SPhoCDIV",
         "handler": "37JncCHr",
         "port_id": 1,
+        "profile_id": "udp1pkt",
         "stream_id": 7
     }
 }
@@ -1715,6 +1920,136 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 
 ----
 
+=== Get All Streams
+* *Name* - 'get_all_streams'
+* *API Class* - 'core'
+* *Valid States* - 'owned'
+* *Description* - get all streams from a port
+* *Parameters*
+** *port_id* ['int'] - port for the associated profile
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] for the associated stream
+
+* *Result* ['object'] - {}
+
+
+[source,bash]
+----
+
+'Request':
+
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "get_all_streams",
+    "params": {
+	    "api_h": "SPhoCDIV",
+        "port_id": 1,
+    }
+}
+
+'Response':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "result": {
+        "streams": {
+            "502" : {
+                "enabled": true,
+                "isg": 4.3,
+                "mode": {
+                    "pps": 3,
+                    "type": "continuous"
+                },
+                "next_stream_id": -1,
+                "packet": {
+                    "binary": [
+                        4,
+                        1,
+                        255
+                    ],
+                    "meta": ""
+                },
+                "self_start": true
+            }
+        }
+    }
+}
+
+'Request':
+
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "get_all_streams",
+    "params": {
+	    "api_h": "SPhoCDIV",
+        "port_id": 1,
+        "profile_id": "*"
+    }
+}
+
+'Response':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "result": {
+        "profiles": {
+            "_" : {
+                "502" : {
+                    "enabled": true,
+                    "isg": 4.3,
+                    "mode": {
+                        "pps": 3,
+                        "type": "continuous"
+                    },
+                    "next_stream_id": -1,
+                    "packet": {
+                        "binary": [
+                            4,
+                            1,
+                            255
+                        ],
+                        "meta": ""
+                    },
+                    "self_start": true
+                }
+            },
+            "udp1pkt": {
+                "18": {
+                    "action_count": 0,
+                    "core_id": -1,
+                    "enabled": true,
+                    "flags": 0,
+                    "flow_stats": {
+                        "enabled": false
+                    },
+                    "isg": 0.0,
+                    "mode": {
+                        "rate": {
+                            "type": "pps",
+                            "value": 1.0
+                        },
+                        "type": "continuous"
+                    },
+                    "next_stream_id": -1,
+                    "packet": {
+                        "binary": "AAAAAQAAAAAAAgAACABFAAAmAAEAAEAROsUQAAABMAAAAQQBAAwAEmFheHh4eHh4eHh4eA==",
+                        "meta": ""
+                    },
+                    "self_start": true,
+                    "start_paused": false,
+                    "vm": {
+                        "instructions": []
+                    }
+                }
+            }
+        }
+    }
+}
+
+----
 
 === Remove All Streams
 * *Name* - 'remove_all_streams'
@@ -1723,7 +2058,8 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 * *Description* - remove all streams from a port
 * *Parameters*
 ** *handler* ['string'] - unique connection handler
-** *port_id* ['int'] - port for the associated stream
+** *port_id* ['int'] - port for the associated profile
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] for the associated stream
 
 * *Result* ['object'] - {}
 
@@ -1740,7 +2076,8 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     "params": {
 	"api_h": "SPhoCDIV",
         "handler": "37JncCHr",
-        "port_id": 2
+        "port_id": 2,
+        "profile_id": "udp1pkt",
     }
 }
 
@@ -1764,6 +2101,7 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 * *Parameters*
 ** *handler* ['string'] - unique connection handler
 ** *port_id* ['int'] - port id on which to start traffic
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] to start traffic
 ** *core_mask* ['uint64'] [*optional*] - a non zero mask to specify which cores will be active during TX, if no value is provided, the value is all bits on (MAX_UINT64)
 
 * *Result* ['object'] - {}
@@ -1780,9 +2118,10 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     "params": {
         "api_h": "SPhoCDIV",
         "handler": "37JncCHr",
-        "port_id": 3
+        "port_id": 3,
         "core_mask": 0xff
     }
+}
 
 'Response':
 
@@ -1792,6 +2131,39 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     "result": {}
 }
 
+'Request':
+
+{
+    "id": "b3llt8hs",
+    "jsonrpc": "2.0",
+    "method": "start_traffic",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "core_mask": 18446744073709551615,
+        "duration": -1.0,
+        "force": false,
+        "mul": {
+            "op": "abs",
+            "type": "raw",
+            "value": 1.0
+        },
+        "port_id": 1,
+        "profile_id": "udp1pkt",
+        "start_at_ts": 0
+    }
+}
+
+'Response':
+
+{
+    "id": "b3llt8hs",
+    "jsonrpc": "2.0",
+    "result": {
+        "multiplier": 1.0,
+        "ts": 20395.399607074254
+    }
+}
 
 ----
 
@@ -1803,6 +2175,7 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 * *Parameters*
 ** *handler* ['string'] - unique connection handler
 ** *port_id* ['int'] - port id on which to stop traffic
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] to stop traffic
 
 * *Result* ['object'] - {}
 
@@ -1830,9 +2203,166 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     "result": {}
 }
 
+'Request':
+
+{
+    "id": "h2fyhni7",
+    "jsonrpc": "2.0",
+    "method": "stop_traffic",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "port_id": 1,
+        "profile_id": "udp1pkt"
+    }
+}
+
+'Response':
+
+{
+    "id": "h2fyhni7",
+    "jsonrpc": "2.0",
+    "result": {}
+}
 
 ----
 
+=== Update Traffic
+* *Name* - 'update_traffic'
+* *API Class* - 'core'
+* *Valid States* - 'owned'
+* *Description* - Update the traffic on a specific port or profile.
+* *Parameters*
+** *handler* ['string'] - unique connection handler
+** *mul* - object of type xref:mul_obj['mul']
+** *port_id* ['int'] - port id on which to update traffic
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] to update traffic
+
+* *Result* ['object'] - {}
+
+The object type 'mul' anchor:mul_obj[]
+
+.Object type mul
+[options="header",cols="1,1,3"]
+|=================
+| Field           | Type    | Description
+| op              | string  | operation ("abs", "add", "sub")
+| type            | string  | traffic type ("raw", "pps", "bps", "bps_L1", "percentage")
+| value           | double  | value (overrides old one)
+|=================
+
+[source,bash]
+----
+
+'Request':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "update_traffic",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "force": false,
+        "handler": "37JncCHr",
+        "mul": {
+            "op": "abs",
+            "type": "bps",
+            "value": 1000.0
+        },
+        "port_id": 1,
+        "profile_id": "udp1pkt"
+    }
+}
+
+'Response':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "result": {
+        "multiplier": 1.953125
+    }
+}
+
+----
+
+=== Pause Traffic
+* *Name* - 'pause_traffic'
+* *API Class* - 'core'
+* *Valid States* - 'owned'
+* *Description* - Pause the traffic on a specific port or profile.
+* *Parameters*
+** *handler* ['string'] - unique connection handler
+** *port_id* ['int'] - port id on which to pause traffic
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] to pause traffic
+
+* *Result* ['object'] - {}
+
+[source,bash]
+----
+
+'Request':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "pause_traffic",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "port_id": 0,
+        "profile_id": "udp1pkt"
+    }
+}
+
+'Response':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "result": {}
+}
+
+----
+
+=== Resume Traffic
+* *Name* - 'resume_traffic'
+* *API Class* - 'core'
+* *Valid States* - 'owned'
+* *Description* - Resume the traffic on a specific port or profile.
+* *Parameters*
+** *handler* ['string'] - unique connection handler
+** *port_id* ['int'] - port id on which to resume traffic
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] to resume traffic
+
+* *Result* ['object'] - {}
+
+[source,bash]
+----
+
+'Request':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "resume_traffic",
+    "params": {
+        "api_h": "SPhoCDIV",
+        "handler": "37JncCHr",
+        "port_id": 0,
+        "profile_id": "udp1pkt"
+    }
+}
+
+'Response':
+
+{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "result": {}
+}
+
+----
 
 === Remove RX Filters
 * *Name* - 'remove_rx_filters'
@@ -1845,6 +2375,7 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
 * *Parameters*
 ** *handler* ['string'] - unique connection handler
 ** *port_id* ['int'] - port id on which to remove all RX filters
+** *profile_id* ['string'] [*optional*] - xref:profile_id['profile'] to remove all RX filters
 
 * *Result* ['object'] - {}
 
@@ -1860,7 +2391,8 @@ In case rx_stats feature is enabled, rx_object **must include** all rx_stats obj
     "params": {
 	"api_h": "SPhoCDIV",
         "handler": "ywVlqZa8",
-        "port_id": 3
+        "port_id": 3,
+        "profile_id": "udp1pkt"
     }
 }
 

--- a/doc/trex_stateless.asciidoc
+++ b/doc/trex_stateless.asciidoc
@@ -5202,6 +5202,41 @@ For example, one could use following: +
 Prior to updating rate of whole port, need to revert changes made to rates of specific streams.
 =====================================================================
 
+===== dynamic multiple profiles
+
+TRex can support the multiple profiles dynamically on the same port.
+
+In the console, profile ids can be specified via -p argument. +
+The expression in TRex console allows -p <port number>.<profile id> instead of port number. +
+For example, start imix.py profile on port '0.imix' and udp_1pkt.py profile on port '0.udp1pkt'. +
+In this way, 'imix' and 'udp1pkt' traffic can be running simultaneously on port 0.
+
+*Example*::
+
+[source,bash]
+----
+# start(add) dynamic profile on port 0.imix(3 streams are running on IMIX)
+trex> start -f stl/imix.py -p 0.imix
+
+# start(add) dynamic profile on port 0.udp1pkt
+trex> start -f stl/udp_1pkt.py -p 0.udp1pkt
+
+# change packet rate of udp1pkt during run-time
+trex> update -p 0.udp1pkt -m 1gbps
+
+# show all profiles
+trex> profiles
+
+# stop traffic on 0.imix, 0.udp1pkt traffic is still running
+trex> stop -p 0.imix
+
+# stop all traffic on port 0
+trex> stop -p 0.*
+
+# remove the active profiles on port 0
+trex> stop -p 0.* --remove
+----
+
 ===== TUI
 
 The textual user interface (TUI) displays constantly updated TRex statistics in a text window.

--- a/doc/trex_stateless.asciidoc
+++ b/doc/trex_stateless.asciidoc
@@ -5221,20 +5221,81 @@ trex> start -f stl/imix.py -p 0.imix
 # start(add) dynamic profile on port 0.udp1pkt
 trex> start -f stl/udp_1pkt.py -p 0.udp1pkt
 
+# start(add) dynamic profile on port 1.imix(3 streams are running on IMIX)
+trex> start -f stl/imix.py -p 1.imix
+
+# start(add) dynamic profile on port 1.udp1pkt
+trex> start -f stl/udp_1pkt.py -p 1.udp1pkt
+
+# show all streams
+trex> streams
+Port 0:
+
+    ID     |      name       |     profile     |     packet type     |  length  |       mode       |      rate       |    PG ID     |     next     
+-----------+-----------------+-----------------+---------------------+----------+------------------+-----------------+--------------+-------------
+    1      |        -        |      imix       | Ethernet:IP:UDP:Raw |       64 |    Continuous    |     28 pps      |      -       |      -       
+    2      |        -        |      imix       | Ethernet:IP:UDP:Raw |      594 |    Continuous    |     16 pps      |      -       |      -       
+    3      |        -        |      imix       | Ethernet:IP:UDP:Raw |     1518 |    Continuous    |      4 pps      |      -       |      -       
+    4      |        -        |     udp1pkt     | Ethernet:IP:UDP:Raw |       64 |    Continuous    |      1 pps      |      -       |      -       
+
+Port 1:
+
+    ID     |      name       |     profile     |     packet type     |  length  |       mode       |      rate       |    PG ID     |     next     
+-----------+-----------------+-----------------+---------------------+----------+------------------+-----------------+--------------+-------------
+    1      |        -        |      imix       | Ethernet:IP:UDP:Raw |       64 |    Continuous    |     28 pps      |      -       |      -       
+    2      |        -        |      imix       | Ethernet:IP:UDP:Raw |      594 |    Continuous    |     16 pps      |      -       |      -       
+    3      |        -        |      imix       | Ethernet:IP:UDP:Raw |     1518 |    Continuous    |      4 pps      |      -       |      -       
+    4      |        -        |     udp1pkt     | Ethernet:IP:UDP:Raw |       64 |    Continuous    |      1 pps      |      -       |      -       
+
+
 # change packet rate of udp1pkt during run-time
 trex> update -p 0.udp1pkt -m 1gbps
 
+# pause traffic on port 0.udp1pkt (traffic on 0.imix is still running
+trex> pause -p 0.udp1pkt
+
 # show all profiles
 trex> profiles
+Port 0:
 
-# stop traffic on 0.imix, 0.udp1pkt traffic is still running
+  Profile ID    |   state    | stream ID  
+----------------+------------+-----------
+    udp1pkt     |   PAUSE    |    [4]     
+     imix       |     TX     | [1, 2, 3]  
+
+Port 1:
+
+  Profile ID    |   state    | stream ID  
+----------------+------------+-----------
+    udp1pkt     |     TX     |    [4]     
+     imix       |     TX     | [1, 2, 3]  
+
+# resume every paused traffic on port 0 (including 0.udp1pkt)
+trex> resume -p 0.*
+
+Resume traffic on port(s) [0.udp1pkt]:
+[SUCCESS]
+
+# stop traffic on 0.imix (traffic on 0.udp1pkt is still running)
 trex> stop -p 0.imix
 
 # stop all traffic on port 0
 trex> stop -p 0.*
 
-# remove the active profiles on port 0
-trex> stop -p 0.* --remove
+# stop and remove all traffic on port 1
+trex> stop -p 1.* --remove
+
+# show all streams
+trex>streams
+Port 0:
+
+    ID     |      name       |     profile     |     packet type     |  length  |       mode       |      rate       |    PG ID     |     next     
+-----------+-----------------+-----------------+---------------------+----------+------------------+-----------------+--------------+-------------
+    1      |        -        |      imix       | Ethernet:IP:UDP:Raw |       64 |    Continuous    |     28 pps      |      -       |      -       
+    2      |        -        |      imix       | Ethernet:IP:UDP:Raw |      594 |    Continuous    |     16 pps      |      -       |      -       
+    3      |        -        |      imix       | Ethernet:IP:UDP:Raw |     1518 |    Continuous    |      4 pps      |      -       |      -       
+    4      |        -        |     udp1pkt     | Ethernet:IP:UDP:Raw |       64 |    Continuous    |      1 pps      |      -       |      -       
+
 ----
 
 ===== TUI

--- a/scripts/automation/regression/stateless_tests/stl_client_test.py
+++ b/scripts/automation/regression/stateless_tests/stl_client_test.py
@@ -881,3 +881,33 @@ class STLClient_Test(CStlGeneral_Test):
         except STLError as e:
             assert False , '{0}'.format(e)
 
+    def test_latency_pause_resume_dynamic_profile (self):
+
+        port_list = [self.tx_port, self.rx_port]
+        profile_list = ["p1", "p2"]
+        stream_pg_id = 0
+
+        try:    
+            for port in port_list:
+                for profile in profile_list:
+
+                    stream_pg_id = stream_pg_id + 1
+                    s1 = STLStream(name = 'latency',
+                                   packet = self.pkt,
+                                   mode = STLTXCont(percentage = self.percentage),
+                                   flow_stats = STLFlowLatencyStats(pg_id = stream_pg_id))
+
+                    port_profile = str(port)  + "." + str(profile)
+
+                    self.c.add_streams([s1], ports = port_profile)
+                    self.c.clear_stats()
+                    self.c.start(ports = port_profile)
+
+                    for i in range(100):
+                        self.c.pause()
+                        self.c.resume()
+
+                    self.c.stop(ports = port_profile)
+
+        except STLError as e:
+            assert False , '{0}'.format(e)

--- a/scripts/automation/regression/stateless_tests/stl_client_test.py
+++ b/scripts/automation/regression/stateless_tests/stl_client_test.py
@@ -736,7 +736,7 @@ class STLClient_Test(CStlGeneral_Test):
             print("start")
             for i in range(0, 10):
 
-                duration = random.randint(0, 10)
+                duration = random.randint(1, 10)
                 golden_duration = golden * duration
 
                 self.c.clear_stats()
@@ -880,3 +880,4 @@ class STLClient_Test(CStlGeneral_Test):
 
         except STLError as e:
             assert False , '{0}'.format(e)
+

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -22,6 +22,7 @@ from .trex_conn import Connection
 from .trex_ns import NSCmds,NSCmd,NSCmdResult
 from .trex_logger import ScreenLogger
 from .trex_types import *
+from .trex_types import PortProfileID
 from .trex_exceptions import *
 from .trex_psv import *
 from .trex_vlan import VLAN
@@ -115,6 +116,9 @@ class TRexClient(object):
 
         # port state checker
         self.psv = PortStateValidator(self)
+
+        # server version check for dynamic port addition
+        self.is_dynamic = False
 
 
     def get_mode (self):
@@ -359,9 +363,8 @@ class TRexClient(object):
     def _transmit(self, method_name, params = None):
         return self.conn.rpc.transmit(method_name, params)
 
-
     # execute 'method' for a port list
-    def _for_each_port (self, method, port_id_list = None, *args, **kwargs):
+    def _for_each_port (self, method, port_list = None, *args, **kwargs):
 
         # specific port params
         pargs = {}
@@ -372,14 +375,21 @@ class TRexClient(object):
 
 
         # handle single port case
-        port_id_list = listify_if_int(port_id_list)
+        if port_list is not None:
+            port_list = listify(port_list)
 
         # none means all
-        port_id_list = port_id_list if port_id_list is not None else self.get_all_ports()
+        port_list = port_list if port_list is not None else self.get_all_ports()
         
         rc = RC()
 
-        for port_id in port_id_list:
+        for port in port_list:
+
+            port_id = int(port)
+            profile_id = None
+            if isinstance(port, PortProfileID):
+                profile_id = port.profile_id
+
             # get port specific
             pkwargs = pargs.get(port_id, {})
             if pkwargs:
@@ -387,8 +397,12 @@ class TRexClient(object):
             else:
                 pkwargs = kwargs
 
+            if profile_id:
+                pkwargs.update({'profile_id': profile_id})
+
             func = getattr(self.ports[port_id], method)
             rc.add(func(*args, **pkwargs))
+
 
         return rc
 
@@ -422,6 +436,9 @@ class TRexClient(object):
         rc = self._transmit("get_supported_cmds")
         if not rc:
             return rc
+
+        # server version check for dynamic port addition
+        self.is_dynamic = 'get_profile_list' in rc.data()
 
         self.supported_cmds = sorted(rc.data())
 

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
@@ -153,6 +153,13 @@ class ServerEventsIDs(object):
     EVENT_PORT_ERROR     = 7
     EVENT_PORT_ATTR_CHG  = 8
 
+    EVENT_PROFILE_STARTED       = 10
+    EVENT_PROFILE_STOPPED       = 11
+    EVENT_PROFILE_PAUSED        = 12
+    EVENT_PROFILE_RESUMED       = 13
+    EVENT_PROFILE_FINISHED_TX   = 14
+    EVENT_PROFILE_ERROR         = 17
+
     EVENT_ASTF_STATE_CHG = 50
 
     EVENT_SERVER_STOPPED = 100
@@ -447,6 +454,48 @@ class TRexSubscriber():
             attr    = data['attr']
 
             self.ctx.event_handler.on_event("port attr chg", port_id, attr)
+
+
+        # profile started
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_STARTED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile started", port_id, profile_id)
+
+
+        # profile stopeed
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_STOPPED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile stopped", port_id, profile_id)
+
+
+        # profile paused
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_PAUSED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile paused", port_id, profile_id)
+
+
+        # profile resumed
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_RESUMED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile resumed", port_id, profile_id)
+
+
+        # profile finised tx
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_FINISHED_TX:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile finished tx", port_id, profile_id)
+
+
+        # profile error
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_ERROR:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile error", port_id, profile_id)
 
 
         # ASTF state changed

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
@@ -456,11 +456,32 @@ class TRexSubscriber():
             self.ctx.event_handler.on_event("port attr chg", port_id, attr)
 
 
+        # profile started
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_STARTED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile started", port_id, profile_id)
+
+
         # profile stopeed
         elif event_id == ServerEventsIDs.EVENT_PROFILE_STOPPED:
             port_id = int(data['port_id'])
             profile_id = str(data['profile_id'])
             self.ctx.event_handler.on_event("profile stopped", port_id, profile_id)
+
+
+        # profile paused
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_PAUSED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile paused", port_id, profile_id)
+
+
+         # profile resumed
+        elif event_id == ServerEventsIDs.EVENT_PROFILE_RESUMED:
+            port_id = int(data['port_id'])
+            profile_id = str(data['profile_id'])
+            self.ctx.event_handler.on_event("profile resumed", port_id, profile_id)
 
 
         # profile finised tx

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
@@ -456,32 +456,11 @@ class TRexSubscriber():
             self.ctx.event_handler.on_event("port attr chg", port_id, attr)
 
 
-        # profile started
-        elif event_id == ServerEventsIDs.EVENT_PROFILE_STARTED:
-            port_id = int(data['port_id'])
-            profile_id = str(data['profile_id'])
-            self.ctx.event_handler.on_event("profile started", port_id, profile_id)
-
-
         # profile stopeed
         elif event_id == ServerEventsIDs.EVENT_PROFILE_STOPPED:
             port_id = int(data['port_id'])
             profile_id = str(data['profile_id'])
             self.ctx.event_handler.on_event("profile stopped", port_id, profile_id)
-
-
-        # profile paused
-        elif event_id == ServerEventsIDs.EVENT_PROFILE_PAUSED:
-            port_id = int(data['port_id'])
-            profile_id = str(data['profile_id'])
-            self.ctx.event_handler.on_event("profile paused", port_id, profile_id)
-
-
-        # profile resumed
-        elif event_id == ServerEventsIDs.EVENT_PROFILE_RESUMED:
-            port_id = int(data['port_id'])
-            profile_id = str(data['profile_id'])
-            self.ctx.event_handler.on_event("profile resumed", port_id, profile_id)
 
 
         # profile finised tx

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_types.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_types.py
@@ -16,6 +16,46 @@ except NameError:
 
 __all__ = ["RC", "RC_OK", "RC_ERR", "RC_WARN", "listify", "listify_if_int", "validate_type", "is_integer", "basestring", "LRU_cache"]
 
+DEFAULT_PROFILE_ID = "_"
+ALL_PROFILE_ID = "*"
+
+# class to represent a profile that belongs to a port
+# used for dynamic port allocation in STL
+class PortProfileID(object):
+    def __init__ (self, port_str):
+        try:
+            port_str = str(port_str)
+            port_info = port_str.split(".")
+            if len(port_info) == 1 :
+                 self.port_id =  int(port_str)
+                 self.profile_id = DEFAULT_PROFILE_ID
+            elif len(port_info) == 2 :
+                 self.port_id = int(port_info[0])
+                 self.profile_id = str(port_info[1])
+                 if not self.profile_id:
+                     self.profile_id = DEFAULT_PROFILE_ID
+            else:
+                 raise TRexTypeError("Wrong profile value %s. Should be in the format PORT[.PROFILE]" % port_str)
+        except ValueError:
+            raise TRexTypeError("Wrong profile value %s. Should be in the format PORT[.PROFILE]" % port_str)
+        self.profile_name = str(self.port_id)  + "." + str(self.profile_id)
+
+    def __index__(self):
+        return self.port_id
+
+    def __int__(self):
+        return self.port_id
+
+    def __repr__(self):
+        return self.profile_name
+
+    def __str__(self):
+        return self.profile_name
+
+    def __eq__(self, other):
+        if not isinstance(other, PortProfileID):
+            return False
+        return (self.port_id, self.profile_id) == (other.port_id, other.profile_id)
 
 class RpcResponseStatus(namedtuple('RpcResponseStatus', ['success', 'id', 'msg'])):
         __slots__ = ()

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -1991,6 +1991,7 @@ class STLClient(TRexClient):
                 msg = 'no active ports'
             else:
                 msg = 'no active traffic on ports {0}'.format(ports)
+            print(msg)
         else:
             # call API
             self.stop(active_ports)
@@ -2002,6 +2003,7 @@ class STLClient(TRexClient):
                     msg = 'no ports with streams'
                 else:
                     msg = 'no streams on ports {0}'.format(ports)
+                print(msg)
             else:
                 # call API
                 self.remove_all_streams(ports)

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -2,15 +2,18 @@ import time
 import sys
 import os
 from collections import OrderedDict
+from functools import wraps
 
-from ..utils.common import get_current_user, list_intersect, is_sub_list, user_input, list_difference
+from ..utils.common import get_current_user, list_intersect, is_sub_list, user_input, list_difference, parse_ports_from_profiles
 from ..utils import parsing_opts, text_tables
 from ..utils.text_opts import format_text, format_num
 
 from ..common.trex_exceptions import *
+from ..common.trex_events import Event
 from ..common.trex_logger import Logger
 from ..common.trex_client import TRexClient, PacketBuffer
 from ..common.trex_types import *
+from ..common.trex_types import PortProfileID, ALL_PROFILE_ID
 from ..common.trex_psv import *
 from ..common.trex_api_annotators import client_api, console_api
 
@@ -19,6 +22,47 @@ from .trex_stl_streams import STLStream, STLProfile
 from .trex_stl_stats import CPgIdStats
 
 from texttable import ansi_len
+
+def validate_port_input(port_arg):
+    """Decorator to support PortProfileID type input.
+       Convert int,str argument to PortProfileID type
+    """
+    def wrap (func):
+        def wrapper(self, *args, **kwargs):
+            code = func.__code__
+            fname = func.__name__
+            names = code.co_varnames[:code.co_argcount]
+            argname = port_arg
+
+            try:
+                port_index = names.index(argname) - 1
+                argval = args[port_index]
+                args = list(args)
+                args[port_index] = convert_port_to_profile(argval)
+                args = tuple(args)
+            except (ValueError, IndexError):
+                argval = kwargs.get(argname)
+                kwargs[argname] = convert_port_to_profile(argval)
+
+            return func(self, *args, **kwargs)
+
+        def convert_port_to_profile(port):
+            if port is None:
+                return port
+
+            if isinstance(port, list):
+                result = list(port)
+                for idx, val in enumerate(result):
+                    validate_type('port', val, (int, str, PortProfileID))
+                    result[idx] = PortProfileID(str(val))
+            else:
+                validate_type('port', port, (int, str, PortProfileID))
+                result = PortProfileID(str(port))
+
+            return result
+
+        return wrapper
+    return wrap
 
 class STLClient(TRexClient):
 
@@ -75,6 +119,7 @@ class STLClient(TRexClient):
     def get_mode (self):
         return "STL"
 
+
 ############################    called       #############################
 ############################    by base      #############################
 ############################    TRex Client  #############################   
@@ -93,7 +138,7 @@ class STLClient(TRexClient):
         self.ports.clear()
         for info in system_info['ports']:
             port_id = info['index']
-            self.ports[port_id] = STLPort(self.ctx, port_id, self.conn.rpc, info)
+            self.ports[port_id] = STLPort(self.ctx, port_id, self.conn.rpc, info, self.is_dynamic)
         return RC_OK()
 
 
@@ -107,8 +152,47 @@ class STLClient(TRexClient):
         return RC_OK()
 
 
+############################     events     #############################
+############################                #############################
+############################                #############################
 
-############################    private     #############################
+    # register all common events
+    def _register_events (self):
+        super(STLClient, self)._register_events()
+        self.ctx.event_handler.register_event_handler("profile stopped",     self._on_profile_stopped)
+        self.ctx.event_handler.register_event_handler("profile finished tx", self._on_profile_finished_tx)
+        self.ctx.event_handler.register_event_handler("profile error",       self._on_profile_error)
+
+
+    def _on_profile_stopped (self, port_id, profile_id):
+        msg = "Profile {0}.{1} has stopped".format(port_id, profile_id)
+
+        if port_id in self.ports:
+            self.ports[port_id].async_event_profile_stopped(profile_id)
+
+        return Event('server', 'info', msg)
+
+
+    def _on_profile_finished_tx (self, port_id, profile_id):
+        msg = "Profile {0}.{1} job done".format(port_id, profile_id)
+
+        if port_id in self.ports:
+            self.ports[port_id].async_event_profile_job_done(profile_id)
+
+        ev = Event('server', 'info', msg)
+        if port_id in self.get_acquired_ports():
+            self.ctx.logger.info(ev)
+
+        return ev
+
+
+    def _on_profile_error (self, port_id, profile_id):
+        msg = "Profile {0}.{1} job failed".format(port_id, profile_id)
+
+        return Event('server', 'warning', msg)
+
+
+#########################    private/helper     #########################
 ############################    functions   #############################
 ############################                #############################
 
@@ -128,6 +212,41 @@ class STLClient(TRexClient):
         # remove RX filters
         return self._for_each_port('remove_rx_filters', rx_ports)
 
+    # Check console API ports argument
+    def validate_profile_input(self, input_profiles):
+        ports = []
+        result_profiles = []
+        for profile in input_profiles:
+            if profile.profile_id == ALL_PROFILE_ID:
+                if int(profile) not in ports:
+                    ports.append(int(profile))
+                else:
+                    raise TRexError("Cannot have more than on %d.* in the params" %int(profile))
+
+        for pid in ports:
+            for profile in input_profiles:
+                if int(profile) == pid and profile.profile_id != ALL_PROFILE_ID:
+                    raise TRexError("Cannot have %d.* and %s passed together as --ports" %(int(profile), str(profile)))
+
+            port_profiles = self.ports[pid].get_port_profiles("all")
+            result_profiles.extend(port_profiles)
+
+        for profile in input_profiles:
+            if profile.profile_id != ALL_PROFILE_ID:
+                if profile not in result_profiles:
+                    result_profiles.append(profile)
+
+        return result_profiles
+
+    # Get all profiles with the certain state from ports
+    # state = {"active", "transmitting", "paused", "streams"}
+    def get_profiles_with_state(self, state):
+        active_ports = self.get_acquired_ports()
+        active_profiles = []
+        for port in active_ports:
+            port_profiles = self.ports[port].get_port_profiles(state)
+            active_profiles.extend(port_profiles)
+        return active_profiles
 
 ############################    Stateless   #############################
 ############################       API      #############################
@@ -150,8 +269,12 @@ class STLClient(TRexClient):
     
         """
         ports = ports if ports is not None else self.get_all_ports()
-    
         ports = self.psv.validate('reset', ports)
+
+        all_profiles = []
+        for port in ports:
+            profile = PortProfileID(str(port) + ".*")
+            all_profiles.append(profile)
     
         if restart:
             if not all([p.is_link_change_supported() for p in self.ports.values()]):
@@ -166,8 +289,8 @@ class STLClient(TRexClient):
             with self.ctx.logger.suppress():
                 # force take the port and ignore any streams on it
                 self.acquire(ports, force = True, sync_streams = False)
-                self.stop(ports)
-                self.remove_all_streams(ports)
+                self.stop(all_profiles)
+                self.remove_all_streams(all_profiles)
                 self.clear_stats(ports)
                 self.set_port_attr(ports,
                                    promiscuous = False if self.any_port.is_prom_supported() else None,
@@ -261,6 +384,7 @@ class STLClient(TRexClient):
 
 
     @client_api('command', True)
+    @validate_port_input("ports")
     def remove_all_streams (self, ports = None):
         """
             remove all streams from port(s)
@@ -275,9 +399,7 @@ class STLClient(TRexClient):
 
         """
 
-
         ports = ports if ports is not None else self.get_acquired_ports()
-
         # validate ports
         ports = self.psv.validate('remove_all_streams', ports, (PSV_ACQUIRED, PSV_IDLE))
 
@@ -290,6 +412,7 @@ class STLClient(TRexClient):
 
  
     @client_api('command', True)
+    @validate_port_input("ports")
     def add_streams (self, streams, ports = None):
         """
             Add a list of streams to port(s)
@@ -308,11 +431,10 @@ class STLClient(TRexClient):
 
         """
 
-
         ports = ports if ports is not None else self.get_acquired_ports()
 
         # validate ports
-        ports = self.psv.validate('remove_all_streams', ports, (PSV_ACQUIRED, PSV_IDLE))
+        ports = self.psv.validate('add_streams', ports, (PSV_ACQUIRED, PSV_IDLE))
 
         if isinstance(streams, STLProfile):
             streams = streams.get_streams()
@@ -326,6 +448,7 @@ class STLClient(TRexClient):
             raise TRexArgumentError('streams', streams)
 
         self.ctx.logger.pre_cmd("Attaching {0} streams to port(s) {1}:".format(len(streams), ports))
+
         rc = self._for_each_port('add_streams', ports, streams)
         self.ctx.logger.post_cmd(rc)
 
@@ -365,6 +488,7 @@ class STLClient(TRexClient):
 
 
     @client_api('command', True)
+    @validate_port_input("ports")
     def remove_streams (self, stream_id_list, ports = None):
         """
             Remove a list of streams from ports
@@ -396,7 +520,6 @@ class STLClient(TRexClient):
         for i, stream_id in enumerate(stream_id_list):
             validate_type('stream ID:{0}'.format(i), stream_id, int)
             
-        
         ports = ports if ports is not None else self.get_acquired_ports()
         ports = self.psv.validate('remove_streams', ports, (PSV_ACQUIRED, PSV_IDLE))
 
@@ -428,6 +551,13 @@ class STLClient(TRexClient):
 
     # common checks for start API
     def __pre_start_check (self, cmd_name, ports, force, streams_per_port = None):
+        ports = listify(ports)
+        for port in ports:
+            if isinstance(port, PortProfileID):
+                if port.profile_id == ALL_PROFILE_ID:
+                    err = 'Profile id * is invalid for starting the traffic. Please assign a specific profile id'
+                    raise TRexError(err)
+
         if force:
             return self.psv.validate(cmd_name, ports)
 
@@ -477,6 +607,7 @@ class STLClient(TRexClient):
     
                 
     @client_api('command', True)
+    @validate_port_input("ports")
     def start (self,
                ports = None,
                mult = "1",
@@ -528,10 +659,20 @@ class STLClient(TRexClient):
 
         """
 
-        ports = listify(ports if ports is not None else self.get_acquired_ports())
+        if ports is None:
+            ports = []
+            for pid in self.get_acquired_ports():
+                port = PortProfileID(pid)
+                ports.append(port)
+        else:
+            ports = listify(ports)
+
+        port_id_list = parse_ports_from_profiles(ports)
+
         streams_per_port = {}
-        for port in ports:
+        for port in port_id_list:
             streams_per_port[port] = self.ports[port].streams.values()
+
         ports = self.__pre_start_check('START', ports, force, streams_per_port)
 
         validate_type('mult', mult, basestring)
@@ -545,9 +686,8 @@ class STLClient(TRexClient):
         # decode core mask argument
         if core_mask is None:
             core_mask = self.CORE_MASK_SINGLE if synchronized else self.CORE_MASK_SPLIT
-        decoded_mask = self.__decode_core_mask(ports, core_mask)
+        decoded_mask = self.__decode_core_mask(port_id_list, core_mask)
         #######################
-
         # verify multiplier
         mult_obj = parsing_opts.decode_multiplier(mult,
                                                   allow_update = False,
@@ -557,16 +697,21 @@ class STLClient(TRexClient):
 
 
         # stop active ports if needed
-        active_ports = list(set(self.get_active_ports()).intersection(ports))
-        if active_ports and force:
-            self.stop(active_ports)
+        active_profiles = list_intersect(self.get_profiles_with_state("active"), ports)
+        if active_profiles and force:
+            self.stop(active_profiles)
 
         if synchronized:
             # start synchronized (per pair of ports) traffic
             if len(ports) % 2:
                 raise TRexError('Must use even number of ports in synchronized mode')
             for port in ports:
-                if port ^ 1 not in ports:
+                pair_port = int(port) ^ 0x1
+                if isinstance(port, PortProfileID):
+                    pair_port = str(pair_port) + "." + str(port.profile_id)
+                    pair_port = PortProfileID(pair_port)
+
+                if pair_port not in ports:
                     raise TRexError('Must use adjacent ports in synchronized mode. Port "%s" has not pair.' % port)
 
             start_time = time.time()
@@ -594,6 +739,7 @@ class STLClient(TRexClient):
         
 
     @client_api('command', True)
+    @validate_port_input("ports")
     def stop (self, ports = None, rx_delay_ms = None):
         """
             Stop port(s)
@@ -615,12 +761,16 @@ class STLClient(TRexClient):
         """
 
         if ports is None:
-            ports = self.get_active_ports()
+            ports = self.get_profiles_with_state("active")
             if not ports:
                 return
 
         ports = self.psv.validate('STOP', ports, PSV_ACQUIRED)
-        
+        if not ports:
+            return
+
+        port_id_list = parse_ports_from_profiles(ports)
+
         self.ctx.logger.pre_cmd("Stopping traffic on port(s) {0}:".format(ports))
         rc = self._for_each_port('stop', ports)
         self.ctx.logger.post_cmd(rc)
@@ -629,16 +779,15 @@ class STLClient(TRexClient):
             raise TRexError(rc)
 
         if rx_delay_ms is None:
-            if self.ports[ports[0]].is_virtual(): # assume all ports have same type
+            if self.ports[port_id_list[0]].is_virtual(): # assume all ports have same type
                 rx_delay_ms = 100
             else:
                 rx_delay_ms = 10
 
         # remove any RX filters
-        rc = self._remove_rx_filters(ports, rx_delay_ms)
+        rc = self._remove_rx_filters(port_id_list, rx_delay_ms)
         if not rc:
             raise TRexError(rc)
-
 
     @client_api('command', True)
     def wait_on_traffic (self, ports = None, timeout = None, rx_delay_ms = None):
@@ -688,6 +837,7 @@ class STLClient(TRexClient):
 
         
     @client_api('command', True)
+    @validate_port_input("ports")
     def update (self, ports = None, mult = "1", total = False, force = False):
         """
             Update traffic on port(s)
@@ -717,8 +867,7 @@ class STLClient(TRexClient):
 
         """
 
-
-        ports = ports if ports is not None else self.get_active_ports()
+        ports = ports if ports is not None else self.get_profiles_with_state("active")
         ports = self.psv.validate('update', ports, (PSV_ACQUIRED, PSV_TX))
 
         validate_type('mult', mult, basestring)
@@ -743,6 +892,7 @@ class STLClient(TRexClient):
 
 
     @client_api('command', True)
+    @validate_port_input("port")
     def update_streams(self, port, mult = "1", force = False, stream_ids = None):
         """
             | Temporary hack to update specific streams.
@@ -767,8 +917,6 @@ class STLClient(TRexClient):
                 + :exc:`TRexError`
 
         """
-
-        validate_type('port', port, int)
         validate_type('mult', mult, basestring)
         validate_type('force', force, bool)
         validate_type('stream_ids', stream_ids, list)
@@ -783,11 +931,9 @@ class STLClient(TRexClient):
         if not mult_obj:
             raise TRexArgumentError('mult', mult)
 
-
         # call low level functions
         self.ctx.logger.pre_cmd('Updating streams %s on port %s:' % (stream_ids, port))
-
-        rc = self.ports[port].update_streams(mult_obj, force, stream_ids)
+        rc = self._for_each_port("update_streams", port, mult_obj, force, stream_ids)
         self.ctx.logger.post_cmd(rc)
 
         if not rc:
@@ -795,6 +941,7 @@ class STLClient(TRexClient):
 
 
     @client_api('command', True)
+    @validate_port_input("ports")
     def pause (self, ports = None):
         """
             Pause traffic on port(s). Works only for ports that are active, and only if all streams are in Continuous mode.
@@ -807,13 +954,12 @@ class STLClient(TRexClient):
                 + :exc:`TRexError`
 
         """
-
-
-        ports = ports if ports is not None else self.get_transmitting_ports()
+        ports = ports if ports is not None else self.get_profiles_with_state("transmitting")
         ports = self.psv.validate('pause', ports, (PSV_ACQUIRED, PSV_TX))
 
         self.ctx.logger.pre_cmd("Pausing traffic on port(s) {0}:".format(ports))
         rc = self._for_each_port("pause", ports)
+
         self.ctx.logger.post_cmd(rc)
 
         if not rc:
@@ -821,6 +967,7 @@ class STLClient(TRexClient):
 
 
     @client_api('command', True)
+    @validate_port_input("port")
     def pause_streams(self, port, stream_ids):
         """
             Temporary hack to pause specific streams.
@@ -838,16 +985,15 @@ class STLClient(TRexClient):
 
         """
 
-        validate_type('port', port, int)
         validate_type('stream_ids', stream_ids, list)
 
-        ports = self.psv.validate('update_streams', port, (PSV_ACQUIRED, PSV_TX))
+        ports = self.psv.validate('pause_streams', port, (PSV_ACQUIRED, PSV_TX))
 
         if not stream_ids:
             raise TRexError('Please specify stream IDs to pause')
 
         self.ctx.logger.pre_cmd('Pause streams %s on port %s:' % (stream_ids, port))
-        rc = self.ports[port].pause_streams(stream_ids)
+        rc = self._for_each_port("pause_streams", port, stream_ids)
         self.ctx.logger.post_cmd(rc)
 
         if not rc:
@@ -855,6 +1001,7 @@ class STLClient(TRexClient):
 
 
     @client_api('command', True)
+    @validate_port_input("ports")
     def resume (self, ports = None):
         """
             Resume traffic on port(s)
@@ -868,9 +1015,7 @@ class STLClient(TRexClient):
 
         """
 
-
-        ports = ports if ports is not None else self.get_paused_ports()
-
+        ports = ports if ports is not None else self.get_profiles_with_state("paused")
         ports = self.psv.validate('resume', ports, (PSV_ACQUIRED, PSV_PAUSED))
 
         self.ctx.logger.pre_cmd("Resume traffic on port(s) {0}:".format(ports))
@@ -882,6 +1027,7 @@ class STLClient(TRexClient):
 
 
     @client_api('command', True)
+    @validate_port_input("port")
     def resume_streams(self, port, stream_ids):
         """
             Temporary hack to resume specific streams.
@@ -899,7 +1045,6 @@ class STLClient(TRexClient):
 
         """
 
-        validate_type('port', port, int)
         validate_type('stream_ids', stream_ids, list)
 
         ports = self.psv.validate('resume_streams', port, (PSV_ACQUIRED))
@@ -908,7 +1053,7 @@ class STLClient(TRexClient):
             raise TRexError('Please specify stream IDs to resume')
 
         self.ctx.logger.pre_cmd('Resume streams %s on port %s:' % (stream_ids, port))
-        rc = self.ports[port].resume_streams(stream_ids)
+        rc = self._for_each_port("resume_streams", port, stream_ids)
         self.ctx.logger.post_cmd(rc)
 
         if not rc:
@@ -1105,7 +1250,7 @@ class STLClient(TRexClient):
         """
         ports = ports if ports is not None else self.get_acquired_ports()
         ports = self.__pre_start_check('PUSH', ports, force)
-        
+
         validate_type('pcap_filename', pcap_filename, basestring)
         validate_type('ipg_usec', ipg_usec, (float, int, type(None)))
         validate_type('speedup',  speedup, (float, int))
@@ -1547,6 +1692,14 @@ class STLClient(TRexClient):
         else:
             raise TRexError('Unhandled stats: %s' % opts.stats)
 
+    def _get_profiles(self, port_id_list):
+        profiles_per_port = OrderedDict()
+        for port_id in port_id_list:
+            data = self.ports[port_id].generate_loaded_profiles()
+            if data:
+                profiles_per_port[port_id] = data
+        return profiles_per_port
+
     def _get_streams(self, port_id_list, streams_mask, table_format):
         streams_per_port = OrderedDict()
         for port_id in port_id_list:
@@ -1554,6 +1707,28 @@ class STLClient(TRexClient):
             if data:
                 streams_per_port[port_id] = data
         return streams_per_port
+
+    @console_api('profiles', 'STL', True, True)
+    def profiles_line(self, line):
+        '''Get loaded to server profiles information'''
+        parser = parsing_opts.gen_parser(self,
+                                         "profiles",
+                                         self.profiles_line.__doc__,
+                                         parsing_opts.PORT_LIST_WITH_ALL)
+
+        opts = parser.parse_args(line.split())
+        if not opts:
+            return opts
+
+        profiles_per_port = self._get_profiles(opts.ports)
+
+        if not profiles_per_port:
+            self.logger.info(format_text("No profiles found with desired filter.\n", "bold", "magenta"))
+
+        for port_id, port_profiles_table in profiles_per_port.items():
+            if port_profiles_table:
+                text_tables.print_table_with_header(port_profiles_table,
+                                                    header = 'Port %s:' % port_id)
 
     @console_api('streams', 'STL', True, True)
     def streams_line(self, line):
@@ -1700,7 +1875,7 @@ class STLClient(TRexClient):
         
         return True
 
-    
+
     @console_api('start', 'STL', True)
     def start_line (self, line):
         '''Start selected traffic on specified ports on TRex\n'''
@@ -1708,7 +1883,7 @@ class STLClient(TRexClient):
         parser = parsing_opts.gen_parser(self,
                                          "start",
                                          self.start_line.__doc__,
-                                         parsing_opts.PORT_LIST_WITH_ALL,
+                                         parsing_opts.PROFILE_LIST,
                                          parsing_opts.TOTAL,
                                          parsing_opts.FORCE,
                                          parsing_opts.FILE_PATH,
@@ -1721,6 +1896,14 @@ class STLClient(TRexClient):
 
         opts = parser.parse_args(line.split(), default_ports = self.get_acquired_ports(), verify_acquired = True)
 
+        ports = []
+        for port in opts.ports:
+            if not isinstance(port, PortProfileID):
+                port = PortProfileID(port)
+            ports.append(port)
+
+        port_id_list = parse_ports_from_profiles(ports)
+
         # core mask
         if opts.core_mask is not None:
             core_mask =  opts.core_mask
@@ -1728,41 +1911,56 @@ class STLClient(TRexClient):
             core_mask = self.CORE_MASK_PIN if opts.pin_cores else self.CORE_MASK_SPLIT
 
         # just for sanity - will be checked on the API as well
-        self.__decode_core_mask(opts.ports, core_mask)
+        self.__decode_core_mask(port_id_list, core_mask)
 
+        # process tunables
+        if type(opts.tunables) is dict:
+            tunables = opts.tunables
+        else:
+            tunables = {}
+
+        streams_per_profile = {}
         streams_per_port = {}
         # pack the profile
         try:
-            for port in opts.ports:
+            for profile in ports:
+                profile_name = str(profile)
+                port_id = int(profile)
                 profile = STLProfile.load(opts.file[0],
-                                          direction = opts.tunables.get('direction', port % 2),
-                                          port_id = port,
-                                          **opts.tunables)
-                streams_per_port[port] = profile.get_streams()
+                                          direction = tunables.get('direction', port_id % 2),
+                                          port_id = port_id,
+                                          **tunables)
+                stream_list = profile.get_streams()
+                streams_per_profile[profile_name] = stream_list
+                if port_id not in streams_per_port:
+                    streams_per_port[port_id] = list(stream_list)
+                else:
+                    streams_per_port[port_id].extend(list(stream_list))
         except TRexError as e:
             s = format_text("\nError loading profile '{0}'\n".format(opts.file[0]), 'bold')
             s += "\n" + e.brief()
             raise TRexError(s)
 
         # for better use experience - check this before any other action on port
-        self.__pre_start_check('START', opts.ports, opts.force, streams_per_port)
+        self.__pre_start_check('START', ports, opts.force, streams_per_port)
+        ports = self.validate_profile_input(ports)
 
         # stop ports if needed
-        active_ports = list_intersect(self.get_active_ports(), opts.ports)
-        if active_ports and opts.force:
-            self.stop(active_ports)
+        active_profiles = list_intersect(self.get_profiles_with_state("active"), ports)
+        if active_profiles and opts.force:
+            self.stop(active_profiles)
 
         # remove all streams
-        self.remove_all_streams(opts.ports)
+        self.remove_all_streams(ports)
 
-        for port in opts.ports:
-            self.add_streams(streams_per_port[port], ports = port)
+        for profile in ports:
+            profile_name = str(profile)
+            self.add_streams(streams_per_profile[profile_name], ports = profile)
 
         if opts.dry:
-            self.validate(opts.ports, opts.mult, opts.duration, opts.total)
+            self.validate(ports, opts.mult, opts.duration, opts.total)
         else:
-
-            self.start(opts.ports,
+            self.start(ports,
                        opts.mult,
                        opts.force,
                        opts.duration,
@@ -1779,22 +1977,34 @@ class STLClient(TRexClient):
         parser = parsing_opts.gen_parser(self,
                                          "stop",
                                          self.stop_line.__doc__,
-                                         parsing_opts.PORT_LIST_WITH_ALL)
+                                         parsing_opts.PROFILE_LIST,
+                                         parsing_opts.REMOVE)
 
-        opts = parser.parse_args(line.split(), default_ports = self.get_active_ports(), verify_acquired = True, allow_empty = True)
+        opts = parser.parse_args(line.split(), default_ports = self.get_profiles_with_state("active"), verify_acquired = True, allow_empty = True)
+        ports = self.validate_profile_input(opts.ports)
 
         # find the relevant ports
-        ports = list_intersect(opts.ports, self.get_active_ports())
-        if not ports:
-            if not opts.ports:
+        port_id_list = parse_ports_from_profiles(ports)
+        active_ports = list_intersect(ports, self.get_profiles_with_state("active"))
+        if not active_ports:
+            if not ports:
                 msg = 'no active ports'
             else:
-                msg = 'no active traffic on ports {0}'.format(opts.ports)
+                msg = 'no active traffic on ports {0}'.format(ports)
+        else:
+            # call API
+            self.stop(active_ports)
 
-            raise TRexError(msg)
-
-        # call API
-        self.stop(ports)
+        if opts.remove:
+            streams_ports = list_intersect(ports, self.get_profiles_with_state("streams"))
+            if not streams_ports:
+                if not ports:
+                    msg = 'no ports with streams'
+                else:
+                    msg = 'no streams on ports {0}'.format(ports)
+            else:
+                # call API
+                self.remove_all_streams(ports)
 
         return True
 
@@ -1805,32 +2015,33 @@ class STLClient(TRexClient):
         parser = parsing_opts.gen_parser(self,
                                          "update",
                                          self.update_line.__doc__,
-                                         parsing_opts.PORT_LIST_WITH_ALL,
+                                         parsing_opts.PROFILE_LIST,
                                          parsing_opts.MULTIPLIER,
                                          parsing_opts.TOTAL,
                                          parsing_opts.FORCE,
                                          parsing_opts.STREAMS_MASK)
 
-        opts = parser.parse_args(line.split(), default_ports = self.get_active_ports(), verify_acquired = True)
+        opts = parser.parse_args(line.split(), default_ports = self.get_profiles_with_state("active"), verify_acquired = True)
+        ports = self.validate_profile_input(opts.ports)
 
         if opts.ids:
-            if len(opts.ports) != 1:
-                raise TRexError('must provide exactly one port when specifying stream_ids, got: %s' % opts.ports)
+            if len(ports) != 1:
+                raise TRexError('must provide exactly one port when specifying stream_ids, got: %s' % ports)
 
-            self.update_streams(opts.ports[0], opts.mult, opts.force, opts.ids)
+            self.update_streams(ports[0], opts.mult, opts.force, opts.ids)
             return True
 
         # find the relevant ports
-        ports = list_intersect(opts.ports, self.get_active_ports())
-        if not ports:
-            if not opts.ports:
+        profiles = list_intersect(ports, self.get_profiles_with_state("active"))
+        if not profiles:
+            if not ports:
                 msg = 'no active ports'
             else:
-                msg = 'no active traffic on ports {0}'.format(opts.ports)
+                msg = 'no active traffic on ports {0}'.format(ports)
 
             raise TRexError(msg)
 
-        self.update(ports, opts.mult, opts.total, opts.force)
+        self.update(profiles, opts.mult, opts.total, opts.force)
 
         return True
 
@@ -1841,34 +2052,35 @@ class STLClient(TRexClient):
         parser = parsing_opts.gen_parser(self,
                                          "pause",
                                          self.pause_line.__doc__,
-                                         parsing_opts.PORT_LIST_WITH_ALL,
+                                         parsing_opts.PROFILE_LIST,
                                          parsing_opts.STREAMS_MASK)
 
-        opts = parser.parse_args(line.split(), default_ports = self.get_transmitting_ports(), verify_acquired = True)
+        opts = parser.parse_args(line.split(), default_ports = self.get_profiles_with_state("transmitting"), verify_acquired = True)
+        ports = self.validate_profile_input(opts.ports)
 
         if opts.ids:
-            if len(opts.ports) != 1:
-                raise TRexError('pause - must provide exactly one port when specifying stream_ids, got: %s' % opts.ports)
+            if len(ports) != 1:
+                raise TRexError('pause - must provide exactly one port when specifying stream_ids, got: %s' % ports)
 
-            self.pause_streams(opts.ports[0], opts.ids)
+            self.pause_streams(ports[0], opts.ids)
 
             return True
 
         # check for already paused case
-        if opts.ports and is_sub_list(opts.ports, self.get_paused_ports()):
-            raise TRexError('all of port(s) {0} are already paused'.format(opts.ports))
+        if ports and is_sub_list(ports, self.get_profiles_with_state("paused")):
+            raise TRexError('all of ports(s) {0} are already paused'.format(ports))
 
         # find the relevant ports
-        ports = list_intersect(opts.ports, self.get_transmitting_ports())
-        if not ports:
-            if not opts.ports:
+        profiles = list_intersect(ports, self.get_profiles_with_state("transmitting"))
+        if not profiles:
+            if not ports:
                 msg = 'no transmitting ports'
             else:
-                msg = 'none of ports {0} are transmitting'.format(opts.ports)
+                msg = 'none of ports {0} are transmitting'.format(ports)
 
             raise TRexError(msg)
 
-        self.pause(ports)
+        self.pause(profiles)
 
         return True
 
@@ -1879,30 +2091,31 @@ class STLClient(TRexClient):
         parser = parsing_opts.gen_parser(self,
                                          "resume",
                                          self.resume_line.__doc__,
-                                         parsing_opts.PORT_LIST_WITH_ALL,
+                                         parsing_opts.PROFILE_LIST,
                                          parsing_opts.STREAMS_MASK)
 
-        opts = parser.parse_args(line.split(), default_ports = self.get_paused_ports(), verify_acquired = True)
+        opts = parser.parse_args(line.split(), default_ports = self.get_profiles_with_state("paused"), verify_acquired = True)
+        ports = self.validate_profile_input(opts.ports)
 
         if opts.ids:
-            if len(opts.ports) != 1:
-                raise TRexError('must provide exactly one port when specifying stream_ids, got: %s' % opts.ports)
+            if len(ports) != 1:
+                raise TRexError('must provide exactly one port when specifying stream_ids, got: %s' % ports)
 
-            self.resume_streams(opts.ports[0], opts.ids)
+            self.resume_streams(ports[0], opts.ids)
             return True
 
         # find the relevant ports
-        ports = list_intersect(opts.ports, self.get_paused_ports())
-        if not ports:
-            if not opts.ports:
+        profiles = list_intersect(ports, self.get_profiles_with_state("paused"))
+        if not profiles:
+            if not ports:
                 msg = 'no paused ports'
             else:
-                msg = 'none of ports {0} are paused'.format(opts.ports)
+                msg = 'none of ports {0} are paused'.format(ports)
 
             raise TRexError(msg)
 
 
-        self.resume(ports)
+        self.resume(profiles)
 
         # true means print time
         return True

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -159,9 +159,20 @@ class STLClient(TRexClient):
     # register all common events
     def _register_events (self):
         super(STLClient, self)._register_events()
+        self.ctx.event_handler.register_event_handler("profile started",     self._on_profile_started)
         self.ctx.event_handler.register_event_handler("profile stopped",     self._on_profile_stopped)
+        self.ctx.event_handler.register_event_handler("profile paused",      self._on_profile_paused)
+        self.ctx.event_handler.register_event_handler("profile resumed",      self._on_profile_resumed)
         self.ctx.event_handler.register_event_handler("profile finished tx", self._on_profile_finished_tx)
         self.ctx.event_handler.register_event_handler("profile error",       self._on_profile_error)
+
+
+    def _on_profile_started (self, port_id, profile_id):
+        msg = "Profile {0}.{1} has started".format(port_id, profile_id)
+        if port_id in self.ports:
+            self.ports[port_id].async_event_profile_started(profile_id)
+
+        return Event('server', 'info', msg)
 
 
     def _on_profile_stopped (self, port_id, profile_id):
@@ -169,6 +180,22 @@ class STLClient(TRexClient):
 
         if port_id in self.ports:
             self.ports[port_id].async_event_profile_stopped(profile_id)
+
+        return Event('server', 'info', msg)
+
+
+    def _on_profile_paused (self, port_id, profile_id):
+        msg = "Profile {0}.{1} has paused".format(port_id, profile_id)
+        if port_id in self.ports:
+            self.ports[port_id].async_event_profile_paused(profile_id)
+
+        return Event('server', 'info', msg)
+
+
+    def _on_profile_resumed (self, port_id, profile_id):
+        msg = "Profile {0}.{1} has resumed".format(port_id, profile_id)
+        if port_id in self.ports:
+            self.ports[port_id].async_event_profile_resumed(profile_id)
 
         return Event('server', 'info', msg)
 

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -207,7 +207,8 @@ class STLPort(Port):
 
     def sync(self):
         params = {"port_id": self.port_id,
-                  "profile_id": ALL_PROFILE_ID}
+                  "profile_id": ALL_PROFILE_ID,'block': False}
+
 
         rc = self.transmit("get_port_status", params)
         if rc.bad():

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -41,7 +41,7 @@ class STLPort(Port):
         self.is_dynamic = dynamic
         self.profile_stream_list = {}
         self.profile_state_list = {}
-
+        self.__is_sync = False
 
 ############################   dynamic profile   #############################
 ############################   helper functions  #############################
@@ -233,6 +233,9 @@ class STLPort(Port):
 
         self.__is_sync = True
         return self.ok()
+
+    def is_sync(self):
+        return self.__is_sync
 
     # sync all the streams with the server
     def sync_streams (self):

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -929,15 +929,19 @@ class STLPort(Port):
 
 
     @writeable
-    def remove_rx_filters (self):
+    def remove_rx_filters (self, profile_id = DEFAULT_PROFILE_ID):
         assert(self.has_rx_enabled())
 
         if self.state == self.STATE_IDLE:
             return self.ok()
 
+        profile_state = self.profile_state_list.get(profile_id)
+        if not profile_state:
+            return self.ok()
 
         params = {"handler": self.handler,
-                  "port_id": self.port_id}
+                  "port_id": self.port_id,
+                  "profile_id":  profile_id}
 
         rc = self.transmit("remove_rx_filters", params)
         if rc.bad():

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -5,11 +5,10 @@ from ..utils.common import list_difference, list_intersect
 from ..utils.text_opts import limit_string
 from ..utils import text_tables
 
-from ..common.trex_types import listify, RpcCmdData, RC, RC_OK
+from ..common.trex_types import listify, RpcCmdData, RC, RC_OK, PortProfileID, DEFAULT_PROFILE_ID, ALL_PROFILE_ID
 from ..common.trex_port import Port, owned, writeable, up
 
 from .trex_stl_streams import STLStream
-
 
 ########## utlity ############
 def mult_to_factor (mult, max_bps_l2, max_pps, line_util):
@@ -31,7 +30,7 @@ class STLPort(Port):
 
     MASK_ALL = ((1 << 64) - 1)
 
-    def __init__ (self, ctx, port_id, rpc, info):
+    def __init__ (self, ctx, port_id, rpc, info, dynamic):
         Port.__init__(self, ctx, port_id, rpc, info)
 
         self.has_rx_streams = False
@@ -39,35 +38,237 @@ class STLPort(Port):
         self.profile = None
         self.next_available_id = 1
 
+        self.is_dynamic = dynamic
+        self.profile_stream_list = {}
+        self.profile_state_list = {}
+
+
+############################   dynamic profile   #############################
+############################   helper functions  #############################
+
+    def __set_profile_stream_id (self, stream_id, profile_id = DEFAULT_PROFILE_ID, state = None):
+        if not state:
+            state = self.STATE_STREAMS
+        self.profile_stream_list.setdefault(profile_id, [])
+        if stream_id not in self.profile_stream_list.get(profile_id):
+            self.profile_stream_list[profile_id].append(stream_id)
+        self.profile_state_list.setdefault(profile_id, state)
+        return self.profile_stream_list.get(profile_id)
+
+
+    def __get_stream_profile(self, stream_id):
+        if not self.profile_stream_list:
+            return None
+        for profile_id, streams in self.profile_stream_list.items():
+            if stream_id in streams:
+                return profile_id
+        return None
+
+    def __set_profile_state (self, state, profile_id = DEFAULT_PROFILE_ID):
+        if state:
+            if profile_id == ALL_PROFILE_ID:
+                for key in self.profile_state_list.keys():
+                    self.profile_state_list[key] = state
+            elif type(profile_id) == list:
+                 for key in profile_id:
+                     self.profile_state_list[key] = state
+            else:
+                 self.profile_state_list[profile_id] = state
+        #return None if not found
+        return self.profile_state_list
+
+
+    def __delete_profile (self, profile_id = DEFAULT_PROFILE_ID):
+        stream_ids = self.profile_stream_list.get(profile_id)
+        if profile_id == ALL_PROFILE_ID:
+            stream_ids = self.profile_stream_list.keys()
+            self.profile_stream_list.clear()
+            self.profile_state_list.clear()
+        elif stream_ids:
+            del self.profile_stream_list[profile_id]
+            del self.profile_state_list[profile_id]
+        else:
+            stream_ids = []
+        #return None if not found
+        return stream_ids
+
+
+    def __delete_profile_stream (self, stream_id, profile_id = DEFAULT_PROFILE_ID):
+        if self.profile_stream_list.get(profile_id):
+            self.profile_stream_list[profile_id].remove(stream_id)
+        #if empty, make it idle
+        if not self.profile_stream_list.get(profile_id):
+            del self.profile_stream_list[profile_id]
+            del self.profile_state_list[profile_id]
+
+
+    def __sync_port_state_from_profile (self):
+        if self.STATE_PCAP_TX  in self.profile_state_list.values():
+            self.state = self.STATE_PCAP_TX
+        if self.STATE_TX in self.profile_state_list.values():
+            self.state = self.STATE_TX
+        elif self.STATE_PAUSE in self.profile_state_list.values():
+            self.state = self.STATE_PAUSE
+        elif self.STATE_STREAMS in self.profile_state_list.values():
+            self.state = self.STATE_STREAMS
+        elif self.STATE_IDLE in self.profile_state_list.values() or not self.profile_state_list:
+            self.state = self.STATE_IDLE
+        else:
+            raise Exception("port {0}: bad state received from server".format(self.port_id))
+
+
+    def __get_profiles_from_state (self, state):
+        result = []
+        for pid, pstate in self.profile_state_list.items():
+            if pstate == state:
+                result.append(pid)
+        return result
+
+
+    def __state_from_name_dynamic(self, profile_state):
+        if profile_state == "IDLE":
+            return self.STATE_IDLE
+        elif profile_state == "STREAMS":
+            return self.STATE_STREAMS
+        elif profile_state == "TX":
+            return self.STATE_TX
+        elif profile_state == "PAUSE":
+            return self.STATE_PAUSE
+        ##ASTF and PCAP not supported for profile
+        else:
+            raise Exception("port {0}: bad state received from server '{1}'".format(self.port_id, profile_state))
+
+
+    def state_from_name_dynamic(self, profile_state):
+        # dict is returned from dynamic profile server version(new)
+        for profile_id,state in profile_state.items():
+            profile_state = self.__state_from_name_dynamic(state)
+            self.__set_profile_state(profile_state, profile_id)
+
+        if self.state is not self.STATE_PCAP_TX:
+            self.__sync_port_state_from_profile()
+
+
+############################     event      #############################
+############################     handler    #############################
+
+    def async_event_profile_started (self, profile_id):
+        if not self.is_acquired():
+            self.__set_profile_state(self.STATE_TX, profile_id)
+            self.__sync_port_state_from_profile()
+
+
+    def async_event_profile_stopped (self, profile_id):
+        if not self.is_acquired():
+            self.__set_profile_state(self.STATE_STREAMS, profile_id)
+            self.__sync_port_state_from_profile()
+
+
+    def async_event_profile_paused (self, profile_id):
+        if not self.is_acquired():
+            self.__set_profile_state(self.STATE_PAUSE, profile_id)
+            self.__sync_port_state_from_profile()
+
+
+    def async_event_profile_resumed (self, profile_id):
+        if not self.is_acquired():
+            self.__set_profile_state(self.STATE_TX, profile_id)
+            self.__sync_port_state_from_profile()
+
+
+    def async_event_profile_job_done (self, profile_id):
+        # until thread is locked - order is important
+        self.tx_stopped_ts = datetime.now()
+        self.__set_profile_state(self.STATE_STREAMS, profile_id)
+        self.__sync_port_state_from_profile()
+
+        self.last_factor_type = None
+
+
+############################  STL PORT API  #############################
+############################                #############################
+
+    def sync_port_streams(self, rc_data):
+        try:
+            # dynamic profile server version (profiles in rc_data.keys())
+            if self.is_dynamic:
+                for profile_id, stream_value_list in rc_data['profiles'].items():
+                    for stream_id, stream_value in stream_value_list.items():
+                        self.__set_profile_stream_id(int(stream_id), str(profile_id))
+                        self.streams[int(stream_id)] = STLStream.from_json(stream_value)
+            # legacy server version (streams in rc_data.keys())
+            else:
+                for k, v in rc_data['streams'].items():
+                    self.streams[int(k)] = STLStream.from_json(v)
+                    self.__set_profile_stream_id(int(k))
+        except Exception as e:
+             print(e)
+             raise Exception("invalid return from server, %s" % rc_data)
+
+    def sync(self):
+        params = {"port_id": self.port_id,
+                  "profile_id": ALL_PROFILE_ID}
+
+        rc = self.transmit("get_port_status", params)
+        if rc.bad():
+            return self.err(rc.err())
+
+        # sync the port
+        self.state_from_name(rc.data()['state'])
+        if self.is_dynamic:
+            self.state_from_name_dynamic(rc.data()['state_profile'])
+
+        self.owner = rc.data()['owner']
+
+        # for stateless (hack)
+        if 'max_stream_id' in rc.data():
+            self.next_available_id = int(rc.data()['max_stream_id']) + 1
+
+        self.status = rc.data()
+
+        # replace the attributes in a thread safe manner
+        self.update_ts_attr(rc.data()['attr'])
+
+        self.service_mode = rc.data()['service']
+
+        self.__is_sync = True
+        return self.ok()
 
     # sync all the streams with the server
     def sync_streams (self):
 
         self.streams = {}
         
-        params = {"port_id": self.port_id}
+        params = {"port_id": self.port_id,
+                  "profile_id": ALL_PROFILE_ID}
 
         rc = self.transmit("get_all_streams", params)
         if rc.bad():
             return self.err(rc.err())
 
-        for k, v in rc.data()['streams'].items():
-            self.streams[int(k)] = STLStream.from_json(v)
-            
+        self.sync_port_streams(rc.data())
         return self.ok()
 
 
     @owned
-    def pause_streams(self, stream_ids):
+    def pause_streams(self, stream_ids, profile_id = DEFAULT_PROFILE_ID):
 
-        if self.state == self.STATE_PCAP_TX:
+        if profile_id == ALL_PROFILE_ID:
+            return self.err("invalid profile_id [%s]" % profile_id)
+
+        profile_state = self.profile_state_list.get(profile_id)
+        if not profile_state :
+            return self.err("profile [%s] does not exist in the port [%s]" %(profile_id, self.port_id))
+
+        if profile_state == self.STATE_PCAP_TX:
             return self.err('pause is not supported during PCAP TX')
 
-        if self.state != self.STATE_TX and self.state != self.STATE_PAUSE:
+        if profile_state != self.STATE_TX and profile_state != self.STATE_PAUSE:
             return self.err('port should be either paused or transmitting')
 
         params = {'handler':    self.handler,
                   'port_id':    self.port_id,
+                  'profile_id': profile_id,
                   'stream_ids': stream_ids or []}
 
         rc  = self.transmit('pause_streams', params)
@@ -78,16 +279,24 @@ class STLPort(Port):
 
 
     @owned
-    def resume_streams(self, stream_ids):
+    def resume_streams(self, stream_ids, profile_id = DEFAULT_PROFILE_ID):
 
-        if self.state == self.STATE_PCAP_TX:
+        if profile_id == ALL_PROFILE_ID:
+            return self.err("Invalid profile_id [%s]" % profile_id)
+
+        profile_state = self.profile_state_list.get(profile_id)
+        if not profile_state:
+            return self.err("profile [%s] does not exist in the port [%s]" %(profile_id, self.port_id))
+
+        if profile_state == self.STATE_PCAP_TX:
             return self.err('resume is not supported during PCAP TX')
 
-        if self.state != self.STATE_TX and self.state != self.STATE_PAUSE:
+        if profile_state != self.STATE_TX and profile_state != self.STATE_PAUSE:
             return self.err('port should be either paused or transmitting')
 
         params = {'handler':    self.handler,
                   'port_id':    self.port_id,
+                  'profile_id': profile_id,
                   'stream_ids': stream_ids or []}
 
         rc = self.transmit('resume_streams', params)
@@ -96,19 +305,26 @@ class STLPort(Port):
 
         return self.ok()
 
-
     
     @owned
-    def update_streams(self, mul, force, stream_ids):
+    def update_streams(self, mul, force, stream_ids, profile_id = DEFAULT_PROFILE_ID):
 
-        if self.state == self.STATE_PCAP_TX:
+        if profile_id == ALL_PROFILE_ID:
+            return self.err("Invalid profile_id [%s]" % profile_id)
+
+        profile_state = self.profile_state_list.get(profile_id)
+        if not profile_state:
+            return self.err("profile [%s] does not exist in the port [%s]" %(profile_id, self.port_id))
+
+        if profile_state == self.STATE_PCAP_TX:
             return self.err('update is not supported during PCAP TX')
 
-        if self.state != self.STATE_TX and self.state != self.STATE_PAUSE:
+        if profile_state != self.STATE_TX and profile_state != self.STATE_PAUSE:
             return self.err('port should be either paused or transmitting')
 
         params = {'handler':    self.handler,
                   'port_id':    self.port_id,
+                  "profile_id": profile_id,
                   'mul':        mul,
                   'force':      force,
                   'stream_ids': stream_ids or []}
@@ -125,14 +341,15 @@ class STLPort(Port):
         self.next_available_id += 1
         return id
 
-
     # add streams
     @writeable
-    def add_streams (self, streams_list):
+    def add_streams (self, streams_list, profile_id = DEFAULT_PROFILE_ID):
+
+        if profile_id == ALL_PROFILE_ID:
+            return self.err("Invalid profile_id [%s]" % profile_id)
 
         # listify
         streams_list = listify(streams_list)
-        
         lookup = {}
 
         # allocate IDs
@@ -167,8 +384,10 @@ class STLPort(Port):
 
             params = {"handler": self.handler,
                       "port_id": self.port_id,
+                      "profile_id": profile_id,
                       "stream_id": stream_id,
                       "stream": stream_json}
+
 
             cmd = RpcCmdData('add_stream', params, 'core')
             batch.append(cmd)
@@ -176,11 +395,14 @@ class STLPort(Port):
 
         rc = self.transmit_batch(batch)
         ret = RC()
+
+
         for i, single_rc in enumerate(rc):
             if single_rc:
                 stream_id = batch[i].params['stream_id']
                 self.streams[stream_id] = streams_list[i].clone()
-                
+                self.__set_profile_stream_id(int(stream_id), str(profile_id), self.STATE_STREAMS)
+
                 ret.add(RC_OK(data = stream_id))
 
                 self.has_rx_streams = self.has_rx_streams or streams_list[i].has_flow_stats()
@@ -188,28 +410,33 @@ class STLPort(Port):
             else:
                 ret.add(single_rc)
 
+
         self.state = self.STATE_STREAMS if (len(self.streams) > 0) else self.STATE_IDLE
 
         return ret if ret else self.err(str(ret))
 
-
-
     # remove stream from port
     @writeable
-    def remove_streams (self, stream_id_list):
+    def remove_streams (self, stream_id_list, profile_id = DEFAULT_PROFILE_ID):
+
+        if profile_id == ALL_PROFILE_ID:
+            return self.err("Invalid profile_id [%s]" % profile_id)
 
         # single element to list
         stream_id_list = listify(stream_id_list)
 
+        profile_streams = self.profile_stream_list.get(profile_id)
+
         # verify existance
-        not_found = list_difference(stream_id_list, self.streams)
-        found     = list_intersect(stream_id_list, self.streams)
+        not_found = list_difference(stream_id_list, profile_streams)
+        found     = list_intersect(stream_id_list, profile_streams)
 
         batch = []
         
         for stream_id in found:
             params = {"handler": self.handler,
                       "port_id": self.port_id,
+                      "profile_id": profile_id,
                       "stream_id": stream_id}
 
             cmd = RpcCmdData('remove_stream', params, 'core')
@@ -222,7 +449,8 @@ class STLPort(Port):
                 if single_rc:
                     id = batch[i].params['stream_id']
                     del self.streams[id]
-    
+                    self.__delete_profile_stream(id, profile_id)
+
             self.state = self.STATE_STREAMS if (len(self.streams) > 0) else self.STATE_IDLE
     
             # recheck if any RX stats streams present on the port
@@ -239,19 +467,25 @@ class STLPort(Port):
 
     # remove all the streams
     @writeable
-    def remove_all_streams (self):
+    def remove_all_streams (self, profile_id = DEFAULT_PROFILE_ID):
 
         params = {"handler": self.handler,
-                  "port_id": self.port_id}
+                  "port_id": self.port_id,
+                  "profile_id": profile_id}
 
         rc = self.transmit("remove_all_streams", params)
         if not rc:
             return self.err(rc.err())
 
-        self.streams = {}
+        streams_deleted = self.__delete_profile(profile_id)
 
-        self.state = self.STATE_IDLE
-        self.has_rx_streams = False
+        for stream_id in streams_deleted:
+            if self.streams.get(stream_id):
+                del self.streams[stream_id]
+
+        if not self.streams:
+            self.state = self.STATE_IDLE
+            self.has_rx_streams = False
 
         return self.ok()
 
@@ -316,13 +550,21 @@ class STLPort(Port):
             return self.err(rc.err())
 
     @writeable
-    def start (self, mul, duration, force, mask, start_at_ts = 0):
+    def start (self, mul, duration, force, mask, start_at_ts = 0, profile_id = DEFAULT_PROFILE_ID):
 
-        if self.state == self.STATE_IDLE:
+        if profile_id == ALL_PROFILE_ID:
+            return self.err("Invalid profile_id [%s]" % profile_id)
+
+        profile_state = self.profile_state_list.get(profile_id)
+        if not profile_state:
+            return self.err("profile [%s] does not exist in the port [%s]" %(profile_id, self.port_id))
+
+        if profile_state == self.STATE_IDLE:
             return self.err("unable to start traffic - no streams attached to port")
 
         params = {"handler":     self.handler,
                   "port_id":     self.port_id,
+                  "profile_id":  profile_id,
                   "mul":         mul,
                   "duration":    duration,
                   "force":       force,
@@ -339,30 +581,39 @@ class STLPort(Port):
             self.state = last_state
             return self.err(rc.err())
 
+        self.__set_profile_state(self.state, profile_id)
+
         # save this for TUI
         self.last_factor_type = mul['type']
         
         return rc
 
+    def is_writeable (self):
+        if self.is_dynamic:
+            # operations on port can be done on state idle or state streams
+            return self.state in (self.STATE_IDLE, self.STATE_STREAMS, self.STATE_TX, self.STATE_PAUSE, self.STATE_ASTF_LOADED)
+        else:
+            return super(STLPort, self).is_writeable()
 
     # stop traffic
     # with force ignores the cached state and sends the command
     @owned
-    def stop (self, force = False):
+    def stop (self, force = False, profile_id = DEFAULT_PROFILE_ID):
 
         # if not is not active and not force - go back
         if not self.is_active() and not force:
             return self.ok()
 
         params = {"handler": self.handler,
-                  "port_id": self.port_id}
+                  "port_id": self.port_id,
+                  "profile_id":  profile_id}
 
         rc = self.transmit("stop_traffic", params)
         if rc.bad():
             return self.err(rc.err())
 
-        self.state = self.STATE_STREAMS
-        
+        self.__set_profile_state(self.STATE_STREAMS, profile_id)
+        self.__sync_port_state_from_profile()
         self.last_factor_type = None
         
         # timestamp for last tx
@@ -372,34 +623,56 @@ class STLPort(Port):
 
 
     @owned
-    def pause (self):
+    def pause (self, profile_id = DEFAULT_PROFILE_ID):
 
-        if (self.state == self.STATE_PCAP_TX) :
-            return self.err("pause is not supported during PCAP TX")
+        profile_list = []
+        if profile_id == ALL_PROFILE_ID:
+            profile_list = self.__get_profiles_from_state(self.STATE_TX)
+        else:
+            profile_state = self.profile_state_list.get(profile_id)
+            if not profile_state:
+                return self.err("profile [%s] does not exist in the port [%s]" %(profile_id, self.port_id))
+            if (profile_state == self.STATE_PCAP_TX) :
+                return self.err("pause is not supported during PCAP TX")
+            if (profile_state != self.STATE_TX) :
+                return self.err("port is not transmitting")
+            profile_list.append(profile_id)
 
-        if (self.state != self.STATE_TX) :
+        if not profile_list :
             return self.err("port is not transmitting")
 
         params = {"handler": self.handler,
-                  "port_id": self.port_id}
+                  "port_id": self.port_id,
+                  "profile_id":  profile_id}
 
         rc  = self.transmit("pause_traffic", params)
         if rc.bad():
             return self.err(rc.err())
 
-        self.state = self.STATE_PAUSE
-
+        self.__set_profile_state(self.STATE_PAUSE, profile_list)
+        self.__sync_port_state_from_profile()
         return self.ok()
 
-
     @owned
-    def resume (self):
+    def resume (self, profile_id = DEFAULT_PROFILE_ID):
+        profile_list = []
+        if profile_id == ALL_PROFILE_ID:
+            profile_list = self.__get_profiles_from_state(self.STATE_PAUSE)
+        else:
+            profile_state = self.profile_state_list.get(profile_id)
+            if not profile_state:
+                return self.err("profile [%s] does not exist in the port [%s]" %(profile_id, self.port_id))
+            if profile_state != self.STATE_PAUSE:
+                return self.err("port is not in pause mode")
+            profile_list.append(profile_id)
 
-        if self.state != self.STATE_PAUSE:
+        if not profile_list :
             return self.err("port is not in pause mode")
 
+
         params = {"handler": self.handler,
-                  "port_id": self.port_id}
+                  "port_id": self.port_id,
+                  "profile_id": profile_id}
 
         # only valid state after stop
 
@@ -408,21 +681,33 @@ class STLPort(Port):
             return self.err(rc.err())
 
         self.state = self.STATE_TX
+        self.__set_profile_state(self.state, profile_list)
 
         return self.ok()
 
 
     @owned
-    def update (self, mul, force):
+    def update (self, mul, force, profile_id = DEFAULT_PROFILE_ID):
 
-        if (self.state == self.STATE_PCAP_TX) :
-            return self.err("update is not supported during PCAP TX")
+        profile_list = []
+        if profile_id == ALL_PROFILE_ID:
+            profile_list = self.__get_profiles_from_state(self.STATE_TX)
+        else:
+            profile_state = self.profile_state_list.get(profile_id)
+            if not profile_state :
+                return self.err("profile [%s] does not exist in the port [%s]" %(profile_id, self.port_id))
+            if (profile_state == self.STATE_PCAP_TX) :
+                return self.err("update is not supported during PCAP TX")
+            if (profile_state != self.STATE_TX) :
+                return self.err("port is not transmitting")
+            profile_list.append(profile_id)
 
-        if (self.state != self.STATE_TX) :
+        if not profile_list :
             return self.err("port is not transmitting")
 
         params = {"handler": self.handler,
                   "port_id": self.port_id,
+                  "profile_id":  profile_id,
                   "mul":     mul,
                   "force":   force}
 
@@ -438,6 +723,9 @@ class STLPort(Port):
 
     @writeable
     def push_remote (self, pcap_filename, ipg_usec, speedup, count, duration, is_dual, slave_handler, min_ipg_usec):
+
+        if ((self.state == self.STATE_TX) or (self.state == self.STATE_PAUSE)):
+            return self.err("push_remote is not allowed while transmitting traffic")
 
         params = {"handler": self.handler,
                   "port_id": self.port_id,
@@ -479,6 +767,27 @@ class STLPort(Port):
     def get_profile (self):
         return self.profile
 
+    def get_port_profiles (self, state = "all"):
+        result = []
+        for profile_id, profile_state in self.profile_state_list.items():
+            port_profile = PortProfileID(str(self.port_id) + "." + str(profile_id))
+            if state == "active":
+                if (profile_state == self.STATE_TX ) or (profile_state == self.STATE_PAUSE) or (profile_state == self.STATE_PCAP_TX):
+                    result.append(port_profile)
+            elif state == "transmitting":
+                if (profile_state == self.STATE_TX ) or (profile_state == self.STATE_PCAP_TX):
+                    result.append(port_profile)
+            elif state == "paused":
+                if (profile_state == self.STATE_PAUSE):
+                    result.append(port_profile)
+            elif state == "streams":
+                if (profile_state == self.STATE_STREAMS):
+                    result.append(port_profile)
+            elif state == "all":
+                result.append(port_profile)
+            else:
+                raise Exception("invalid state input, %s" %state)
+        return result
 
     def print_profile (self, mult, duration):
         if not self.get_profile():
@@ -519,8 +828,42 @@ class STLPort(Port):
         print("Duration              (base / req):   {:^12} / {:^12}".format(format_time(exp_time_base_sec),
                                                                              format_time(exp_time_factor_sec)))
 
+    ################# profiles printout ######################
+    def generate_loaded_profiles(self):
 
-    
+        info_table = text_tables.TRexTextTable()
+        info_table.set_cols_align(["c"] + ["c"] + ["c"])
+        info_table.set_cols_width([15]  + [10]  + [10])
+        info_table.header(["Profile ID", "state", "stream ID"])
+
+        profile_id_list = self.profile_state_list.keys()
+        for profile_id in profile_id_list:
+            profile_streams = self.profile_stream_list.get(profile_id) or '-'
+            profile_state = self.profile_state_list.get(profile_id)
+            profile_state = self.__name_from_state(profile_state)
+            info_table.add_row([
+                profile_id,
+                profile_state,
+                profile_streams
+                ])
+
+        return info_table
+
+    def __name_from_state(self, profile_state):
+        if profile_state == self.STATE_IDLE:
+            return "IDLE"
+        elif profile_state == self.STATE_STREAMS:
+            return "STREAMS"
+        elif profile_state == self.STATE_TX:
+            return "TX"
+        elif profile_state == self.STATE_PAUSE:
+            return "PAUSE"
+        elif profile_state == self.STATE_PCAP_TX:
+            return "PCAP_TX"
+        ##ASTF is not supported
+        else:
+            return "UNKNOWN"
+
     ################# stream printout ######################
     def generate_loaded_streams_sum(self, stream_id_list, table_format = True):
         self.sync_streams()
@@ -542,10 +885,10 @@ class STLPort(Port):
             p_type_field_len = max(p_type_field_len, len(pkt_types[stream_id]))
 
         info_table = text_tables.TRexTextTable()
-        info_table.set_cols_align(["c"] + ["c"] + ["c"] + ["r"] + ["c"] + ["c"] + ["c"] + ["c"])
-        info_table.set_cols_width([10]  + [15]  + [p_type_field_len]  + [8] + [16]  + [15] + [12] + [12])
-        info_table.set_cols_dtype(["t"] * 8)
-        info_table.header(["ID", "name", "packet type", "length", "mode", "rate", "PG ID", "next"])
+        info_table.set_cols_align(["c"] + ["c"] + ["c"] + ["c"] + ["r"] + ["c"] + ["c"] + ["c"] + ["c"])
+        info_table.set_cols_width([10]  + [15] + [15] + [p_type_field_len]  + [8] + [16]  + [15] + [12] + [12])
+        info_table.set_cols_dtype(["t"] * 9)
+        info_table.header(["ID", "name", "profile", "packet type", "length", "mode", "rate", "PG ID", "next"])
 
         for stream_id, stream in data.items():
             if stream.has_flow_stats():
@@ -556,6 +899,7 @@ class STLPort(Port):
             info_table.add_row([
                 stream_id,
                 stream.get_name() or '-',
+                self.__get_stream_profile(stream_id) or '-',
                 pkt_types[stream_id],
                 len(stream.get_pkt())+ 4,
                 stream.get_mode(),

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
@@ -9,7 +9,7 @@ import cProfile, pstats
 
 from scapy.utils import *
 from scapy.utils6 import *
-from ..common.trex_types import validate_type
+from ..common.trex_types import listify, validate_type
 
 try:
     import pwd
@@ -33,6 +33,20 @@ def user_input():
         # using python version 2
         return raw_input()
 
+def parse_ports_from_profiles(ports):
+    """
+    Parse distinct port ids from profiles
+
+    :parameters:
+        ports : list
+            list of profiles(PortProfileID)
+
+    :return:
+        list of port ids(int)
+    """
+    ports = listify(ports)
+    port_id_list = list(set([int(port) for port in ports]))
+    return port_id_list
 
 class random_id_gen:
     """

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -5,6 +5,7 @@ from .text_opts import format_text
 
 from ..common.trex_vlan import VLAN
 from ..common.trex_types import *
+from ..common.trex_types import PortProfileID
 from ..common.trex_exceptions import TRexError, TRexConsoleNoAction, TRexConsoleError
 from ..common.trex_psv import PSV_ACQUIRED
 
@@ -65,6 +66,11 @@ match_multiplier_help = """Multiplier should be passed in the following format:
 
                           """
 
+dynamic_profile_help = """A list of profiles on which to apply the command.
+                          Multiple profile IDs are allocated dynamically on the same port.
+                          Profile expression is used as <port id>.<profile id>.
+                          Default profile id is \"_\" when not specified.
+                       """
 
 # decodes multiplier
 # if allow_update - no +/- is allowed
@@ -320,6 +326,7 @@ def decode_tunables (tunable_str):
 
     return tunables
 
+
 class OPTIONS_DB_ARGS:
     MULTIPLIER = ArgumentPack(
         ['-m', '--multiplier'],
@@ -518,6 +525,17 @@ class OPTIONS_DB_ARGS:
          'action': 'merge',
          'type': decode_tunables})
 
+    PROFILE_LIST = ArgumentPack(
+        ['-p', '--port'],
+        {"nargs": '+',
+         'dest':'ports',
+         'metavar': 'PORT[.PROFILE]',
+         'action': 'merge',
+         'type': PortProfileID,
+         'help': dynamic_profile_help,
+         'default': []})
+
+
     PORT_LIST = ArgumentPack(
         ['-p', '--port'],
         {"nargs": '+',
@@ -596,6 +614,12 @@ class OPTIONS_DB_ARGS:
         {"action": "store_true",
          'default': False,
          'help': "Set if you want to stop active ports before appyling command."})
+
+    REMOVE = ArgumentPack(
+        ['--remove'],
+        {"action": "store_true",
+         'default': False,
+         'help': "Set if you want to remove the active profiles after stopping them."})
 
     READONLY = ArgumentPack(
         ['-r'],

--- a/src/publisher/trex_publisher.h
+++ b/src/publisher/trex_publisher.h
@@ -52,6 +52,13 @@ public:
         EVENT_PORT_ERROR            = 7,
         EVENT_PORT_ATTR_CHANGED     = 8,
 
+        EVENT_PROFILE_STARTED       = 10,
+        EVENT_PROFILE_STOPPED       = 11,
+        EVENT_PROFILE_PAUSED        = 12,
+        EVENT_PROFILE_RESUMED       = 13,
+        EVENT_PROFILE_FINISHED_TX   = 14,
+        EVENT_PROFILE_ERROR         = 17,
+
         EVENT_ASTF_STATE_CHG        = 50,
         /*
         EVENT_ASTF_IDLE             = 50,

--- a/src/stx/stl/trex_stl_port.h
+++ b/src/stx/stl/trex_stl_port.h
@@ -257,6 +257,11 @@ public:
 
 private:
 
+    /**
+     * when a port stops, perform various actions
+     *
+     */
+    void common_profile_stop_actions(bool async);
     
     /**
      * calculate effective M per core


### PR DESCRIPTION
Hi I've made a few changes according to your feedback.
@Cyborn-Minjae-Lee @egwakim @ejangle @JaeyongYu @jsmoon @JunsubHan4rmEricsson @taewoonyun @yonghwan007 @youngjun1

These are the changes that have taken place that are different from #218 
**1) Profile state update**
: async event for profile state needs to be implemented both in server and client side (in addition to the exisitng async port state event)
**2) Explicit "Remove" of a profile**
: --remove function for "stop command" needs to be supported (instead of recycling the reset command)
**3) "Streams" for each profile**
: streams command need to show profile information as well

**In addition, the following regression tests also pass**
test_basic_cont
test_basic_multi_burst
test_basic_single_burst

In other words, duration issues have been fixed.
Please provide feedback.

Thanks. 