### PR TITLE
doesn't work on python3.7 since async is a keyword

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/stats/trex_global_stats.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/stats/trex_global_stats.py
@@ -78,8 +78,8 @@ class GlobalStats(AbstractStats):
                                                                        self.get("m_rx_core_pps", format = True, suffix = "pkt/sec"),
                                                                        self.get_trend_gui("m_rx_cpu_util", use_raw = True),)),
 
-                             ("async_util.", "{0}% / {1}".format( format_threshold(round_float(self.client.conn.async.monitor.get_cpu_util()), [85, 100], [0, 85]),
-                                                                 format_num(self.client.conn.async.monitor.get_bps() / 8.0, suffix = "B/sec"))),
+                             ("async_util.", "{0}% / {1}".format( format_threshold(round_float(self.client.conn.async_.monitor.get_cpu_util()), [85, 100], [0, 85]),
+                                                                 format_num(self.client.conn.async_.monitor.get_bps() / 8.0, suffix = "B/sec"))),
                             ])
 
         stats_data_right = OrderedDict([

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -1202,7 +1202,7 @@ class TRexClient(object):
         if self.is_connected():
             raise TRexError('Can set timeout only when not connected')
         self.conn.rpc.set_timeout_sec(timeout_sec)
-        self.conn.async.set_timeout_sec(timeout_sec)
+        self.conn.async_.set_timeout_sec(timeout_sec)
 
 
     @client_api('command', False)

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_conn.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_conn.py
@@ -33,7 +33,7 @@ class Connection(object):
         self.rpc = JsonRpcClient(ctx)
         
         # async
-        self.async = TRexSubscriber(self.ctx, self.rpc)
+        self.async_ = TRexSubscriber(self.ctx, self.rpc)
          
         # init state
         self.state   = (self.DISCONNECTED, None)
@@ -57,7 +57,7 @@ class Connection(object):
         try:
             self.rpc.disconnect()
             self.rpc.set_api_h(None)
-            self.async.disconnect()
+            self.async_.disconnect()
 
         finally:
             self.state = (self.DISCONNECTED, None)
@@ -86,7 +86,7 @@ class Connection(object):
             when it retruns, an async barrier is guaranteed
             
         '''
-        return self.async.barrier()
+        return self.async_.barrier()
         
         
     def sync (self):
@@ -95,7 +95,7 @@ class Connection(object):
             must be called after all the config
             was done
         '''
-        return self.async.barrier(baseline = True)
+        return self.async_.barrier(baseline = True)
  
         
     def mark_for_disconnect (self, cause):
@@ -107,7 +107,7 @@ class Connection(object):
         '''
 
         # avoid any messages handling for the async thread
-        self.async.set_as_zombie()
+        self.async_.set_as_zombie()
         
         # change state
         self.state = (self.MARK_FOR_DISCONNECT, cause)
@@ -140,7 +140,7 @@ class Connection(object):
             return True if any data has arrived 
             the server in the last 3 seconds
         '''
-        return ( self.async.last_data_recv_ts is not None and ((time.time() - self.async.last_data_recv_ts) <= 3) )
+        return ( self.async_.last_data_recv_ts is not None and ((time.time() - self.async_.last_data_recv_ts) <= 3) )
 
 
     def is_connected (self):
@@ -186,7 +186,7 @@ class Connection(object):
 
         # connect async channel
         self.ctx.logger.pre_cmd("Connecting to publisher server on {0}:{1}".format(self.ctx.server, self.ctx.async_port))
-        rc = self.async.connect()
+        rc = self.async_.connect()
         self.ctx.logger.post_cmd(rc)
 
         if not rc:

--- a/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
@@ -988,10 +988,10 @@ class AsyncKeys:
 # Legend engine
 class AsyncKeysEngineLegend:
     def __init__ (self, async):
-        self.async = async
+        self.async_ = async
 
     def get_type (self):
-        return self.async.MODE_LEGEND
+        return self.async_.MODE_LEGEND
 
     def tick (self, seq, pm):
 
@@ -1018,8 +1018,8 @@ class AsyncKeysEngineLegend:
 
 # console engine
 class AsyncKeysEngineConsole:
-    def __init__ (self, async, console, client, save_console_history):
-        self.async = async
+    def __init__ (self, async_, console, client, save_console_history):
+        self.async_ = async_
         self.lines = deque(maxlen = 100)
 
         self.generate_prompt       = console.generate_prompt
@@ -1052,7 +1052,7 @@ class AsyncKeysEngineConsole:
         return ' '.join([format_text(cmd, 'bold') for cmd in self.ac.keys()])
 
     def get_type (self):
-        return self.async.MODE_CONSOLE
+        return self.async_.MODE_CONSOLE
 
 
     def handle_escape_char (self, seq):
@@ -1301,7 +1301,7 @@ class AsyncKeysEngineConsole:
         
         func = self.ac.get(op)
         if func:
-            with self.async.tui_global_lock:
+            with self.async_.tui_global_lock:
                 func_rc = func(param)
 
         # take out the empty line


### PR DESCRIPTION
```
  File "trex/common/trex_client.py", line 1188
    self.conn.async.set_timeout_sec(timeout_sec)
                  ^
SyntaxError: invalid syntax

```

The self.async and any uses for it need to be renamed to work with recent version of python