### PR TITLE
Fix mount /mnt/huge fail on read-only directory permission case

### DIFF
--- a/scripts/dpdk_setup_ports.py
+++ b/scripts/dpdk_setup_ports.py
@@ -680,13 +680,12 @@ Other network devices
 
 
     def config_hugepages(self, wanted_count = None):
-        huge_mnt_dir = '/mnt/huge'
-        if not os.path.isdir(huge_mnt_dir):
-            print("Creating huge node")
-            os.makedirs(huge_mnt_dir)
-
         mount_output = subprocess.check_output('mount', stderr = subprocess.STDOUT).decode(errors='replace')
         if 'hugetlbfs' not in mount_output:
+	    huge_mnt_dir = '/mnt/huge'
+	    if not os.path.isdir(huge_mnt_dir):
+		print("Creating huge node")
+		os.makedirs(huge_mnt_dir)
             os.system('mount -t hugetlbfs nodev %s' % huge_mnt_dir)
 
         for socket_id in range(2):


### PR DESCRIPTION
To fix the issue when some server have already have mounted hugetlbfs, but have read-only permission on /mnt/ directory. TRex will exit with exception in spite of available mounted hugetlbfs in that case because mkdir /mnt/huge will fail with exception.
This change will fix the issue on that case and I did not added exception handling intentionally to be able to exit TRex when real issue happening when creating directory on /mnt/huge.
