### PR TITLE
ASTF Dynamic Multiple Profile in CP side

### DIFF
--- a/scripts/automation/regression/data/astf_dns2.json
+++ b/scripts/automation/regression/data/astf_dns2.json
@@ -1,0 +1,76 @@
+{
+    "templates": [
+        {
+            "client_template": {
+                "program_index": 0,
+                "cluster": {},
+                "cps": 1,
+                "port": 54,
+                "ip_gen": {
+                    "dist_client": {
+                        "index": 0
+                    },
+                    "dist_server": {
+                        "index": 1
+                    }
+                }
+            },
+            "server_template": {
+                "program_index": 1,
+                "assoc": [
+                    {
+                        "port": 54
+                    }
+                ]
+            }
+        }
+    ],
+    "ip_gen_dist_list": [
+        {
+            "distribution": "seq",
+            "ip_end": "32.0.0.255",
+            "ip_start": "32.0.0.0",
+            "dir": "c",
+            "ip_offset": "1.0.0.0"
+        },
+        {
+            "distribution": "seq",
+            "ip_end": "64.0.255.255",
+            "ip_start": "64.0.0.0",
+            "dir": "s",
+            "ip_offset": "1.0.0.0"
+        }
+    ],
+    "program_list": [
+        {
+            "commands": [
+                {
+                    "name": "tx_msg",
+                    "buf_index": 0
+                },
+                {
+                    "name": "rx_msg",
+                    "min_pkts": 1
+                }
+            ],
+            "stream": false
+        },
+        {
+            "commands": [
+                {
+                    "name": "rx_msg",
+                    "min_pkts": 1
+                },
+                {
+                    "name": "tx_msg",
+                    "buf_index": 1
+                }
+            ],
+            "stream": false
+        }
+    ],
+    "buf_list": [
+        "ACoAAAABAAAAAAAAA3d3dwVjaXNjbwNjb20AAAEAAQ==",
+        "ACqEgAABAAEAAAAAA3d3dwVjaXNjbwNjb20AAAEAAcAMAAEAAQAAAAAABGRkZGQ="
+    ]
+}

--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -261,7 +261,7 @@ void CFlowTable::handle_close(CTcpPerThreadCtx * ctx,
     if ( remove_from_ft ){
         m_ft.remove(&flow->m_hash);
     }
-    free_flow(flow);
+    free_flow(flow, remove_from_ft);
 }
 
 void CFlowTable::process_tcp_packet(CTcpPerThreadCtx * ctx,
@@ -358,7 +358,7 @@ void       CFlowTable::generate_rst_pkt(CPerProfileCtx * ctx,
     }
 
 
-    free_flow(flow);
+    free_flow(flow, false);
 }
 
 CUdpFlow * CFlowTable::alloc_flow_udp(CPerProfileCtx * ctx,
@@ -402,10 +402,12 @@ CTcpFlow * CFlowTable::alloc_flow(CPerProfileCtx * ctx,
     return(flow);
 }
 
-void CFlowTable::free_flow(CFlowBase * flow){
+void CFlowTable::free_flow(CFlowBase * flow, bool on_table){
     assert(flow);
     flow->m_ctx->m_flow_cnt--;
-    flow->m_ctx->on_flow_close();
+    if (on_table) {
+        flow->m_ctx->on_flow_close();
+    }
 
     if ( flow->is_udp() ){
         CUdpFlow * udp_flow=(CUdpFlow *)flow;

--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -405,6 +405,7 @@ CTcpFlow * CFlowTable::alloc_flow(CPerProfileCtx * ctx,
 void CFlowTable::free_flow(CFlowBase * flow){
     assert(flow);
     flow->m_ctx->m_flow_cnt--;
+    flow->m_ctx->on_flow_close();
 
     if ( flow->is_udp() ){
         CUdpFlow * udp_flow=(CUdpFlow *)flow;

--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -142,7 +142,6 @@ public:
 typedef CHashEntry<flow_key_t> flow_hash_ent_t;
 typedef CCloseHash<flow_key_t> flow_hash_t;
 
-
 class CTcpPerThreadCtx ;
 class CTcpFlow;
 class CUdpFlow;
@@ -291,7 +290,7 @@ public:
       }
 public:
 
-void generate_rst_pkt(CTcpPerThreadCtx * ctx,
+    void generate_rst_pkt(CPerProfileCtx * ctx,
                       uint32_t src,
                       uint32_t dst,
                       uint16_t src_port,
@@ -304,7 +303,7 @@ void generate_rst_pkt(CTcpPerThreadCtx * ctx,
                       CFlowKeyFullTuple &ftuple);
 
 
-    CTcpFlow * alloc_flow(CTcpPerThreadCtx * ctx,
+    CTcpFlow * alloc_flow(CPerProfileCtx * ctx,
                           uint32_t src,
                           uint32_t dst,
                           uint16_t src_port,
@@ -313,7 +312,7 @@ void generate_rst_pkt(CTcpPerThreadCtx * ctx,
                           bool is_ipv6,
                           uint16_t tg_id=0);
 
-    CUdpFlow * alloc_flow_udp(CTcpPerThreadCtx * ctx,
+    CUdpFlow * alloc_flow_udp(CPerProfileCtx * ctx,
                               uint32_t src,
                               uint32_t dst,
                               uint16_t src_port,
@@ -331,8 +330,10 @@ void generate_rst_pkt(CTcpPerThreadCtx * ctx,
     }
 public:
     void terminate_all_flows();
+    void terminate_profile_flows(CPerProfileCtx * ctx);
     void terminate_flow(CTcpPerThreadCtx * ctx,
-                        CFlowBase * flow);
+                        CFlowBase  * flow,
+                        bool remove_from_ft);
 
 
 private:
@@ -344,7 +345,7 @@ private:
                                                           struct rte_mbuf * mbuf);
 
 
-private: 
+public:
     void reset_stats();
 public:
       CSttFlowTableStats m_sts;
@@ -356,7 +357,6 @@ private:
 
     CEmulAppApi    *   m_tcp_api;
     CEmulAppApi    *   m_udp_api;
-
 };
 
 

--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -344,7 +344,7 @@ private:
                                                           struct rte_mbuf * mbuf);
 
 
-public:
+private:
     void reset_stats();
 public:
       CSttFlowTableStats m_sts;

--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -323,7 +323,7 @@ public:
                               uint16_t tg_id=0);
 
 
-    void free_flow(CFlowBase * flow);
+    void free_flow(CFlowBase * flow, bool on_table);
 
     void set_debug(bool enable){
         m_verbose = enable;

--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -290,7 +290,7 @@ public:
       }
 public:
 
-    void generate_rst_pkt(CPerProfileCtx * ctx,
+    void generate_rst_pkt(CPerProfileCtx * pctx,
                       uint32_t src,
                       uint32_t dst,
                       uint16_t src_port,
@@ -303,7 +303,7 @@ public:
                       CFlowKeyFullTuple &ftuple);
 
 
-    CTcpFlow * alloc_flow(CPerProfileCtx * ctx,
+    CTcpFlow * alloc_flow(CPerProfileCtx * pctx,
                           uint32_t src,
                           uint32_t dst,
                           uint16_t src_port,
@@ -312,7 +312,7 @@ public:
                           bool is_ipv6,
                           uint16_t tg_id=0);
 
-    CUdpFlow * alloc_flow_udp(CPerProfileCtx * ctx,
+    CUdpFlow * alloc_flow_udp(CPerProfileCtx * pctx,
                               uint32_t src,
                               uint32_t dst,
                               uint16_t src_port,
@@ -323,14 +323,13 @@ public:
                               uint16_t tg_id=0);
 
 
-    void free_flow(CFlowBase * flow, bool on_table);
+    void free_flow(CFlowBase * flow);
 
     void set_debug(bool enable){
         m_verbose = enable;
     }
 public:
     void terminate_all_flows();
-    void terminate_profile_flows(CPerProfileCtx * ctx);
     void terminate_flow(CTcpPerThreadCtx * ctx,
                         CFlowBase  * flow,
                         bool remove_from_ft);

--- a/src/44bsd/sch_rampup.cpp
+++ b/src/44bsd/sch_rampup.cpp
@@ -26,10 +26,12 @@ limitations under the License.
 
 
 CAstfFifRampup::CAstfFifRampup(CTcpPerThreadCtx * ctx,
+                   uint32_t           id,
                    uint16_t           rampup_sec,
                    double             cps){
         /* total ticks */
         m_ctx=ctx;
+        m_profile_id=id;
         m_ticks = (uint32_t)rampup_sec*1000/TICK_MSEC;
         m_rampup_sec =rampup_sec;
         assert(m_ticks>1);
@@ -53,13 +55,13 @@ CAstfFifRampup::~CAstfFifRampup(){
 void CAstfFifRampup::on_timer_update(CAstfTimerFunctorObj *tmr){
 
     double cur_cps = m_cps*(double)m_cur_tick/((double)m_ticks);
-    m_ctx->m_fif_d_time  = 1.0/cur_cps;
+    m_ctx->set_fif_d_time(1.0/cur_cps, m_profile_id);
 
     double max_rampup_sec = (double)m_rampup_sec/4.0;
 
     /* make sure the d time is not bigger than the rampup time (could be in smaller numbers) */
-    if (m_ctx->m_fif_d_time > max_rampup_sec ) {
-        m_ctx->m_fif_d_time = max_rampup_sec;
+    if (m_ctx->get_fif_d_time(m_profile_id) > max_rampup_sec ) {
+        m_ctx->set_fif_d_time(max_rampup_sec, m_profile_id);
     }
     //printf("tick  %d %d (%f,%f) dtime:%f \n",(int)m_cur_tick,(int)m_ticks,cur_cps,m_cps,m_ctx->m_fif_d_time);
     if (m_cur_tick == m_ticks) {

--- a/src/44bsd/sch_rampup.cpp
+++ b/src/44bsd/sch_rampup.cpp
@@ -25,13 +25,11 @@ limitations under the License.
 #include <assert.h>
 
 
-CAstfFifRampup::CAstfFifRampup(CTcpPerThreadCtx * ctx,
-                   uint32_t           id,
+CAstfFifRampup::CAstfFifRampup(CPerProfileCtx * ctx,
                    uint16_t           rampup_sec,
                    double             cps){
         /* total ticks */
         m_ctx=ctx;
-        m_profile_id=id;
         m_ticks = (uint32_t)rampup_sec*1000/TICK_MSEC;
         m_rampup_sec =rampup_sec;
         assert(m_ticks>1);
@@ -46,7 +44,7 @@ CAstfFifRampup::CAstfFifRampup(CTcpPerThreadCtx * ctx,
 CAstfFifRampup::~CAstfFifRampup(){
     if (m_tmr) {
         assert(m_tmr->is_running());
-        m_ctx->m_timer_w.timer_stop(m_tmr);
+        m_ctx->m_tcp_ctx->m_timer_w.timer_stop(m_tmr);
         delete m_tmr;
         m_tmr=0;
     }
@@ -55,13 +53,13 @@ CAstfFifRampup::~CAstfFifRampup(){
 void CAstfFifRampup::on_timer_update(CAstfTimerFunctorObj *tmr){
 
     double cur_cps = m_cps*(double)m_cur_tick/((double)m_ticks);
-    m_ctx->set_fif_d_time(1.0/cur_cps, m_profile_id);
+    m_ctx->m_fif_d_time = 1.0/cur_cps;
 
     double max_rampup_sec = (double)m_rampup_sec/4.0;
 
     /* make sure the d time is not bigger than the rampup time (could be in smaller numbers) */
-    if (m_ctx->get_fif_d_time(m_profile_id) > max_rampup_sec ) {
-        m_ctx->set_fif_d_time(max_rampup_sec, m_profile_id);
+    if (m_ctx->m_fif_d_time > max_rampup_sec ) {
+        m_ctx->m_fif_d_time = max_rampup_sec;
     }
     //printf("tick  %d %d (%f,%f) dtime:%f \n",(int)m_cur_tick,(int)m_ticks,cur_cps,m_cps,m_ctx->m_fif_d_time);
     if (m_cur_tick == m_ticks) {
@@ -71,7 +69,7 @@ void CAstfFifRampup::on_timer_update(CAstfTimerFunctorObj *tmr){
         return;
     }
 
-    m_ctx->m_timer_w.timer_start(tmr,
+    m_ctx->m_tcp_ctx->m_timer_w.timer_start(tmr,
                                  tw_time_msec_to_ticks(CAstfFifRampup::TICK_MSEC) 
                                  );
     m_cur_tick++;

--- a/src/44bsd/sch_rampup.h
+++ b/src/44bsd/sch_rampup.h
@@ -36,6 +36,7 @@ private:
 
 public:
     CAstfFifRampup(CTcpPerThreadCtx * ctx,
+                   uint32_t           id,
                    uint16_t           rampup_sec,
                    double             cps);
     ~CAstfFifRampup();
@@ -45,6 +46,7 @@ public:
 
 private:
     CTcpPerThreadCtx * m_ctx;
+    uint32_t           m_profile_id;
     CAstfTimerFunctorObj  * m_tmr;
     double             m_cps;
     uint16_t           m_ticks;

--- a/src/44bsd/sch_rampup.h
+++ b/src/44bsd/sch_rampup.h
@@ -22,6 +22,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+class CPerProfileCtx;
 class CTcpPerThreadCtx;
 class CAstfTimerFunctorObj;
 
@@ -35,8 +36,7 @@ private:
     const int TICK_MSEC=1000; /* each 1000msec a tick */
 
 public:
-    CAstfFifRampup(CTcpPerThreadCtx * ctx,
-                   uint32_t           id,
+    CAstfFifRampup(CPerProfileCtx * ctx,
                    uint16_t           rampup_sec,
                    double             cps);
     ~CAstfFifRampup();
@@ -45,8 +45,7 @@ public:
     void on_timer_update(CAstfTimerFunctorObj *tmr);
 
 private:
-    CTcpPerThreadCtx * m_ctx;
-    uint32_t           m_profile_id;
+    CPerProfileCtx   * m_ctx;
     CAstfTimerFunctorObj  * m_tmr;
     double             m_cps;
     uint16_t           m_ticks;

--- a/src/44bsd/sch_rampup.h
+++ b/src/44bsd/sch_rampup.h
@@ -36,7 +36,7 @@ private:
     const int TICK_MSEC=1000; /* each 1000msec a tick */
 
 public:
-    CAstfFifRampup(CPerProfileCtx * ctx,
+    CAstfFifRampup(CPerProfileCtx * pctx,
                    uint16_t           rampup_sec,
                    double             cps);
     ~CAstfFifRampup();
@@ -45,7 +45,8 @@ public:
     void on_timer_update(CAstfTimerFunctorObj *tmr);
 
 private:
-    CPerProfileCtx   * m_ctx;
+    CTcpPerThreadCtx * m_ctx;
+    CPerProfileCtx   * m_pctx;
     CAstfTimerFunctorObj  * m_tmr;
     double             m_cps;
     uint16_t           m_ticks;

--- a/src/44bsd/sim_cs_tcp.cpp
+++ b/src/44bsd/sim_cs_tcp.cpp
@@ -575,7 +575,7 @@ int CClientServerTcp::test2(){
 
     uint32_t tx_num_bytes=100*1024;
 
-    c_flow = m_c_ctx.m_ft.alloc_flow(&m_c_ctx,0x10000001,0x30000001,1025,80,m_vlan,false);
+    c_flow = m_c_ctx.m_ft.alloc_flow(DEFAULT_PROFILE_CTX(&m_c_ctx),0x10000001,0x30000001,1025,80,m_vlan,false);
     CFlowKeyTuple   c_tuple;
     c_tuple.set_ip(0x10000001);
     c_tuple.set_port(1025);
@@ -645,21 +645,21 @@ int CClientServerTcp::test2(){
     m_sim.run_sim();
 
     printf(" C counters \n");
-    m_c_ctx.m_tcpstat.Dump(stdout);
+    m_c_ctx.get_tcpstat()->Dump(stdout);
     m_c_ctx.m_ft.dump(stdout);
     printf(" S counters \n");
-    m_s_ctx.m_tcpstat.Dump(stdout);
+    m_s_ctx.get_tcpstat()->Dump(stdout);
     m_s_ctx.m_ft.dump(stdout);
 
 
-    //EXPECT_EQ(m_c_ctx.m_tcpstat.m_sts.tcps_sndbyte,4024);
-    //EXPECT_EQ(m_c_ctx.m_tcpstat.m_sts.tcps_rcvackbyte,4024);
-    //EXPECT_EQ(m_c_ctx.m_tcpstat.m_sts.tcps_connects,1);
+    //EXPECT_EQ(m_c_ctx.get_tcpstat()->m_sts.tcps_sndbyte,4024);
+    //EXPECT_EQ(m_c_ctx.get_tcpstat()->m_sts.tcps_rcvackbyte,4024);
+    //EXPECT_EQ(m_c_ctx.get_tcpstat()->m_sts.tcps_connects,1);
 
 
-    //EXPECT_EQ(m_s_ctx.m_tcpstat.m_sts.tcps_rcvbyte,4024);
-    //EXPECT_EQ(m_s_ctx.m_tcpstat.m_sts.tcps_accepts,1);
-    //EXPECT_EQ(m_s_ctx.m_tcpstat.m_sts.tcps_preddat,m_s_ctx.m_tcpstat.m_sts.tcps_rcvpack-1);
+    //EXPECT_EQ(m_s_ctx.get_tcpstat()->m_sts.tcps_rcvbyte,4024);
+    //EXPECT_EQ(m_s_ctx.get_tcpstat()->m_sts.tcps_accepts,1);
+    //EXPECT_EQ(m_s_ctx.get_tcpstat()->m_sts.tcps_preddat,m_s_ctx.get_tcpstat()->m_sts.tcps_rcvpack-1);
 
 
     //app.m_write_buf.Delete();
@@ -1068,7 +1068,7 @@ int CClientServerTcp::simple_http_generic(method_program_cb_t cb){
     m_c_ctx.tcp_initwnd = m_c_ctx.tcp_mssdflt;
     m_s_ctx.tcp_initwnd = m_c_ctx.tcp_mssdflt;
 
-    c_flow = m_c_ctx.m_ft.alloc_flow(&m_c_ctx,0x10000001,0x30000001,1025,80,m_vlan,m_ipv6);
+    c_flow = m_c_ctx.m_ft.alloc_flow(DEFAULT_PROFILE_CTX(&m_c_ctx),0x10000001,0x30000001,1025,80,m_vlan,m_ipv6);
     CFlowKeyTuple   c_tuple;
     c_tuple.set_ip(0x10000001);
     c_tuple.set_port(1025);
@@ -1133,27 +1133,27 @@ int CClientServerTcp::simple_http_generic(method_program_cb_t cb){
     #define TX_BYTES 249
     #define RX_BYTES 32768
 
-    printf(" [%d %d] [%d %d] [%d %d] \n",(int)m_c_ctx.m_tcpstat.m_sts.tcps_sndbyte,
-                                         (int)m_c_ctx.m_tcpstat.m_sts.tcps_rcvbyte,
-                                         (int)m_s_ctx.m_tcpstat.m_sts.tcps_rcvbyte,
-                                         (int)m_s_ctx.m_tcpstat.m_sts.tcps_sndbyte,
+    printf(" [%d %d] [%d %d] [%d %d] \n",(int)m_c_ctx.get_tcpstat()->m_sts.tcps_sndbyte,
+                                         (int)m_c_ctx.get_tcpstat()->m_sts.tcps_rcvbyte,
+                                         (int)m_s_ctx.get_tcpstat()->m_sts.tcps_rcvbyte,
+                                         (int)m_s_ctx.get_tcpstat()->m_sts.tcps_sndbyte,
                                          (int)TX_BYTES,
                                          (int)RX_BYTES );
 
     if (m_check_counters){
-        if (m_s_ctx.m_tcpstat.m_sts.tcps_sndbyte>0 && 
-            m_s_ctx.m_tcpstat.m_sts.tcps_rcvbyte>0) {
-            if ( (m_c_ctx.m_tcpstat.m_sts.tcps_drops ==0) && 
-                 (m_s_ctx.m_tcpstat.m_sts.tcps_drops ==0) ){
+        if (m_s_ctx.get_tcpstat()->m_sts.tcps_sndbyte>0 &&
+            m_s_ctx.get_tcpstat()->m_sts.tcps_rcvbyte>0) {
+            if ( (m_c_ctx.get_tcpstat()->m_sts.tcps_drops ==0) &&
+                 (m_s_ctx.get_tcpstat()->m_sts.tcps_drops ==0) ){
                             /* flow wasn't initiated due to drop of SYN too many times */
-            assert(m_c_ctx.m_tcpstat.m_sts.tcps_sndbyte==TX_BYTES);
-            assert(m_c_ctx.m_tcpstat.m_sts.tcps_rcvbyte==RX_BYTES);
-            assert(m_c_ctx.m_tcpstat.m_sts.tcps_rcvackbyte==TX_BYTES);
+            assert(m_c_ctx.get_tcpstat()->m_sts.tcps_sndbyte==TX_BYTES);
+            assert(m_c_ctx.get_tcpstat()->m_sts.tcps_rcvbyte==RX_BYTES);
+            assert(m_c_ctx.get_tcpstat()->m_sts.tcps_rcvackbyte==TX_BYTES);
 
-            assert(m_s_ctx.m_tcpstat.m_sts.tcps_rcvackbyte==RX_BYTES);
-            assert(m_s_ctx.m_tcpstat.m_sts.tcps_sndbyte==RX_BYTES);
+            assert(m_s_ctx.get_tcpstat()->m_sts.tcps_rcvackbyte==RX_BYTES);
+            assert(m_s_ctx.get_tcpstat()->m_sts.tcps_sndbyte==RX_BYTES);
 
-            assert(m_s_ctx.m_tcpstat.m_sts.tcps_rcvbyte==TX_BYTES);
+            assert(m_s_ctx.get_tcpstat()->m_sts.tcps_rcvbyte==TX_BYTES);
             }
         }
     }
@@ -1202,7 +1202,7 @@ int CClientServerTcp::fill_from_file() {
     uint16_t temp_index = 0;
     uint16_t tg_id = ro_db->get_template_tg_id(temp_index);
 
-    c_flow = m_c_ctx.m_ft.alloc_flow(&m_c_ctx,0x10000001,0x30000001,src_port,dst_port,m_vlan,false, tg_id);
+    c_flow = m_c_ctx.m_ft.alloc_flow(DEFAULT_PROFILE_CTX(&m_c_ctx),0x10000001,0x30000001,src_port,dst_port,m_vlan,false, tg_id);
 
     CFlowKeyTuple c_tuple;
     c_tuple.set_ip(0x10000001);

--- a/src/44bsd/tcp_debug.cpp
+++ b/src/44bsd/tcp_debug.cpp
@@ -88,7 +88,7 @@ const char *prurequests[] = {
 /*
  * Tcp debug routines
  */
-void tcp_trace(CTcpPerThreadCtx * ctx,
+void tcp_trace(CPerProfileCtx * ctx,
           short act, 
           short ostate, 
           struct tcpcb * tp, 
@@ -214,7 +214,7 @@ void tcp_trace(CTcpPerThreadCtx * ctx,
 
 #else
 
-void tcp_trace(CTcpPerThreadCtx * ctx,
+void tcp_trace(CPerProfileCtx * ctx,
           short act, 
           short ostate, 
           struct tcpcb * tp, 

--- a/src/44bsd/tcp_debug.cpp
+++ b/src/44bsd/tcp_debug.cpp
@@ -88,7 +88,7 @@ const char *prurequests[] = {
 /*
  * Tcp debug routines
  */
-void tcp_trace(CPerProfileCtx * ctx,
+void tcp_trace(CPerProfileCtx * pctx,
           short act, 
           short ostate, 
           struct tcpcb * tp, 
@@ -214,7 +214,7 @@ void tcp_trace(CPerProfileCtx * ctx,
 
 #else
 
-void tcp_trace(CPerProfileCtx * ctx,
+void tcp_trace(CPerProfileCtx * pctx,
           short act, 
           short ostate, 
           struct tcpcb * tp, 

--- a/src/44bsd/tcp_input.cpp
+++ b/src/44bsd/tcp_input.cpp
@@ -145,7 +145,7 @@ void CTcpReass::Dump(FILE *fd){
 }
 
 
-int CTcpReass::tcp_reass_no_data(CTcpPerThreadCtx * ctx,
+int CTcpReass::tcp_reass_no_data(CPerProfileCtx * ctx,
                                  struct tcpcb *tp){
     int flags=0;
 
@@ -181,7 +181,7 @@ int CTcpReass::tcp_reass_no_data(CTcpPerThreadCtx * ctx,
 }
 
 
-int CTcpReass::tcp_reass(CTcpPerThreadCtx * ctx,
+int CTcpReass::tcp_reass(CPerProfileCtx * ctx,
                          struct tcpcb *tp, 
                          struct tcpiphdr *ti, 
                          struct rte_mbuf *m){
@@ -190,7 +190,7 @@ int CTcpReass::tcp_reass(CTcpPerThreadCtx * ctx,
 }
 
 
-int CTcpReass::pre_tcp_reass(CTcpPerThreadCtx * ctx,
+int CTcpReass::pre_tcp_reass(CPerProfileCtx * ctx,
                          struct tcpcb *tp, 
                          struct tcpiphdr *ti, 
                          struct rte_mbuf *m){
@@ -200,8 +200,8 @@ int CTcpReass::pre_tcp_reass(CTcpPerThreadCtx * ctx,
         rte_pktmbuf_free(m);
     }
     uint16_t tg_id = tp->m_flow->m_tg_id;
-    INC_STAT(ctx,tg_id, tcps_rcvoopack);
-    INC_STAT_CNT(ctx,tg_id, tcps_rcvoobyte,ti->ti_len);
+    INC_STAT(ctx, tg_id, tcps_rcvoopack);
+    INC_STAT_CNT(ctx, tg_id, tcps_rcvoobyte,ti->ti_len);
 
     if (m_active_blocks==0) {
         /* first one - just add it to the list */
@@ -295,7 +295,7 @@ int CTcpReass::pre_tcp_reass(CTcpPerThreadCtx * ctx,
 
 
 
-int tcp_reass_no_data(CTcpPerThreadCtx * ctx,
+int tcp_reass_no_data(CPerProfileCtx * ctx,
                       struct tcpcb *tp){
 
     if ( TCPS_HAVERCVDSYN(tp->t_state) == 0 )
@@ -314,7 +314,7 @@ int tcp_reass_no_data(CTcpPerThreadCtx * ctx,
 
 
 
-int tcp_reass(CTcpPerThreadCtx * ctx,
+int tcp_reass(CPerProfileCtx * ctx,
               struct tcpcb *tp, 
               struct tcpiphdr *ti, 
               struct rte_mbuf *m){
@@ -340,6 +340,12 @@ int tcp_reass(CTcpPerThreadCtx * ctx,
     }
     return (res);
 }
+#ifdef  TREX_SIM
+int tcp_reass(CTcpPerThreadCtx * ctx,
+              struct tcpcb *tp,
+              struct tcpiphdr *ti,
+              struct rte_mbuf *m) { return tcp_reass(DEFAULT_PROFILE_CTX(ctx), tp, ti, m); }
+#endif
 
 
 /*
@@ -352,7 +358,7 @@ int tcp_reass(CTcpPerThreadCtx * ctx,
  * Set DELACK for segments received in order, but ack immediately
  * when segments are out of order (so fast retransmit can work).
  */
-inline void TCP_REASS(CTcpPerThreadCtx * ctx,
+inline void TCP_REASS(CPerProfileCtx * ctx,
                       struct tcpcb *tp,
                       struct tcpiphdr *ti,
                       struct rte_mbuf *m,
@@ -381,7 +387,7 @@ inline void TCP_REASS(CTcpPerThreadCtx * ctx,
 
 
 
-void tcp_dooptions(CTcpPerThreadCtx * ctx,
+void tcp_dooptions(CPerProfileCtx * ctx,
               struct tcpcb *tp, 
               uint8_t *cp, 
               int cnt, 
@@ -391,6 +397,7 @@ void tcp_dooptions(CTcpPerThreadCtx * ctx,
               uint32_t * ts_ecr){
     u_short mss;
     int opt, optlen;
+    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
 
     for (; cnt > 0; cnt -= optlen, cp += optlen) {
         opt = cp[0];
@@ -443,7 +450,7 @@ void tcp_dooptions(CTcpPerThreadCtx * ctx,
             if (ti->ti_flags & TH_SYN) {
                 tp->t_flags |= TF_RCVD_TSTMP;
                 tp->ts_recent = *ts_val;
-                tp->ts_recent_age = ctx->tcp_now;
+                tp->ts_recent_age = tcp_ctx->tcp_now;
             }
             break;
         }
@@ -496,7 +503,7 @@ struct tcpcb *debug_flow;
 
 
 /* assuming we found the flow */
-int tcp_flow_input(CTcpPerThreadCtx * ctx,
+int tcp_flow_input(CPerProfileCtx * ctx,
                     struct tcpcb *tp, 
                     struct rte_mbuf *m,
                     TCPHeader *tcp,
@@ -516,6 +523,7 @@ int tcp_flow_input(CTcpPerThreadCtx * ctx,
     int todrop, acked, ourfinisacked, needoutput = 0;
     int off;
 
+    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
     uint8_t *optp;  // TCP option is exist  
 
     uint16_t tg_id = tp->m_flow->m_tg_id;
@@ -591,7 +599,7 @@ int tcp_flow_input(CTcpPerThreadCtx * ctx,
      * Reset idle time and keep-alive timer.
      */
     tp->t_idle = 0;
-    tp->t_timer[TCPT_KEEP] = ctx->tcp_keepidle;
+    tp->t_timer[TCPT_KEEP] = tcp_ctx->tcp_keepidle;
 
     /*
      * Process options if not in LISTEN state,
@@ -629,7 +637,7 @@ int tcp_flow_input(CTcpPerThreadCtx * ctx,
          */
         if (ts_present && SEQ_LEQ(ti->ti_seq, tp->last_ack_sent) &&
            SEQ_LT(tp->last_ack_sent, ti->ti_seq + ti->ti_len)) {
-            tp->ts_recent_age = ctx->tcp_now;
+            tp->ts_recent_age = tcp_ctx->tcp_now;
             tp->ts_recent = ts_val;
         }
 
@@ -642,7 +650,7 @@ int tcp_flow_input(CTcpPerThreadCtx * ctx,
                  */
                 INC_STAT(ctx, tg_id, tcps_predack)
                 if (ts_present)
-                    tcp_xmit_timer(ctx,tp, tcp_du32(ctx->tcp_now,ts_ecr)+1 );
+                    tcp_xmit_timer(ctx,tp, tcp_du32(tcp_ctx->tcp_now,ts_ecr)+1 );
                 else if (tp->t_rtt &&
                         SEQ_GT(ti->ti_ack, tp->t_rtseq))
                     tcp_xmit_timer(ctx,tp, tp->t_rtt);
@@ -761,14 +769,14 @@ int tcp_flow_input(CTcpPerThreadCtx * ctx,
         if (iss)
             tp->iss = iss;
         else
-            tp->iss = ctx->tcp_iss;
-        ctx->tcp_iss += TCP_ISSINCR/4;
+            tp->iss = tcp_ctx->tcp_iss;
+        tcp_ctx->tcp_iss += TCP_ISSINCR/4;
         tp->irs = ti->ti_seq;
         tcp_sendseqinit(tp);
         tcp_rcvseqinit(tp);
         tp->t_flags |= TF_ACKNOW;
         tp->t_state = TCPS_SYN_RECEIVED;
-        tp->t_timer[TCPT_KEEP] = ctx->tcp_keepinit;
+        tp->t_timer[TCPT_KEEP] = tcp_ctx->tcp_keepinit;
         INC_STAT(ctx, tg_id, tcps_accepts);
         goto trimthenstep6;
         }
@@ -862,7 +870,7 @@ trimthenstep6:
         TSTMP_LT(ts_val, tp->ts_recent)) {
 
         /* Check to see if ts_recent is over 24 days old.  */
-        if ((int)(ctx->tcp_now - tp->ts_recent_age) > TCP_PAWS_IDLE) {
+        if ((int)(tcp_ctx->tcp_now - tp->ts_recent_age) > TCP_PAWS_IDLE) {
             /*
              * Invalidate ts_recent.  If this segment updates
              * ts_recent, the age will be reset later and ts_recent
@@ -877,8 +885,8 @@ trimthenstep6:
             tp->ts_recent = 0;
         } else {
             INC_STAT(ctx, tg_id, tcps_rcvduppack);
-            INC_STAT_CNT(ctx,tg_id, tcps_rcvdupbyte,ti->ti_len);
-            INC_STAT(ctx,tg_id, tcps_pawsdrop);
+            INC_STAT_CNT(ctx, tg_id, tcps_rcvdupbyte,ti->ti_len);
+            INC_STAT(ctx, tg_id, tcps_pawsdrop);
             goto dropafterack;
         }
     }
@@ -895,7 +903,7 @@ trimthenstep6:
             todrop--;
         }
         if (todrop >= ti->ti_len) {
-            INC_STAT(ctx,tg_id, tcps_rcvduppack);
+            INC_STAT(ctx, tg_id, tcps_rcvduppack);
             INC_STAT_CNT(ctx, tg_id, tcps_rcvdupbyte,ti->ti_len);
             /*
              * If segment is just one to the left of the window,
@@ -922,8 +930,8 @@ trimthenstep6:
             }
             tp->t_flags |= TF_ACKNOW;
         } else {
-            INC_STAT(ctx,tg_id, tcps_rcvpartduppack);
-            INC_STAT_CNT(ctx,tg_id, tcps_rcvpartdupbyte, todrop);
+            INC_STAT(ctx, tg_id, tcps_rcvpartduppack);
+            INC_STAT_CNT(ctx, tg_id, tcps_rcvpartdupbyte, todrop);
         }
         /* after this operation, it could be a mbuf with len==0 in  case of mbuf_len==todrop
            still need to free it */
@@ -998,7 +1006,7 @@ trimthenstep6:
     if (ts_present && SEQ_LEQ(ti->ti_seq, tp->last_ack_sent) &&
         SEQ_LT(tp->last_ack_sent, ti->ti_seq + ti->ti_len +
            ((tiflags & (TH_SYN|TH_FIN)) != 0))) {
-        tp->ts_recent_age = ctx->tcp_now;
+        tp->ts_recent_age = tcp_ctx->tcp_now;
         tp->ts_recent = ts_val;
     }
 
@@ -1128,7 +1136,7 @@ trimthenstep6:
                 if (tp->t_timer[TCPT_REXMT] == 0 ||
                     ti->ti_ack != tp->snd_una)
                     tp->t_dupacks = 0;
-                else if (++tp->t_dupacks == ctx->tcprexmtthresh) {
+                else if (++tp->t_dupacks == tcp_ctx->tcprexmtthresh) {
                     tcp_seq onxt = tp->snd_nxt;
                     u_int win =
                         bsd_umin(tp->snd_wnd, tp->snd_cwnd) / 2 / tp->t_maxseg;
@@ -1146,7 +1154,7 @@ trimthenstep6:
                     if (SEQ_GT(onxt, tp->snd_nxt))
                         tp->snd_nxt = onxt;
                     goto drop;
-                } else if (tp->t_dupacks > ctx->tcprexmtthresh) {
+                } else if (tp->t_dupacks > tcp_ctx->tcprexmtthresh) {
                     tp->snd_cwnd += tp->t_maxseg;
                     (void) tcp_output(ctx,tp);
                     goto drop;
@@ -1159,7 +1167,7 @@ trimthenstep6:
          * If the congestion window was inflated to account
          * for the other side's cached packets, retract it.
          */
-        if (tp->t_dupacks > ctx->tcprexmtthresh &&
+        if (tp->t_dupacks > tcp_ctx->tcprexmtthresh &&
             tp->snd_cwnd > tp->snd_ssthresh)
             tp->snd_cwnd = tp->snd_ssthresh;
         tp->t_dupacks = 0;
@@ -1180,7 +1188,7 @@ trimthenstep6:
          * Recompute the initial retransmit timer.
          */
         if (ts_present){
-            tcp_xmit_timer(ctx,tp, tcp_du32(ctx->tcp_now,ts_ecr)+1);
+            tcp_xmit_timer(ctx,tp, tcp_du32(tcp_ctx->tcp_now,ts_ecr)+1);
         }else if (tp->t_rtt && SEQ_GT(ti->ti_ack, tp->t_rtseq)){
             tcp_xmit_timer(ctx,tp,tp->t_rtt);
         }
@@ -1247,7 +1255,7 @@ trimthenstep6:
                  */
                 if (so->so_state & US_SS_CANTRCVMORE) {
                     soisdisconnected(so);
-                    tp->t_timer[TCPT_2MSL] = ctx->tcp_maxidle;
+                    tp->t_timer[TCPT_2MSL] = tcp_ctx->tcp_maxidle;
                 }
                 tp->t_state = TCPS_FIN_WAIT_2;
             }
@@ -1524,7 +1532,7 @@ findpcb:
  * Collect new round-trip time estimate
  * and update averages and current timeout.
  */
-void tcp_xmit_timer(CTcpPerThreadCtx * ctx,
+void tcp_xmit_timer(CPerProfileCtx * ctx,
                     struct tcpcb *tp,
                     int16_t rtt){
     short delta;
@@ -1594,8 +1602,10 @@ void tcp_xmit_timer(CTcpPerThreadCtx * ctx,
 }
 
 
-CTcpTuneables * tcp_get_parent_tunable(CTcpPerThreadCtx * ctx,
+CTcpTuneables * tcp_get_parent_tunable(CPerProfileCtx * ctx,
                                       struct tcpcb *tp){
+
+        CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
 
         if (!(TUNE_HAS_PARENT_FLOW & tp->m_tuneable_flags)) {
             /* not part of a bigger CFlow*/
@@ -1608,12 +1618,12 @@ CTcpTuneables * tcp_get_parent_tunable(CTcpPerThreadCtx * ctx,
         uint16_t temp_id = tcp_flow->m_c_template_idx;
         CTcpTuneables *tcp_tune = NULL;
         CAstfPerTemplateRW *temp_rw = NULL;
-        CAstfTemplatesRW *ctx_temp_rw = ctx->get_template_rw();
+        CAstfTemplatesRW *ctx_temp_rw = ctx->m_template_rw;
         if (ctx_temp_rw)
             temp_rw = ctx_temp_rw->get_template_by_id(temp_id);
 
         if (temp_rw) {
-            if (ctx->m_ft.is_client_side())
+            if (tcp_ctx->m_ft.is_client_side())
                 tcp_tune = temp_rw->get_c_tune();
             else
                 tcp_tune = temp_rw->get_s_tune();
@@ -1638,13 +1648,15 @@ CTcpTuneables * tcp_get_parent_tunable(CTcpPerThreadCtx * ctx,
  * While looking at the routing entry, we also initialize other path-dependent
  * parameters from pre-set or cached values in the routing entry.
  */
-int tcp_mss(CTcpPerThreadCtx * ctx,
+int tcp_mss(CPerProfileCtx * ctx,
         struct tcpcb *tp, 
         u_int offer){
 
+    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+
     if (tp->m_tuneable_flags<2) {
-        tp->snd_cwnd = ctx->tcp_initwnd;
-        return ctx->tcp_mssdflt;
+        tp->snd_cwnd = tcp_ctx->tcp_initwnd;
+        return tcp_ctx->tcp_mssdflt;
     } else {
 
         uint16_t init_win_factor;
@@ -1652,8 +1664,8 @@ int tcp_mss(CTcpPerThreadCtx * ctx,
 
         CTcpTuneables *tune = tcp_get_parent_tunable(ctx,tp);
         if (!tune) {
-            tp->snd_cwnd = ctx->tcp_initwnd;
-            return ctx->tcp_mssdflt;
+            tp->snd_cwnd = tcp_ctx->tcp_initwnd;
+            return tcp_ctx->tcp_mssdflt;
         }
 
         if (tune->is_valid_field(CTcpTuneables::tcp_no_delay)){
@@ -1667,13 +1679,13 @@ int tcp_mss(CTcpPerThreadCtx * ctx,
         if (tune->is_valid_field(CTcpTuneables::tcp_mss_bit)){
             mss = tune->m_tcp_mss;
         }else{
-            mss = ctx->tcp_mssdflt;
+            mss = tcp_ctx->tcp_mssdflt;
         }
 
         if (tune->is_valid_field(CTcpTuneables::tcp_initwnd_bit)){
             init_win_factor = tune->m_tcp_initwnd;
         }else{
-            init_win_factor = ctx->tcp_initwnd_factor;
+            init_win_factor = tcp_ctx->tcp_initwnd_factor;
         }
 
         tp->snd_cwnd = _update_initwnd(mss,init_win_factor);

--- a/src/44bsd/tcp_input.cpp
+++ b/src/44bsd/tcp_input.cpp
@@ -145,7 +145,7 @@ void CTcpReass::Dump(FILE *fd){
 }
 
 
-int CTcpReass::tcp_reass_no_data(CPerProfileCtx * ctx,
+int CTcpReass::tcp_reass_no_data(CPerProfileCtx * pctx,
                                  struct tcpcb *tp){
     int flags=0;
 
@@ -159,8 +159,8 @@ int CTcpReass::tcp_reass_no_data(CPerProfileCtx * ctx,
 
     tp->rcv_nxt += m_blocks[0].m_len;
     uint16_t tg_id = tp->m_flow->m_tg_id;
-    INC_STAT(ctx, tg_id, tcps_rcvpack);
-    INC_STAT_CNT(ctx, tg_id, tcps_rcvbyte, m_blocks[0].m_len);
+    INC_STAT(pctx, tg_id, tcps_rcvpack);
+    INC_STAT_CNT(pctx, tg_id, tcps_rcvbyte, m_blocks[0].m_len);
 
     flags = (m_blocks[0].m_flags==1) ? TH_FIN :0;
 
@@ -181,16 +181,16 @@ int CTcpReass::tcp_reass_no_data(CPerProfileCtx * ctx,
 }
 
 
-int CTcpReass::tcp_reass(CPerProfileCtx * ctx,
+int CTcpReass::tcp_reass(CPerProfileCtx * pctx,
                          struct tcpcb *tp, 
                          struct tcpiphdr *ti, 
                          struct rte_mbuf *m){
-    pre_tcp_reass(ctx,tp,ti,m);
-    return (tcp_reass_no_data(ctx,tp));
+    pre_tcp_reass(pctx,tp,ti,m);
+    return (tcp_reass_no_data(pctx,tp));
 }
 
 
-int CTcpReass::pre_tcp_reass(CPerProfileCtx * ctx,
+int CTcpReass::pre_tcp_reass(CPerProfileCtx * pctx,
                          struct tcpcb *tp, 
                          struct tcpiphdr *ti, 
                          struct rte_mbuf *m){
@@ -200,8 +200,8 @@ int CTcpReass::pre_tcp_reass(CPerProfileCtx * ctx,
         rte_pktmbuf_free(m);
     }
     uint16_t tg_id = tp->m_flow->m_tg_id;
-    INC_STAT(ctx, tg_id, tcps_rcvoopack);
-    INC_STAT_CNT(ctx, tg_id, tcps_rcvoobyte,ti->ti_len);
+    INC_STAT(pctx, tg_id, tcps_rcvoopack);
+    INC_STAT_CNT(pctx, tg_id, tcps_rcvoobyte,ti->ti_len);
 
     if (m_active_blocks==0) {
         /* first one - just add it to the list */
@@ -259,12 +259,12 @@ int CTcpReass::pre_tcp_reass(CPerProfileCtx * ctx,
                 if (q>0) {
                     if (q>=cur.m_len) {
                         /* all packet is duplicate */
-                        INC_STAT(ctx, tg_id,tcps_rcvduppack);
-                        INC_STAT_CNT(ctx, tg_id, tcps_rcvdupbyte,cur.m_len);
+                        INC_STAT(pctx, tg_id,tcps_rcvduppack);
+                        INC_STAT_CNT(pctx, tg_id, tcps_rcvdupbyte,cur.m_len);
                     }else{
                         /* part of it duplicate */
-                        INC_STAT(ctx, tg_id,tcps_rcvpartduppack);
-                        INC_STAT_CNT(ctx, tg_id, tcps_rcvpartdupbyte,(cur.m_len-q));
+                        INC_STAT(pctx, tg_id,tcps_rcvpartduppack);
+                        INC_STAT_CNT(pctx, tg_id, tcps_rcvpartdupbyte,(cur.m_len-q));
                     }
                 }
                 if (cur.m_len>q) {
@@ -281,8 +281,8 @@ int CTcpReass::pre_tcp_reass(CPerProfileCtx * ctx,
 
     if (ci>MAX_TCP_REASS_BLOCKS) {
         /* drop last segment */
-        INC_STAT(ctx, tg_id, tcps_rcvoopackdrop);
-        INC_STAT_CNT(ctx, tg_id, tcps_rcvoobytesdrop,tblocks[MAX_TCP_REASS_BLOCKS].m_len);
+        INC_STAT(pctx, tg_id, tcps_rcvoopackdrop);
+        INC_STAT_CNT(pctx, tg_id, tcps_rcvoobytesdrop,tblocks[MAX_TCP_REASS_BLOCKS].m_len);
     }
     
     m_active_blocks = bsd_umin(ci,MAX_TCP_REASS_BLOCKS);
@@ -295,7 +295,7 @@ int CTcpReass::pre_tcp_reass(CPerProfileCtx * ctx,
 
 
 
-int tcp_reass_no_data(CPerProfileCtx * ctx,
+int tcp_reass_no_data(CPerProfileCtx * pctx,
                       struct tcpcb *tp){
 
     if ( TCPS_HAVERCVDSYN(tp->t_state) == 0 )
@@ -305,16 +305,16 @@ int tcp_reass_no_data(CPerProfileCtx * ctx,
         return (0);
     }
 
-    int res=tp->m_tpc_reass->tcp_reass_no_data(ctx,tp);
+    int res=tp->m_tpc_reass->tcp_reass_no_data(pctx,tp);
     if (tp->m_tpc_reass->get_active_blocks()==0) {
-        tcp_reass_free(ctx,tp);
+        tcp_reass_free(pctx,tp);
     }
     return (res);
 }
 
 
 
-int tcp_reass(CPerProfileCtx * ctx,
+int tcp_reass(CPerProfileCtx * pctx,
               struct tcpcb *tp, 
               struct tcpiphdr *ti, 
               struct rte_mbuf *m){
@@ -325,18 +325,18 @@ int tcp_reass(CPerProfileCtx * ctx,
              (ti->ti_seq == tp->rcv_nxt) && 
              (tp->t_state > TCPS_ESTABLISHED) && 
              (ti->ti_len==0) ) {
-            INC_STAT(ctx, tp->m_flow->m_tg_id, tcps_rcvpack);
+            INC_STAT(pctx, tp->m_flow->m_tg_id, tcps_rcvpack);
             if (m) {
                 rte_pktmbuf_free(m);
             }
             return(ti->ti_flags & TH_FIN);
         }
-        tcp_reass_alloc(ctx,tp);
+        tcp_reass_alloc(pctx,tp);
     }
 
-    int res=tp->m_tpc_reass->tcp_reass(ctx,tp,ti,m);
+    int res=tp->m_tpc_reass->tcp_reass(pctx,tp,ti,m);
     if (tp->m_tpc_reass->get_active_blocks()==0) {
-        tcp_reass_free(ctx,tp);
+        tcp_reass_free(pctx,tp);
     }
     return (res);
 }
@@ -358,7 +358,7 @@ int tcp_reass(CTcpPerThreadCtx * ctx,
  * Set DELACK for segments received in order, but ack immediately
  * when segments are out of order (so fast retransmit can work).
  */
-inline void TCP_REASS(CPerProfileCtx * ctx,
+inline void TCP_REASS(CPerProfileCtx * pctx,
                       struct tcpcb *tp,
                       struct tcpiphdr *ti,
                       struct rte_mbuf *m,
@@ -374,20 +374,20 @@ inline void TCP_REASS(CPerProfileCtx * ctx,
         tp->rcv_nxt += ti->ti_len; 
         tiflags = ti->ti_flags & TH_FIN;
         uint16_t tg_id = tp->m_flow->m_tg_id;
-        INC_STAT(ctx, tg_id, tcps_rcvpack);
-        INC_STAT_CNT(ctx, tg_id, tcps_rcvbyte,ti->ti_len);
+        INC_STAT(pctx, tg_id, tcps_rcvpack);
+        INC_STAT_CNT(pctx, tg_id, tcps_rcvbyte,ti->ti_len);
         sbappend(so,
                  &so->so_rcv, m,ti->ti_len); 
         sorwakeup(so); 
     } else { 
-        tiflags = tcp_reass(ctx,tp, ti, m); 
+        tiflags = tcp_reass(pctx,tp, ti, m); 
         tp->t_flags |= TF_ACKNOW; 
     }
 }
 
 
 
-void tcp_dooptions(CPerProfileCtx * ctx,
+void tcp_dooptions(CPerProfileCtx * pctx,
               struct tcpcb *tp, 
               uint8_t *cp, 
               int cnt, 
@@ -397,7 +397,7 @@ void tcp_dooptions(CPerProfileCtx * ctx,
               uint32_t * ts_ecr){
     u_short mss;
     int opt, optlen;
-    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+    CTcpPerThreadCtx * ctx = pctx->m_ctx;
 
     for (; cnt > 0; cnt -= optlen, cp += optlen) {
         opt = cp[0];
@@ -422,7 +422,7 @@ void tcp_dooptions(CPerProfileCtx * ctx,
                 continue;
             memcpy((char *) &mss,(char *) cp + 2, sizeof(mss));
             mss=bsd_ntohs(mss);
-            (void) tcp_mss(ctx,tp, mss);    /* sets t_maxseg */
+            (void) tcp_mss(pctx,tp, mss);    /* sets t_maxseg */
             break;
 
         case TCPOPT_WINDOW:
@@ -450,7 +450,7 @@ void tcp_dooptions(CPerProfileCtx * ctx,
             if (ti->ti_flags & TH_SYN) {
                 tp->t_flags |= TF_RCVD_TSTMP;
                 tp->ts_recent = *ts_val;
-                tp->ts_recent_age = tcp_ctx->tcp_now;
+                tp->ts_recent_age = ctx->tcp_now;
             }
             break;
         }
@@ -503,7 +503,7 @@ struct tcpcb *debug_flow;
 
 
 /* assuming we found the flow */
-int tcp_flow_input(CPerProfileCtx * ctx,
+int tcp_flow_input(CPerProfileCtx * pctx,
                     struct tcpcb *tp, 
                     struct rte_mbuf *m,
                     TCPHeader *tcp,
@@ -523,7 +523,7 @@ int tcp_flow_input(CPerProfileCtx * ctx,
     int todrop, acked, ourfinisacked, needoutput = 0;
     int off;
 
-    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+    CTcpPerThreadCtx * ctx = pctx->m_ctx;
     uint8_t *optp;  // TCP option is exist  
 
     uint16_t tg_id = tp->m_flow->m_tg_id;
@@ -580,7 +580,7 @@ int tcp_flow_input(CPerProfileCtx * ctx,
                  * send a reset in response to a RST.
                  */
                 if (tiflags & TH_ACK) {
-                    INC_STAT(ctx, tg_id, tcps_badsyn);
+                    INC_STAT(pctx, tg_id, tcps_badsyn);
                     goto dropwithreset;
                 }
                 goto drop;
@@ -599,14 +599,14 @@ int tcp_flow_input(CPerProfileCtx * ctx,
      * Reset idle time and keep-alive timer.
      */
     tp->t_idle = 0;
-    tp->t_timer[TCPT_KEEP] = tcp_ctx->tcp_keepidle;
+    tp->t_timer[TCPT_KEEP] = ctx->tcp_keepidle;
 
     /*
      * Process options if not in LISTEN state,
      * else do it below (after getting remote address).
      */
     if (optp && tp->t_state != TCPS_LISTEN){
-        tcp_dooptions(ctx,tp, optp, optlen, ti,
+        tcp_dooptions(pctx,tp, optp, optlen, ti,
             &ts_present, &ts_val, &ts_ecr);
     }
 
@@ -637,7 +637,7 @@ int tcp_flow_input(CPerProfileCtx * ctx,
          */
         if (ts_present && SEQ_LEQ(ti->ti_seq, tp->last_ack_sent) &&
            SEQ_LT(tp->last_ack_sent, ti->ti_seq + ti->ti_len)) {
-            tp->ts_recent_age = tcp_ctx->tcp_now;
+            tp->ts_recent_age = ctx->tcp_now;
             tp->ts_recent = ts_val;
         }
 
@@ -648,15 +648,15 @@ int tcp_flow_input(CPerProfileCtx * ctx,
                 /*
                  * this is a pure ack for outstanding data.
                  */
-                INC_STAT(ctx, tg_id, tcps_predack)
+                INC_STAT(pctx, tg_id, tcps_predack)
                 if (ts_present)
-                    tcp_xmit_timer(ctx,tp, tcp_du32(tcp_ctx->tcp_now,ts_ecr)+1 );
+                    tcp_xmit_timer(pctx,tp, tcp_du32(ctx->tcp_now,ts_ecr)+1 );
                 else if (tp->t_rtt &&
                         SEQ_GT(ti->ti_ack, tp->t_rtseq))
-                    tcp_xmit_timer(ctx,tp, tp->t_rtt);
+                    tcp_xmit_timer(pctx,tp, tp->t_rtt);
                 acked = ti->ti_ack - tp->snd_una;
-                INC_STAT(ctx, tg_id, tcps_rcvackpack);
-                INC_STAT_CNT(ctx, tg_id, tcps_rcvackbyte,acked);
+                INC_STAT(pctx, tg_id, tcps_rcvackpack);
+                INC_STAT_CNT(pctx, tg_id, tcps_rcvackbyte,acked);
                 /* clear the dup-ack*/
                 if (tp->t_dupacks){
                     tp->t_dupacks=0;
@@ -684,7 +684,7 @@ int tcp_flow_input(CPerProfileCtx * ctx,
                     sowwakeup(so);
                 }
                 if (so->so_snd.sb_cc)
-                    (void) tcp_output(ctx,tp);
+                    (void) tcp_output(pctx,tp);
 
                 return 0;
             }
@@ -696,10 +696,10 @@ int tcp_flow_input(CPerProfileCtx * ctx,
              * with nothing on the reassembly queue and
              * we have enough buffer space to take it.
              */
-            INC_STAT(ctx, tg_id, tcps_preddat);
+            INC_STAT(pctx, tg_id, tcps_preddat);
             tp->rcv_nxt += ti->ti_len;
-            INC_STAT(ctx, tg_id, tcps_rcvpack);
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvbyte, ti->ti_len);
+            INC_STAT(pctx, tg_id, tcps_rcvpack);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvbyte, ti->ti_len);
             /*
              * Drop TCP, IP headers and TCP options then add data
              * to socket buffer. remove padding 
@@ -717,7 +717,7 @@ int tcp_flow_input(CPerProfileCtx * ctx,
              */
             if (tiflags & TH_PUSH){
                 tp->t_flags |= TF_ACKNOW;
-                tcp_output(ctx,tp);
+                tcp_output(pctx,tp);
             }else{
                 tp->t_flags |= TF_DELACK;
             }
@@ -764,20 +764,20 @@ int tcp_flow_input(CPerProfileCtx * ctx,
     case TCPS_LISTEN: {
 
         if (optp)
-            tcp_dooptions(ctx,tp, optp, optlen, ti,
+            tcp_dooptions(pctx,tp, optp, optlen, ti,
                 &ts_present, &ts_val, &ts_ecr);
         if (iss)
             tp->iss = iss;
         else
-            tp->iss = tcp_ctx->tcp_iss;
-        tcp_ctx->tcp_iss += TCP_ISSINCR/4;
+            tp->iss = ctx->tcp_iss;
+        ctx->tcp_iss += TCP_ISSINCR/4;
         tp->irs = ti->ti_seq;
         tcp_sendseqinit(tp);
         tcp_rcvseqinit(tp);
         tp->t_flags |= TF_ACKNOW;
         tp->t_state = TCPS_SYN_RECEIVED;
-        tp->t_timer[TCPT_KEEP] = tcp_ctx->tcp_keepinit;
-        INC_STAT(ctx, tg_id, tcps_accepts);
+        tp->t_timer[TCPT_KEEP] = ctx->tcp_keepinit;
+        INC_STAT(pctx, tg_id, tcps_accepts);
         goto trimthenstep6;
         }
 
@@ -800,7 +800,7 @@ int tcp_flow_input(CPerProfileCtx * ctx,
             goto dropwithreset;
         if (tiflags & TH_RST) {
             if (tiflags & TH_ACK){
-                tp = tcp_drop_now(ctx,tp, TCP_US_ECONNREFUSED);
+                tp = tcp_drop_now(pctx,tp, TCP_US_ECONNREFUSED);
             }
             goto drop;
         }
@@ -816,7 +816,7 @@ int tcp_flow_input(CPerProfileCtx * ctx,
         tcp_rcvseqinit(tp);
         tp->t_flags |= TF_ACKNOW;
         if (tiflags & TH_ACK && SEQ_GT(tp->snd_una, tp->iss)) {
-            INC_STAT(ctx, tg_id, tcps_connects);
+            INC_STAT(pctx, tg_id, tcps_connects);
             soisconnected(so);
             tp->t_state = TCPS_ESTABLISHED;
             /* Do window scaling on this connection? */
@@ -825,13 +825,13 @@ int tcp_flow_input(CPerProfileCtx * ctx,
                 tp->snd_scale = tp->requested_s_scale;
                 tp->rcv_scale = tp->request_r_scale;
             }
-            tcp_reass_no_data(ctx,tp);
+            tcp_reass_no_data(pctx,tp);
             /*
              * if we didn't have to retransmit the SYN,
              * use its rtt as our initial srtt & rtt var.
              */
             if (tp->t_rtt)
-                tcp_xmit_timer(ctx,tp, tp->t_rtt);
+                tcp_xmit_timer(pctx,tp, tp->t_rtt);
         } else {
             tp->t_state = TCPS_SYN_RECEIVED;
         }
@@ -848,8 +848,8 @@ trimthenstep6:
             tcp_pktmbuf_trim(m, todrop);
             ti->ti_len = tp->rcv_wnd;
             tiflags &= ~TH_FIN;
-            INC_STAT(ctx, tg_id, tcps_rcvpackafterwin);
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvbyteafterwin,todrop);
+            INC_STAT(pctx, tg_id, tcps_rcvpackafterwin);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvbyteafterwin,todrop);
         }
         tp->snd_wl1 = ti->ti_seq - 1;
         tp->rcv_up = ti->ti_seq;
@@ -870,7 +870,7 @@ trimthenstep6:
         TSTMP_LT(ts_val, tp->ts_recent)) {
 
         /* Check to see if ts_recent is over 24 days old.  */
-        if ((int)(tcp_ctx->tcp_now - tp->ts_recent_age) > TCP_PAWS_IDLE) {
+        if ((int)(ctx->tcp_now - tp->ts_recent_age) > TCP_PAWS_IDLE) {
             /*
              * Invalidate ts_recent.  If this segment updates
              * ts_recent, the age will be reset later and ts_recent
@@ -884,9 +884,9 @@ trimthenstep6:
              */
             tp->ts_recent = 0;
         } else {
-            INC_STAT(ctx, tg_id, tcps_rcvduppack);
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvdupbyte,ti->ti_len);
-            INC_STAT(ctx, tg_id, tcps_pawsdrop);
+            INC_STAT(pctx, tg_id, tcps_rcvduppack);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvdupbyte,ti->ti_len);
+            INC_STAT(pctx, tg_id, tcps_pawsdrop);
             goto dropafterack;
         }
     }
@@ -903,8 +903,8 @@ trimthenstep6:
             todrop--;
         }
         if (todrop >= ti->ti_len) {
-            INC_STAT(ctx, tg_id, tcps_rcvduppack);
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvdupbyte,ti->ti_len);
+            INC_STAT(pctx, tg_id, tcps_rcvduppack);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvdupbyte,ti->ti_len);
             /*
              * If segment is just one to the left of the window,
              * check two special cases:
@@ -930,8 +930,8 @@ trimthenstep6:
             }
             tp->t_flags |= TF_ACKNOW;
         } else {
-            INC_STAT(ctx, tg_id, tcps_rcvpartduppack);
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvpartdupbyte, todrop);
+            INC_STAT(pctx, tg_id, tcps_rcvpartduppack);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvpartdupbyte, todrop);
         }
         /* after this operation, it could be a mbuf with len==0 in  case of mbuf_len==todrop
            still need to free it */
@@ -952,8 +952,8 @@ trimthenstep6:
      * user processes are gone, then RST the other end.
      */
     if (tp->t_state > TCPS_CLOSE_WAIT && ti->ti_len) {
-        tp = tcp_close(ctx,tp);
-        INC_STAT(ctx, tg_id, tcps_rcvafterclose);
+        tp = tcp_close(pctx,tp);
+        INC_STAT(pctx, tg_id, tcps_rcvafterclose);
         goto dropwithreset;
     }
 
@@ -963,9 +963,9 @@ trimthenstep6:
      */
     todrop = (ti->ti_seq+ti->ti_len) - (tp->rcv_nxt+tp->rcv_wnd);
     if (todrop > 0) {
-        INC_STAT(ctx, tg_id, tcps_rcvpackafterwin);
+        INC_STAT(pctx, tg_id, tcps_rcvpackafterwin);
         if (todrop >= ti->ti_len) {
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvbyteafterwin,ti->ti_len);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvbyteafterwin,ti->ti_len);
             /*
              * If a new connection request is received
              * while in TIME_WAIT, drop the old connection
@@ -976,7 +976,7 @@ trimthenstep6:
                 tp->t_state == TCPS_TIME_WAIT &&
                 SEQ_GT(ti->ti_seq, tp->rcv_nxt)) {
                 iss = tp->snd_nxt + TCP_ISSINCR;
-                tp = tcp_close(ctx,tp);
+                tp = tcp_close(pctx,tp);
                 goto findpcb;
             }
             /*
@@ -988,11 +988,11 @@ trimthenstep6:
              */
             if (tp->rcv_wnd == 0 && ti->ti_seq == tp->rcv_nxt) {
                 tp->t_flags |= TF_ACKNOW;
-                INC_STAT(ctx, tg_id, tcps_rcvwinprobe);
+                INC_STAT(pctx, tg_id, tcps_rcvwinprobe);
             } else
                 goto dropafterack;
         } else{
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvbyteafterwin, todrop);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvbyteafterwin, todrop);
         }
         tcp_pktmbuf_trim(m, todrop);
         ti->ti_len -= todrop;
@@ -1006,7 +1006,7 @@ trimthenstep6:
     if (ts_present && SEQ_LEQ(ti->ti_seq, tp->last_ack_sent) &&
         SEQ_LT(tp->last_ack_sent, ti->ti_seq + ti->ti_len +
            ((tiflags & (TH_SYN|TH_FIN)) != 0))) {
-        tp->ts_recent_age = tcp_ctx->tcp_now;
+        tp->ts_recent_age = ctx->tcp_now;
         tp->ts_recent = ts_val;
     }
 
@@ -1034,14 +1034,14 @@ trimthenstep6:
             so->so_error = ECONNRESET;
         close:
             tp->t_state = TCPS_CLOSED;
-            INC_STAT(ctx, tg_id, tcps_drops);
-            tp = tcp_close(ctx,tp);
+            INC_STAT(pctx, tg_id, tcps_drops);
+            tp = tcp_close(pctx,tp);
             goto drop;
 
         case TCPS_CLOSING:
         case TCPS_LAST_ACK:
         case TCPS_TIME_WAIT:
-            tp = tcp_close(ctx,tp);
+            tp = tcp_close(pctx,tp);
             goto drop;
         }
     }
@@ -1051,7 +1051,7 @@ trimthenstep6:
      * error and we send an RST and drop the connection.
      */
     if (tiflags & TH_SYN) {
-        tp = tcp_drop_now(ctx,tp, TCP_US_ECONNRESET);
+        tp = tcp_drop_now(pctx,tp, TCP_US_ECONNRESET);
         goto dropwithreset;
     }
 
@@ -1075,7 +1075,7 @@ trimthenstep6:
         if (SEQ_GT(tp->snd_una, ti->ti_ack) ||
             SEQ_GT(ti->ti_ack, tp->snd_max))
             goto dropwithreset;
-        INC_STAT(ctx, tg_id, tcps_connects);
+        INC_STAT(pctx, tg_id, tcps_connects);
         soisconnected(so);
         tp->t_state = TCPS_ESTABLISHED;
         /* Do window scaling? */
@@ -1084,7 +1084,7 @@ trimthenstep6:
             tp->snd_scale = tp->requested_s_scale;
             tp->rcv_scale = tp->request_r_scale;
         }
-        (void) tcp_reass_no_data(ctx,tp);
+        (void) tcp_reass_no_data(pctx,tp);
         tp->snd_wl1 = ti->ti_seq - 1;
         /* fall into ... */
 
@@ -1107,7 +1107,7 @@ trimthenstep6:
         if (SEQ_LEQ(ti->ti_ack, tp->snd_una)) {
             if (ti->ti_len == 0 && tiwin == tp->snd_wnd) {
                 if (tp->t_state!=TCPS_FIN_WAIT_2){
-                    INC_STAT(ctx, tg_id, tcps_rcvdupack);  /* we can get ack on FIN-ACK and it should not considered dup */
+                    INC_STAT(pctx, tg_id, tcps_rcvdupack);  /* we can get ack on FIN-ACK and it should not considered dup */
                 }
                 /*
                  * If we have outstanding data (other than
@@ -1136,7 +1136,7 @@ trimthenstep6:
                 if (tp->t_timer[TCPT_REXMT] == 0 ||
                     ti->ti_ack != tp->snd_una)
                     tp->t_dupacks = 0;
-                else if (++tp->t_dupacks == tcp_ctx->tcprexmtthresh) {
+                else if (++tp->t_dupacks == ctx->tcprexmtthresh) {
                     tcp_seq onxt = tp->snd_nxt;
                     u_int win =
                         bsd_umin(tp->snd_wnd, tp->snd_cwnd) / 2 / tp->t_maxseg;
@@ -1148,15 +1148,15 @@ trimthenstep6:
                     tp->t_rtt = 0;
                     tp->snd_nxt = ti->ti_ack;
                     tp->snd_cwnd = tp->t_maxseg;
-                    (void) tcp_output(ctx,tp);
+                    (void) tcp_output(pctx,tp);
                     tp->snd_cwnd = tp->snd_ssthresh +
                            tp->t_maxseg * tp->t_dupacks;
                     if (SEQ_GT(onxt, tp->snd_nxt))
                         tp->snd_nxt = onxt;
                     goto drop;
-                } else if (tp->t_dupacks > tcp_ctx->tcprexmtthresh) {
+                } else if (tp->t_dupacks > ctx->tcprexmtthresh) {
                     tp->snd_cwnd += tp->t_maxseg;
-                    (void) tcp_output(ctx,tp);
+                    (void) tcp_output(pctx,tp);
                     goto drop;
                 }
             } else
@@ -1167,16 +1167,16 @@ trimthenstep6:
          * If the congestion window was inflated to account
          * for the other side's cached packets, retract it.
          */
-        if (tp->t_dupacks > tcp_ctx->tcprexmtthresh &&
+        if (tp->t_dupacks > ctx->tcprexmtthresh &&
             tp->snd_cwnd > tp->snd_ssthresh)
             tp->snd_cwnd = tp->snd_ssthresh;
         tp->t_dupacks = 0;
         if (SEQ_GT(ti->ti_ack, tp->snd_max)) {
-            INC_STAT(ctx,tg_id, tcps_rcvacktoomuch);
+            INC_STAT(pctx,tg_id, tcps_rcvacktoomuch);
             goto dropafterack;
         }
         acked = ti->ti_ack - tp->snd_una;
-        INC_STAT(ctx, tg_id, tcps_rcvackpack);
+        INC_STAT(pctx, tg_id, tcps_rcvackpack);
 
         /*
          * If we have a timestamp reply, update smoothed
@@ -1188,9 +1188,9 @@ trimthenstep6:
          * Recompute the initial retransmit timer.
          */
         if (ts_present){
-            tcp_xmit_timer(ctx,tp, tcp_du32(tcp_ctx->tcp_now,ts_ecr)+1);
+            tcp_xmit_timer(pctx,tp, tcp_du32(ctx->tcp_now,ts_ecr)+1);
         }else if (tp->t_rtt && SEQ_GT(ti->ti_ack, tp->t_rtseq)){
-            tcp_xmit_timer(ctx,tp,tp->t_rtt);
+            tcp_xmit_timer(pctx,tp,tp->t_rtt);
         }
 
         /*
@@ -1220,13 +1220,13 @@ trimthenstep6:
         tp->snd_cwnd = bsd_umin(cw + incr, TCP_MAXWIN<<tp->snd_scale);
         }
         if (acked > so->so_snd.sb_cc) {
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvackbyte,so->so_snd.sb_cc);
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvackbyte_of,(acked-so->so_snd.sb_cc));
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvackbyte,so->so_snd.sb_cc);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvackbyte_of,(acked-so->so_snd.sb_cc));
             tp->snd_wnd -= so->so_snd.sb_cc;
             so->so_snd.sbdrop_all(so);
             ourfinisacked = 1;
         } else {
-            INC_STAT_CNT(ctx, tg_id, tcps_rcvackbyte,acked);
+            INC_STAT_CNT(pctx, tg_id, tcps_rcvackbyte,acked);
             so->so_snd.sbdrop(so,acked);
             tp->snd_wnd -= acked;
             ourfinisacked = 0;
@@ -1255,7 +1255,7 @@ trimthenstep6:
                  */
                 if (so->so_state & US_SS_CANTRCVMORE) {
                     soisdisconnected(so);
-                    tp->t_timer[TCPT_2MSL] = tcp_ctx->tcp_maxidle;
+                    tp->t_timer[TCPT_2MSL] = ctx->tcp_maxidle;
                 }
                 tp->t_state = TCPS_FIN_WAIT_2;
             }
@@ -1284,7 +1284,7 @@ trimthenstep6:
          */
         case TCPS_LAST_ACK:
             if (ourfinisacked) {
-                tp = tcp_close(ctx,tp);
+                tp = tcp_close(pctx,tp);
                 goto drop;
             }
             break;
@@ -1313,7 +1313,7 @@ step6:
         /* keep track of pure window updates */
         if ( (ti->ti_len == 0) &&
             (tp->snd_wl2 == ti->ti_ack) && (tiwin > tp->snd_wnd)){
-            INC_STAT(ctx, tg_id, tcps_rcvwinupd);
+            INC_STAT(pctx, tg_id, tcps_rcvwinupd);
         }
         tp->snd_wnd = tiwin;
         tp->snd_wl1 = ti->ti_seq;
@@ -1402,7 +1402,7 @@ step6:
      */
     if ((ti->ti_len || (tiflags&TH_FIN)) &&
         TCPS_HAVERCVDFIN(tp->t_state) == 0) {
-        TCP_REASS(ctx,tp, ti, m, so, tiflags);
+        TCP_REASS(pctx,tp, ti, m, so, tiflags);
         /*
          * Note the amount of data that peer has sent into
          * our window, in order to estimate the sender's
@@ -1464,7 +1464,7 @@ step6:
         }
     }
     if (so->so_options & US_SO_DEBUG){
-        tcp_trace(ctx,TA_INPUT, ostate, tp, ti, 0,0);
+        tcp_trace(pctx,TA_INPUT, ostate, tp, ti, 0,0);
     }
 
 
@@ -1472,7 +1472,7 @@ step6:
      * Return any desired output.
      */
     if (needoutput || (tp->t_flags & TF_ACKNOW))
-        (void) tcp_output(ctx,tp);
+        (void) tcp_output(pctx,tp);
     return 0;
 
 dropafterack:
@@ -1484,7 +1484,7 @@ dropafterack:
         goto drop;
     rte_pktmbuf_free(m);
     tp->t_flags |= TF_ACKNOW;
-    (void) tcp_output(ctx,tp);
+    (void) tcp_output(pctx,tp);
     return 0;
 
 dropwithreset:
@@ -1500,12 +1500,12 @@ dropwithreset:
     rte_pktmbuf_free(m);
 
     if (tiflags & TH_ACK){
-        tcp_respond(ctx,tp,   (tcp_seq)0, ti->ti_ack, TH_RST);
+        tcp_respond(pctx,tp,   (tcp_seq)0, ti->ti_ack, TH_RST);
     }else {
         if (tiflags & TH_SYN){
             ti->ti_len++;
         }
-        tcp_respond(ctx,tp,  ti->ti_seq+ti->ti_len, (tcp_seq)0,
+        tcp_respond(pctx,tp,  ti->ti_seq+ti->ti_len, (tcp_seq)0,
             TH_RST|TH_ACK);
     }
     /* destroy temporarily created socket */
@@ -1516,7 +1516,7 @@ drop:
      * Drop space held by incoming segment and return.
      */
     if (tp && (so->so_options & US_SO_DEBUG)){
-        tcp_trace(ctx,TA_DROP, ostate, tp, ti, 0, 0);
+        tcp_trace(pctx,TA_DROP, ostate, tp, ti, 0, 0);
     }
     rte_pktmbuf_free(m);
     /* destroy temporarily created socket */
@@ -1532,12 +1532,12 @@ findpcb:
  * Collect new round-trip time estimate
  * and update averages and current timeout.
  */
-void tcp_xmit_timer(CPerProfileCtx * ctx,
+void tcp_xmit_timer(CPerProfileCtx * pctx,
                     struct tcpcb *tp,
                     int16_t rtt){
     short delta;
 
-    INC_STAT(ctx, tp->m_flow->m_tg_id, tcps_rttupdated);
+    INC_STAT(pctx, tp->m_flow->m_tg_id, tcps_rttupdated);
     if (tp->t_srtt != 0) {
         /*
          * srtt is stored as fixed point with 3 bits after the
@@ -1602,10 +1602,10 @@ void tcp_xmit_timer(CPerProfileCtx * ctx,
 }
 
 
-CTcpTuneables * tcp_get_parent_tunable(CPerProfileCtx * ctx,
+CTcpTuneables * tcp_get_parent_tunable(CPerProfileCtx * pctx,
                                       struct tcpcb *tp){
 
-        CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+        CTcpPerThreadCtx * ctx = pctx->m_ctx;
 
         if (!(TUNE_HAS_PARENT_FLOW & tp->m_tuneable_flags)) {
             /* not part of a bigger CFlow*/
@@ -1618,12 +1618,12 @@ CTcpTuneables * tcp_get_parent_tunable(CPerProfileCtx * ctx,
         uint16_t temp_id = tcp_flow->m_c_template_idx;
         CTcpTuneables *tcp_tune = NULL;
         CAstfPerTemplateRW *temp_rw = NULL;
-        CAstfTemplatesRW *ctx_temp_rw = ctx->m_template_rw;
+        CAstfTemplatesRW *ctx_temp_rw = pctx->m_template_rw;
         if (ctx_temp_rw)
             temp_rw = ctx_temp_rw->get_template_by_id(temp_id);
 
         if (temp_rw) {
-            if (tcp_ctx->m_ft.is_client_side())
+            if (ctx->m_ft.is_client_side())
                 tcp_tune = temp_rw->get_c_tune();
             else
                 tcp_tune = temp_rw->get_s_tune();
@@ -1648,24 +1648,24 @@ CTcpTuneables * tcp_get_parent_tunable(CPerProfileCtx * ctx,
  * While looking at the routing entry, we also initialize other path-dependent
  * parameters from pre-set or cached values in the routing entry.
  */
-int tcp_mss(CPerProfileCtx * ctx,
+int tcp_mss(CPerProfileCtx * pctx,
         struct tcpcb *tp, 
         u_int offer){
 
-    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+    CTcpPerThreadCtx * ctx = pctx->m_ctx;
 
     if (tp->m_tuneable_flags<2) {
-        tp->snd_cwnd = tcp_ctx->tcp_initwnd;
-        return tcp_ctx->tcp_mssdflt;
+        tp->snd_cwnd = ctx->tcp_initwnd;
+        return ctx->tcp_mssdflt;
     } else {
 
         uint16_t init_win_factor;
         uint16_t mss;
 
-        CTcpTuneables *tune = tcp_get_parent_tunable(ctx,tp);
+        CTcpTuneables *tune = tcp_get_parent_tunable(pctx,tp);
         if (!tune) {
-            tp->snd_cwnd = tcp_ctx->tcp_initwnd;
-            return tcp_ctx->tcp_mssdflt;
+            tp->snd_cwnd = ctx->tcp_initwnd;
+            return ctx->tcp_mssdflt;
         }
 
         if (tune->is_valid_field(CTcpTuneables::tcp_no_delay)){
@@ -1679,13 +1679,13 @@ int tcp_mss(CPerProfileCtx * ctx,
         if (tune->is_valid_field(CTcpTuneables::tcp_mss_bit)){
             mss = tune->m_tcp_mss;
         }else{
-            mss = tcp_ctx->tcp_mssdflt;
+            mss = ctx->tcp_mssdflt;
         }
 
         if (tune->is_valid_field(CTcpTuneables::tcp_initwnd_bit)){
             init_win_factor = tune->m_tcp_initwnd;
         }else{
-            init_win_factor = tcp_ctx->tcp_initwnd_factor;
+            init_win_factor = ctx->tcp_initwnd_factor;
         }
 
         tp->snd_cwnd = _update_initwnd(mss,init_win_factor);

--- a/src/44bsd/tcp_output.cpp
+++ b/src/44bsd/tcp_output.cpp
@@ -168,7 +168,7 @@ static inline void tcp_pkt_update_len(CFlowTemplate *ftp,
  * 
  * @return 
  */
-static inline int _tcp_build_cpkt(CTcpPerThreadCtx * ctx,
+static inline int _tcp_build_cpkt(CPerProfileCtx * ctx,
                                   CFlowTemplate *ftp,
                                   struct tcpcb *tp,
                                   uint16_t tcphlen,
@@ -193,7 +193,7 @@ static inline int _tcp_build_cpkt(CTcpPerThreadCtx * ctx,
     return(0);
 }
 
-int tcp_build_cpkt(CTcpPerThreadCtx * ctx,
+int tcp_build_cpkt(CPerProfileCtx * ctx,
                    struct tcpcb *tp,
                    uint16_t tcphlen,
                    CTcpPkt &pkt){
@@ -240,7 +240,7 @@ static inline uint16_t update_next_mbuf(rte_mbuf_t   *mi,
  * 
  * @return 
  */
-static inline int tcp_build_dpkt_(CTcpPerThreadCtx * ctx,
+static inline int tcp_build_dpkt_(CPerProfileCtx * ctx,
                                   CFlowTemplate *ftp,
                                   struct tcpcb *tp,
                                   uint32_t offset, 
@@ -315,7 +315,7 @@ static inline int tcp_build_dpkt_(CTcpPerThreadCtx * ctx,
 
 /* len : if TSO==true, it is the TSO packet size (before segmentation), 
          else it is the packet size */
-int tcp_build_dpkt(CTcpPerThreadCtx * ctx,
+int tcp_build_dpkt(CPerProfileCtx * ctx,
                    struct tcpcb *tp,
                    uint32_t offset, 
                    uint32_t dlen,
@@ -345,13 +345,14 @@ int tcp_build_dpkt(CTcpPerThreadCtx * ctx,
  * In any case the ack and sequence number of the transmitted
  * segment are as specified by the parameters.
  */
-void tcp_respond(CTcpPerThreadCtx * ctx,
+void tcp_respond(CPerProfileCtx * ctx,
             struct tcpcb *tp, 
             tcp_seq ack, 
             tcp_seq seq, 
             int flags){
     assert(tp);
     uint32_t win = sbspace(&tp->m_socket.so_rcv);
+    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
 
     CTcpPkt pkt;
     if (tcp_build_cpkt(ctx,tp,TCP_HEADER_LEN,pkt)!=0){
@@ -364,7 +365,7 @@ void tcp_respond(CTcpPerThreadCtx * ctx,
     ti->setFlag(flags);
     ti->setWindowSize((uint16_t) (win >> tp->rcv_scale));
 
-    ctx->m_cb->on_tx(ctx,tp,pkt.m_buf);
+    tcp_ctx->m_cb->on_tx(tcp_ctx,tp,pkt.m_buf);
 }
 
 
@@ -373,7 +374,7 @@ void tcp_respond(CTcpPerThreadCtx * ctx,
 /*
  * Tcp output routine: figure out what should be sent and send it.
  */
-int tcp_output(CTcpPerThreadCtx * ctx,struct tcpcb *tp) {
+int tcp_output(CPerProfileCtx * ctx,struct tcpcb *tp) {
 
     struct tcp_socket *so = &tp->m_socket;
     int32_t len ;
@@ -382,6 +383,7 @@ int tcp_output(CTcpPerThreadCtx * ctx,struct tcpcb *tp) {
     u_char opt[MAX_TCPOPTLEN];
     unsigned optlen, hdrlen;
     int idle, sendalot;
+    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
 
     /*
      * Determine length of data that should be transmitted,
@@ -618,7 +620,7 @@ send:
  
         /* Form timestamp option as shown in appendix A of RFC 1323. */
         *lp++ = bsd_htonl(TCPOPT_TSTAMP_HDR);
-        *lp++ = bsd_htonl(ctx->tcp_now);
+        *lp++ = bsd_htonl(tcp_ctx->tcp_now);
         *lp   = bsd_htonl(tp->ts_recent);
         optlen += TCPOLEN_TSTAMP_APPA;
     }
@@ -819,7 +821,7 @@ send:
         tcp_trace(ctx,TA_OUTPUT, tp->t_state, tp, (struct tcpiphdr *)0, ti,len);
     }
 
-    error = ctx->m_cb->on_tx(ctx,tp,pkt.m_buf);
+    error = tcp_ctx->m_cb->on_tx(tcp_ctx,tp,pkt.m_buf);
 
     if (error) {
 out:
@@ -851,7 +853,7 @@ out:
     return (0);
 }
 
-void tcp_setpersist(CTcpPerThreadCtx * ctx,
+void tcp_setpersist(CPerProfileCtx * ctx,
                     struct tcpcb *tp){
     int16_t t = ((tp->t_srtt >> 2) + tp->t_rttvar) >> 1;
 

--- a/src/44bsd/tcp_output.cpp
+++ b/src/44bsd/tcp_output.cpp
@@ -161,14 +161,14 @@ static inline void tcp_pkt_update_len(CFlowTemplate *ftp,
 /**
  * build control packet without data
  * 
- * @param ctx
+ * @param pctx
  * @param tp
  * @param tcphlen
  * @param pkt
  * 
  * @return 
  */
-static inline int _tcp_build_cpkt(CPerProfileCtx * ctx,
+static inline int _tcp_build_cpkt(CPerProfileCtx * pctx,
                                   CFlowTemplate *ftp,
                                   struct tcpcb *tp,
                                   uint16_t tcphlen,
@@ -178,7 +178,7 @@ static inline int _tcp_build_cpkt(CPerProfileCtx * ctx,
     m=tp->pktmbuf_alloc(len);
     pkt.m_buf=m;
     if (m==0) {
-        INC_STAT(ctx, tp->m_flow->m_tg_id, tcps_nombuf);
+        INC_STAT(pctx, tp->m_flow->m_tg_id, tcps_nombuf);
         /* drop the packet */
         return(-1);
     }
@@ -193,14 +193,14 @@ static inline int _tcp_build_cpkt(CPerProfileCtx * ctx,
     return(0);
 }
 
-int tcp_build_cpkt(CPerProfileCtx * ctx,
+int tcp_build_cpkt(CPerProfileCtx * pctx,
                    struct tcpcb *tp,
                    uint16_t tcphlen,
                    CTcpPkt &pkt){
     assert(tp->m_flow);
     CFlowTemplate *ftp=&tp->m_flow->m_template;
 
-   int res=_tcp_build_cpkt(ctx,ftp,tp,tcphlen,pkt);
+   int res=_tcp_build_cpkt(pctx,ftp,tp,tcphlen,pkt);
    if (res==0){
        tcp_pkt_update_len(ftp,tp,pkt,0,tcphlen) ;
    }
@@ -231,7 +231,7 @@ static inline uint16_t update_next_mbuf(rte_mbuf_t   *mi,
 /**
  * build packet from socket buffer 
  * 
- * @param ctx
+ * @param pctx
  * @param tp
  * @param offset
  * @param dlen
@@ -240,7 +240,7 @@ static inline uint16_t update_next_mbuf(rte_mbuf_t   *mi,
  * 
  * @return 
  */
-static inline int tcp_build_dpkt_(CPerProfileCtx * ctx,
+static inline int tcp_build_dpkt_(CPerProfileCtx * pctx,
                                   CFlowTemplate *ftp,
                                   struct tcpcb *tp,
                                   uint32_t offset, 
@@ -248,7 +248,7 @@ static inline int tcp_build_dpkt_(CPerProfileCtx * ctx,
                                   uint16_t tcphlen, 
                                   CTcpPkt &pkt){
 
-    int res=_tcp_build_cpkt(ctx,ftp,tp,tcphlen,pkt);
+    int res=_tcp_build_cpkt(pctx,ftp,tp,tcphlen,pkt);
     if (res<0) {
         return(res);
     }
@@ -281,7 +281,7 @@ static inline int tcp_build_dpkt_(CPerProfileCtx * ctx,
                 /* need to allocate indirect */
                 rte_mbuf_t   * mi=tp->pktmbuf_alloc_small();
                 if (mi==0) {
-                    INC_STAT(ctx, tp->m_flow->m_tg_id, tcps_nombuf);
+                    INC_STAT(pctx, tp->m_flow->m_tg_id, tcps_nombuf);
                     rte_pktmbuf_free(m);
                     return(-1);
                 }
@@ -315,7 +315,7 @@ static inline int tcp_build_dpkt_(CPerProfileCtx * ctx,
 
 /* len : if TSO==true, it is the TSO packet size (before segmentation), 
          else it is the packet size */
-int tcp_build_dpkt(CPerProfileCtx * ctx,
+int tcp_build_dpkt(CPerProfileCtx * pctx,
                    struct tcpcb *tp,
                    uint32_t offset, 
                    uint32_t dlen,
@@ -324,7 +324,7 @@ int tcp_build_dpkt(CPerProfileCtx * ctx,
     assert(tp->m_flow);
     CFlowTemplate *ftp=&tp->m_flow->m_template;
 
-    int res = tcp_build_dpkt_(ctx,ftp,tp,offset,dlen,tcphlen,pkt);
+    int res = tcp_build_dpkt_(pctx,ftp,tp,offset,dlen,tcphlen,pkt);
     if (res==0){
         tcp_pkt_update_len(ftp,tp,pkt,dlen,tcphlen) ;
     }
@@ -345,17 +345,17 @@ int tcp_build_dpkt(CPerProfileCtx * ctx,
  * In any case the ack and sequence number of the transmitted
  * segment are as specified by the parameters.
  */
-void tcp_respond(CPerProfileCtx * ctx,
+void tcp_respond(CPerProfileCtx * pctx,
             struct tcpcb *tp, 
             tcp_seq ack, 
             tcp_seq seq, 
             int flags){
     assert(tp);
     uint32_t win = sbspace(&tp->m_socket.so_rcv);
-    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+    CTcpPerThreadCtx * ctx = pctx->m_ctx;
 
     CTcpPkt pkt;
-    if (tcp_build_cpkt(ctx,tp,TCP_HEADER_LEN,pkt)!=0){
+    if (tcp_build_cpkt(pctx,tp,TCP_HEADER_LEN,pkt)!=0){
         return;
     }
     TCPHeader * ti=pkt.lpTcp;
@@ -365,7 +365,7 @@ void tcp_respond(CPerProfileCtx * ctx,
     ti->setFlag(flags);
     ti->setWindowSize((uint16_t) (win >> tp->rcv_scale));
 
-    tcp_ctx->m_cb->on_tx(tcp_ctx,tp,pkt.m_buf);
+    ctx->m_cb->on_tx(ctx,tp,pkt.m_buf);
 }
 
 
@@ -374,7 +374,7 @@ void tcp_respond(CPerProfileCtx * ctx,
 /*
  * Tcp output routine: figure out what should be sent and send it.
  */
-int tcp_output(CPerProfileCtx * ctx,struct tcpcb *tp) {
+int tcp_output(CPerProfileCtx * pctx,struct tcpcb *tp) {
 
     struct tcp_socket *so = &tp->m_socket;
     int32_t len ;
@@ -383,7 +383,7 @@ int tcp_output(CPerProfileCtx * ctx,struct tcpcb *tp) {
     u_char opt[MAX_TCPOPTLEN];
     unsigned optlen, hdrlen;
     int idle, sendalot;
-    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+    CTcpPerThreadCtx * ctx = pctx->m_ctx;
 
     /*
      * Determine length of data that should be transmitted,
@@ -560,7 +560,7 @@ again:
     if (so->so_snd.sb_cc && tp->t_timer[TCPT_REXMT] == 0 &&
         tp->t_timer[TCPT_PERSIST] == 0) {
         tp->t_rxtshift = 0;
-        tcp_setpersist(ctx,tp);
+        tcp_setpersist(pctx,tp);
     }
 
     /*
@@ -590,7 +590,7 @@ send:
 
             opt[0] = TCPOPT_MAXSEG;
             opt[1] = 4;
-            mss = bsd_htons((u_short) tcp_mss(ctx,tp, 0));
+            mss = bsd_htons((u_short) tcp_mss(pctx,tp, 0));
             *(uint16_t*)(opt + 2)=mss;
             optlen = 4;
      
@@ -620,7 +620,7 @@ send:
  
         /* Form timestamp option as shown in appendix A of RFC 1323. */
         *lp++ = bsd_htonl(TCPOPT_TSTAMP_HDR);
-        *lp++ = bsd_htonl(tcp_ctx->tcp_now);
+        *lp++ = bsd_htonl(ctx->tcp_now);
         *lp   = bsd_htonl(tp->ts_recent);
         optlen += TCPOLEN_TSTAMP_APPA;
     }
@@ -659,16 +659,16 @@ send:
     uint16_t tg_id = tp->m_flow->m_tg_id; 
     if (len) {
         if (tp->t_force && len == 1){
-            INC_STAT(ctx, tg_id, tcps_sndprobe);
+            INC_STAT(pctx, tg_id, tcps_sndprobe);
         } else if (SEQ_LT(tp->snd_nxt, tp->snd_max)) {
-            INC_STAT(ctx, tg_id, tcps_sndrexmitpack);
-            INC_STAT_CNT(ctx, tg_id, tcps_sndrexmitbyte,len);
+            INC_STAT(pctx, tg_id, tcps_sndrexmitpack);
+            INC_STAT_CNT(pctx, tg_id, tcps_sndrexmitbyte,len);
         } else {
-            INC_STAT(ctx, tg_id, tcps_sndpack);
-            INC_STAT_CNT(ctx, tg_id, tcps_sndbyte_ok,len); /* better to be handle by application layer */
+            INC_STAT(pctx, tg_id, tcps_sndpack);
+            INC_STAT_CNT(pctx, tg_id, tcps_sndbyte_ok,len); /* better to be handle by application layer */
         }
 
-        if (tcp_build_dpkt(ctx,tp,off,len,hdrlen,pkt)!=0){
+        if (tcp_build_dpkt(pctx,tp,off,len,hdrlen,pkt)!=0){
             error = ENOBUFS;
             goto out;
         }
@@ -684,16 +684,16 @@ send:
             flags |= TH_PUSH;
     } else {
         if (tp->t_flags & TF_ACKNOW){
-            INC_STAT(ctx, tg_id, tcps_sndacks);
+            INC_STAT(pctx, tg_id, tcps_sndacks);
         } else if (flags & (TH_SYN|TH_FIN|TH_RST)){
-            INC_STAT(ctx, tg_id, tcps_sndctrl);
+            INC_STAT(pctx, tg_id, tcps_sndctrl);
         } else if (SEQ_GT(tp->snd_up, tp->snd_una)){
-            INC_STAT(ctx, tg_id, tcps_sndurg);
+            INC_STAT(pctx, tg_id, tcps_sndurg);
         } else{
-            INC_STAT(ctx, tg_id, tcps_sndwinup);
+            INC_STAT(pctx, tg_id, tcps_sndwinup);
         }
 
-        if ( tcp_build_cpkt(ctx,tp,hdrlen,pkt)!=0){
+        if ( tcp_build_cpkt(pctx,tp,hdrlen,pkt)!=0){
             error = ENOBUFS;
             goto out;
         }
@@ -790,7 +790,7 @@ send:
             if (tp->t_rtt == 0) {
                 tp->t_rtt = 1;
                 tp->t_rtseq = startseq;
-                INC_STAT(ctx, tg_id, tcps_segstimed);
+                INC_STAT(pctx, tg_id, tcps_segstimed);
             }
         }
 
@@ -818,10 +818,10 @@ send:
      * Trace.
      */
     if (so->so_options & US_SO_DEBUG){
-        tcp_trace(ctx,TA_OUTPUT, tp->t_state, tp, (struct tcpiphdr *)0, ti,len);
+        tcp_trace(pctx,TA_OUTPUT, tp->t_state, tp, (struct tcpiphdr *)0, ti,len);
     }
 
-    error = tcp_ctx->m_cb->on_tx(tcp_ctx,tp,pkt.m_buf);
+    error = ctx->m_cb->on_tx(ctx,tp,pkt.m_buf);
 
     if (error) {
 out:
@@ -836,7 +836,7 @@ out:
         }
         return (error);
     }
-    INC_STAT(ctx, tg_id, tcps_sndtotal);
+    INC_STAT(pctx, tg_id, tcps_sndtotal);
 
     /*
      * Data sent (as far as we can tell).
@@ -853,7 +853,7 @@ out:
     return (0);
 }
 
-void tcp_setpersist(CPerProfileCtx * ctx,
+void tcp_setpersist(CPerProfileCtx * pctx,
                     struct tcpcb *tp){
     int16_t t = ((tp->t_srtt >> 2) + tp->t_rttvar) >> 1;
 

--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -253,7 +253,7 @@ void CEmulApp::force_stop_timer(){
     if (get_timer_init_done()) {
         if (m_timer.is_running()){
             /* must stop timer before free the memory */
-            m_ctx->m_timer_w.timer_stop(&m_timer);
+            m_ctx->m_tcp_ctx->m_timer_w.timer_stop(&m_timer);
         }
     }
 }
@@ -262,7 +262,7 @@ void CEmulApp::tcp_udp_close(){
     if (is_udp_flow()) {
         m_api->disconnect(m_ctx,m_flow);
     }else{
-        tcp_usrclosed(m_ctx,&m_flow->m_tcp);
+        tcp_usrclosed(m_flow->m_ctx,&m_flow->m_tcp);
         if (get_interrupt()==false) {
             m_api->tx_tcp_output(m_ctx,m_flow);
         }
@@ -276,7 +276,7 @@ void CEmulApp::on_tick(){
 
 void CEmulApp::run_cmd_delay_rand(htw_ticks_t min_ticks,
                                  htw_ticks_t max_ticks){
-    uint32_t rnd=m_ctx->m_rand->getRandomInRange(min_ticks,max_ticks);
+    uint32_t rnd=m_ctx->m_tcp_ctx->m_rand->getRandomInRange(min_ticks,max_ticks);
     run_cmd_delay(rnd);
 }
 
@@ -294,9 +294,9 @@ void CEmulApp::run_cmd_delay(htw_ticks_t ticks){
     }
     /* make sure the timer is not running*/
     if (m_timer.is_running()) {
-        m_ctx->m_timer_w.timer_stop(&m_timer);
+        m_ctx->m_tcp_ctx->m_timer_w.timer_stop(&m_timer);
     }
-    m_ctx->m_timer_w.timer_start(&m_timer,ticks);
+    m_ctx->m_tcp_ctx->m_timer_w.timer_start(&m_timer,ticks);
 }
 
 
@@ -612,6 +612,13 @@ int CEmulApp::on_bh_rx_bytes(uint32_t rx_bytes,
     set_interrupt(false);
     return(0);
 }
+
+#ifdef  TREX_SIM
+void CEmulApp::set_flow_ctx(CTcpPerThreadCtx * ctx, CTcpFlow * flow) {
+    m_ctx = DEFAULT_PROFILE_CTX(ctx);
+    m_flow = flow;
+}
+#endif
 
 
 void CEmulAppProgram::add_cmd(CEmulAppCmd & cmd){

--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -253,18 +253,18 @@ void CEmulApp::force_stop_timer(){
     if (get_timer_init_done()) {
         if (m_timer.is_running()){
             /* must stop timer before free the memory */
-            m_ctx->m_tcp_ctx->m_timer_w.timer_stop(&m_timer);
+            m_pctx->m_ctx->m_timer_w.timer_stop(&m_timer);
         }
     }
 }
 
 void CEmulApp::tcp_udp_close(){
     if (is_udp_flow()) {
-        m_api->disconnect(m_ctx,m_flow);
+        m_api->disconnect(m_pctx,m_flow);
     }else{
-        tcp_usrclosed(m_flow->m_ctx,&m_flow->m_tcp);
+        tcp_usrclosed(m_flow->m_pctx,&m_flow->m_tcp);
         if (get_interrupt()==false) {
-            m_api->tx_tcp_output(m_ctx,m_flow);
+            m_api->tx_tcp_output(m_pctx,m_flow);
         }
     }
 }
@@ -276,7 +276,7 @@ void CEmulApp::on_tick(){
 
 void CEmulApp::run_cmd_delay_rand(htw_ticks_t min_ticks,
                                  htw_ticks_t max_ticks){
-    uint32_t rnd=m_ctx->m_tcp_ctx->m_rand->getRandomInRange(min_ticks,max_ticks);
+    uint32_t rnd=m_pctx->m_ctx->m_rand->getRandomInRange(min_ticks,max_ticks);
     run_cmd_delay(rnd);
 }
 
@@ -294,9 +294,9 @@ void CEmulApp::run_cmd_delay(htw_ticks_t ticks){
     }
     /* make sure the timer is not running*/
     if (m_timer.is_running()) {
-        m_ctx->m_tcp_ctx->m_timer_w.timer_stop(&m_timer);
+        m_pctx->m_ctx->m_timer_w.timer_stop(&m_timer);
     }
-    m_ctx->m_tcp_ctx->m_timer_w.timer_start(&m_timer,ticks);
+    m_pctx->m_ctx->m_timer_w.timer_start(&m_timer,ticks);
 }
 
 
@@ -341,7 +341,7 @@ void CEmulApp::process_cmd(CEmulAppCmd * cmd){
 
             m_state=te_SEND;
             if (get_interrupt()==false) {
-                m_api->tx_tcp_output(m_ctx,m_flow);
+                m_api->tx_tcp_output(m_pctx,m_flow);
             }
         }
         break;
@@ -461,7 +461,7 @@ void CEmulApp::process_cmd(CEmulAppCmd * cmd){
     case tcCLOSE_PKT:
         {
             m_state=te_NONE;
-            m_api->disconnect(m_ctx,m_flow);
+            m_api->disconnect(m_pctx,m_flow);
             next();
         }
         break;
@@ -528,7 +528,7 @@ void CEmulApp::start(bool interrupt){
 
 void CEmulApp::do_disconnect(){
     if (!m_flow->is_close_was_called()){
-        m_api->disconnect(m_ctx,m_flow);
+        m_api->disconnect(m_pctx,m_flow);
     }
 }
 
@@ -615,7 +615,7 @@ int CEmulApp::on_bh_rx_bytes(uint32_t rx_bytes,
 
 #ifdef  TREX_SIM
 void CEmulApp::set_flow_ctx(CTcpPerThreadCtx * ctx, CTcpFlow * flow) {
-    m_ctx = DEFAULT_PROFILE_CTX(ctx);
+    m_pctx = DEFAULT_PROFILE_CTX(ctx);
     m_flow = flow;
 }
 #endif

--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -262,7 +262,7 @@ void CEmulApp::tcp_udp_close(){
     if (is_udp_flow()) {
         m_api->disconnect(m_pctx,m_flow);
     }else{
-        tcp_usrclosed(m_flow->m_pctx,&m_flow->m_tcp);
+        tcp_usrclosed(m_pctx,&m_flow->m_tcp);
         if (get_interrupt()==false) {
             m_api->tx_tcp_output(m_pctx,m_flow);
         }

--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -374,6 +374,7 @@ typedef std::vector<CEmulAppCmd> tcp_app_cmd_list_t;
 
 class CTcpFlow;
 class CUdpFlow;
+class CPerProfileCtx;
 class CTcpPerThreadCtx;
 
 /* Api from application to TCP */
@@ -392,11 +393,11 @@ public:
 
     virtual uint32_t rx_drain(CTcpFlow * flow)=0;
 
-    virtual void tx_tcp_output(CTcpPerThreadCtx * ctx,
+    virtual void tx_tcp_output(CPerProfileCtx * ctx,
                                CTcpFlow *         flow)=0;
 
 public:
-    virtual void disconnect(CTcpPerThreadCtx * ctx,
+    virtual void disconnect(CPerProfileCtx * ctx,
                             CTcpFlow *         flow)=0;
 
 public:
@@ -552,7 +553,7 @@ public:
 
     CEmulApp() {
         m_flow = (CTcpFlow *)0;
-        m_ctx =(CTcpPerThreadCtx *)0;
+        m_ctx =(CPerProfileCtx *)0;
         m_api=(CEmulAppApi *)0;
         m_program =(CEmulAppProgram *)0;
         m_flags=0;
@@ -719,13 +720,17 @@ public:
         m_program = prog;
     }
 
-    void set_flow_ctx(CTcpPerThreadCtx *  ctx,
+    void set_flow_ctx(CPerProfileCtx *  ctx,
                       CTcpFlow *          flow){
         m_ctx = ctx;
         m_flow = flow;
     }
+#ifdef  TREX_SIM
+    void set_flow_ctx(CTcpPerThreadCtx *  ctx,
+                      CTcpFlow *          flow);
+#endif
 
-    void set_udp_flow_ctx(CTcpPerThreadCtx *  ctx,
+    void set_udp_flow_ctx(CPerProfileCtx *  ctx,
                           CUdpFlow *          flow){
         m_ctx = ctx;
         m_flow = (CTcpFlow*)flow;
@@ -831,7 +836,7 @@ private:
 private:
     /* cache line 0 */
     CTcpFlow *              m_flow;
-    CTcpPerThreadCtx *      m_ctx;
+    CPerProfileCtx *        m_ctx;
     CEmulAppApi *           m_api; 
 
     CEmulTxQueue            m_q;

--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -393,11 +393,11 @@ public:
 
     virtual uint32_t rx_drain(CTcpFlow * flow)=0;
 
-    virtual void tx_tcp_output(CPerProfileCtx * ctx,
+    virtual void tx_tcp_output(CPerProfileCtx * pctx,
                                CTcpFlow *         flow)=0;
 
 public:
-    virtual void disconnect(CPerProfileCtx * ctx,
+    virtual void disconnect(CPerProfileCtx * pctx,
                             CTcpFlow *         flow)=0;
 
 public:
@@ -553,7 +553,7 @@ public:
 
     CEmulApp() {
         m_flow = (CTcpFlow *)0;
-        m_ctx =(CPerProfileCtx *)0;
+        m_pctx =(CPerProfileCtx *)0;
         m_api=(CEmulAppApi *)0;
         m_program =(CEmulAppProgram *)0;
         m_flags=0;
@@ -720,9 +720,9 @@ public:
         m_program = prog;
     }
 
-    void set_flow_ctx(CPerProfileCtx *  ctx,
+    void set_flow_ctx(CPerProfileCtx *  pctx,
                       CTcpFlow *          flow){
-        m_ctx = ctx;
+        m_pctx = pctx;
         m_flow = flow;
     }
 #ifdef  TREX_SIM
@@ -730,9 +730,9 @@ public:
                       CTcpFlow *          flow);
 #endif
 
-    void set_udp_flow_ctx(CPerProfileCtx *  ctx,
+    void set_udp_flow_ctx(CPerProfileCtx *  pctx,
                           CUdpFlow *          flow){
-        m_ctx = ctx;
+        m_pctx = pctx;
         m_flow = (CTcpFlow*)flow;
     }
 
@@ -836,7 +836,7 @@ private:
 private:
     /* cache line 0 */
     CTcpFlow *              m_flow;
-    CPerProfileCtx *        m_ctx;
+    CPerProfileCtx *        m_pctx;
     CEmulAppApi *           m_api; 
 
     CEmulTxQueue            m_q;

--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -658,7 +658,7 @@ void CTcpPerThreadCtx::update_tuneables(CTcpTuneables *tune) {
     #endif
 }
 
-void CTcpPerThreadCtx::resize_stats(uint32_t profile_id) {
+void CTcpPerThreadCtx::resize_stats(profile_id_t profile_id) {
     uint16_t num_of_tg_ids = get_template_ro(profile_id)->get_num_of_tg_ids();
     get_tcpstat(profile_id)->Resize(num_of_tg_ids);
     get_udpstat(profile_id)->Resize(num_of_tg_ids);
@@ -716,7 +716,7 @@ bool CTcpPerThreadCtx::Create(uint32_t size,
 }
 
 
-void CTcpPerThreadCtx::init_sch_rampup(uint32_t profile_id){
+void CTcpPerThreadCtx::init_sch_rampup(profile_id_t profile_id){
         /* calc default fif rate*/
         astf_thread_id_t max_threads = get_template_rw(profile_id)->get_max_threads();
         set_fif_d_time(get_template_ro(profile_id)->get_delta_tick_sec_thread(max_threads), profile_id);
@@ -734,13 +734,13 @@ void CTcpPerThreadCtx::init_sch_rampup(uint32_t profile_id){
 
 
 
-void CTcpPerThreadCtx::call_startup(uint32_t profile_id){
+void CTcpPerThreadCtx::call_startup(profile_id_t profile_id){
     if ( is_client_side() ){
         init_sch_rampup(profile_id);
     }
 }
 
-void CTcpPerThreadCtx::delete_startup(uint32_t profile_id) {
+void CTcpPerThreadCtx::delete_startup(profile_id_t profile_id) {
     if (get_sch_rampup(profile_id)) {
         delete get_sch_rampup(profile_id);
         set_sch_rampup(nullptr, profile_id);
@@ -758,7 +758,7 @@ void CTcpPerThreadCtx::Delete(){
     }
 }
 
-void CTcpPerThreadCtx::append_server_ports(uint32_t profile_id) {
+void CTcpPerThreadCtx::append_server_ports(profile_id_t profile_id) {
     CPerProfileCtx * pctx = get_profile_ctx(profile_id);
     CAstfDbRO * template_db = pctx->m_template_ro;
     std::vector<uint16_t> server_ports;
@@ -781,7 +781,7 @@ void CTcpPerThreadCtx::append_server_ports(uint32_t profile_id) {
     }
 }
 
-void CTcpPerThreadCtx::remove_server_ports(uint32_t profile_id) {
+void CTcpPerThreadCtx::remove_server_ports(profile_id_t profile_id) {
     CPerProfileCtx * pctx = get_profile_ctx(profile_id);
     CAstfDbRO * template_db = pctx->m_template_ro;
     std::vector<uint16_t> server_ports;

--- a/src/44bsd/tcp_timer.cpp
+++ b/src/44bsd/tcp_timer.cpp
@@ -239,7 +239,7 @@ tcp_timers(CPerProfileCtx * pctx,struct tcpcb *tp, int timer){
              * correspondent TCP to respond.
              */
             INC_STAT(pctx, tg_id, tcps_keepprobe);
-            tcp_respond(pctx,tp, 
+            tcp_respond(pctx,tp,
                 tp->rcv_nxt, tp->snd_una - 1, 0);
             tp->t_timer[TCPT_KEEP] = ctx->tcp_keepintvl;
         } else

--- a/src/44bsd/tcp_timer.cpp
+++ b/src/44bsd/tcp_timer.cpp
@@ -58,13 +58,13 @@ int tcp_totbackoff = 511;   /* sum of tcp_backoff[] */
 /*
  * Fast timeout routine for processing delayed acks
  */
-void tcp_fasttimo(CPerProfileCtx * ctx, struct tcpcb *tp){
+void tcp_fasttimo(CPerProfileCtx * pctx, struct tcpcb *tp){
 
         if (tp->t_flags & TF_DELACK) {
             tp->t_flags &= ~TF_DELACK;
             tp->t_flags |= TF_ACKNOW;
-            INC_STAT(ctx, tp->m_flow->m_tg_id, tcps_delack);
-            (void) tcp_output(ctx,tp);
+            INC_STAT(pctx, tp->m_flow->m_tg_id, tcps_delack);
+            (void) tcp_output(pctx,tp);
         }
 }
 
@@ -91,10 +91,10 @@ void tcp_canceltimers(struct tcpcb *tp){
  * TCP timer processing.
  */
 struct tcpcb *
-tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
+tcp_timers(CPerProfileCtx * pctx,struct tcpcb *tp, int timer){
     register int rexmt;
     uint16_t tg_id = tp->m_flow->m_tg_id;
-    CTcpPerThreadCtx * tcp_ctx = ctx->m_tcp_ctx;
+    CTcpPerThreadCtx * ctx = pctx->m_ctx;
 
     switch (timer) {
 
@@ -106,10 +106,10 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
      */
     case TCPT_2MSL:
         if (tp->t_state != TCPS_TIME_WAIT &&
-            tp->t_idle <= tcp_ctx->tcp_maxidle)
-            tp->t_timer[TCPT_2MSL] = tcp_ctx->tcp_keepintvl;
+            tp->t_idle <= ctx->tcp_maxidle)
+            tp->t_timer[TCPT_2MSL] = ctx->tcp_keepintvl;
         else
-            tp = tcp_close(ctx,tp);
+            tp = tcp_close(pctx,tp);
         break;
 
     /*
@@ -120,16 +120,16 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
     case TCPT_REXMT:
         if (++tp->t_rxtshift > TCP_MAXRXTSHIFT) {
             tp->t_rxtshift = TCP_MAXRXTSHIFT;
-            INC_STAT(ctx, tg_id, tcps_timeoutdrop);
-            tp = tcp_drop_now(ctx,tp, tp->t_softerror ?
+            INC_STAT(pctx, tg_id, tcps_timeoutdrop);
+            tp = tcp_drop_now(pctx,tp, tp->t_softerror ?
                 tp->t_softerror : TCP_US_ETIMEDOUT);
             break;
         }
         if (tp->t_state < TCPS_ESTABLISHED){
             rexmt = TCP_REXMTVAL(tp) * tcp_syn_backoff[tp->t_rxtshift];
-            INC_STAT(ctx, tg_id, tcps_rexmttimeo_syn);
+            INC_STAT(pctx, tg_id, tcps_rexmttimeo_syn);
         }else{
-            INC_STAT(ctx, tg_id, tcps_rexmttimeo);
+            INC_STAT(pctx, tg_id, tcps_rexmttimeo);
             rexmt = TCP_REXMTVAL(tp) * tcp_backoff[tp->t_rxtshift];
         }
 
@@ -186,7 +186,7 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
         tp->snd_ssthresh = win * tp->t_maxseg;
         tp->t_dupacks = 0;
         }
-        (void) tcp_output(ctx,tp);
+        (void) tcp_output(pctx,tp);
         break;
 
     /*
@@ -194,7 +194,7 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
      * Force a byte to be output, if possible.
      */
     case TCPT_PERSIST:
-        INC_STAT(ctx, tg_id, tcps_persisttimeo);
+        INC_STAT(pctx, tg_id, tcps_persisttimeo);
         /*
          * Hack: if the peer is dead/unreachable, we do not
          * time out if the window is closed.  After a full
@@ -203,15 +203,15 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
          * backoff that we would use if retransmitting.
          */
         if (tp->t_rxtshift == TCP_MAXRXTSHIFT &&
-            (tp->t_idle >= tcp_ctx->tcp_maxpersistidle ||
+            (tp->t_idle >= ctx->tcp_maxpersistidle ||
             tp->t_idle >= TCP_REXMTVAL(tp) * tcp_totbackoff)) {
-            INC_STAT(ctx, tg_id, tcps_persistdrop);
-            tp = tcp_drop_now(ctx,tp, TCP_US_ETIMEDOUT);
+            INC_STAT(pctx, tg_id, tcps_persistdrop);
+            tp = tcp_drop_now(pctx,tp, TCP_US_ETIMEDOUT);
             break;
         }
-        tcp_setpersist(ctx,tp);
+        tcp_setpersist(pctx,tp);
         tp->t_force = 1;
-        (void) tcp_output(ctx,tp);
+        (void) tcp_output(pctx,tp);
         tp->t_force = 0;
         break;
 
@@ -220,11 +220,11 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
      * or drop connection if idle for too long.
      */
     case TCPT_KEEP:
-        INC_STAT(ctx, tg_id, tcps_keeptimeo);
+        INC_STAT(pctx, tg_id, tcps_keeptimeo);
         if (tp->t_state < TCPS_ESTABLISHED)
             goto dropit;
         if (tp->m_socket.so_options & US_SO_KEEPALIVE) {
-                if (tp->t_idle >= tcp_ctx->tcp_keepidle + tcp_ctx->tcp_maxidle)
+                if (tp->t_idle >= ctx->tcp_keepidle + ctx->tcp_maxidle)
                 goto dropit;
             /*
              * Send a packet designed to force a response
@@ -238,16 +238,16 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
              * by the protocol spec, this requires the
              * correspondent TCP to respond.
              */
-            INC_STAT(ctx, tg_id, tcps_keepprobe);
-            tcp_respond(ctx,tp, 
+            INC_STAT(pctx, tg_id, tcps_keepprobe);
+            tcp_respond(pctx,tp, 
                 tp->rcv_nxt, tp->snd_una - 1, 0);
-            tp->t_timer[TCPT_KEEP] = tcp_ctx->tcp_keepintvl;
+            tp->t_timer[TCPT_KEEP] = ctx->tcp_keepintvl;
         } else
-            tp->t_timer[TCPT_KEEP] = tcp_ctx->tcp_keepidle;
+            tp->t_timer[TCPT_KEEP] = ctx->tcp_keepidle;
         break;
     dropit:
-        INC_STAT(ctx, tg_id, tcps_keepdrops);
-        tp = tcp_drop_now(ctx,tp, TCP_US_ETIMEDOUT);
+        INC_STAT(pctx, tg_id, tcps_keepdrops);
+        tp = tcp_drop_now(pctx,tp, TCP_US_ETIMEDOUT);
         break;
     }
     return (tp);
@@ -260,7 +260,7 @@ tcp_timers(CPerProfileCtx * ctx,struct tcpcb *tp, int timer){
  * Updates the timers in all active tcb's and
  * causes finite state machine actions if timers expire.
  */
-void tcp_slowtimo(CPerProfileCtx * ctx, struct tcpcb *tp)
+void tcp_slowtimo(CPerProfileCtx * pctx, struct tcpcb *tp)
 {
     int i;
 
@@ -269,7 +269,7 @@ void tcp_slowtimo(CPerProfileCtx * ctx, struct tcpcb *tp)
 
     for (i = 0; i < TCPT_NTIMERS; i++) {
         if (tp->t_timer[i] && --tp->t_timer[i] == 0) {
-            tcp_timers(ctx,tp, i);
+            tcp_timers(pctx,tp, i);
             if (tp->t_state == TCPS_CLOSED) {
                 return;
             }

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -1056,10 +1056,16 @@ public:
         m_profiles[profile_id]->m_profile_id = profile_id;
         m_profiles[profile_id]->m_stop_id = stop_id == 0 ? 1: stop_id;
     }
-    void remove_profile_ctx(uint32_t profile_id) {
-        assert(is_profile_ctx(profile_id));
-        //delete m_profiles[profile_id];
-        //m_profiles.erase(profile_id);
+    void cleanup_inactive_profiles() {
+        for (auto it = m_profiles.begin(); it != m_profiles.end(); ) {
+            if (!it->second->is_active()) {
+                delete it->second;
+                m_profiles.erase(it);
+            }
+            else {
+                it++;
+            }
+        }
     }
 
     int profile_flow_cnt(uint32_t profile_id) { return get_profile_ctx(profile_id)->m_flow_cnt; }

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -1060,10 +1060,10 @@ public:
         for (auto it = m_profiles.begin(); it != m_profiles.end(); ) {
             if (!it->second->is_active()) {
                 delete it->second;
-                m_profiles.erase(it);
+                it = m_profiles.erase(it);
             }
             else {
-                it++;
+                ++it;
             }
         }
     }

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -1046,6 +1046,7 @@ public:
         return m_profiles[profile_id];
     }
     CPerProfileCtx* get_first_profile_ctx() {
+        assert(m_profiles.size() != 0);
         return m_profiles.begin()->second;
     }
     void create_profile_ctx(profile_id_t profile_id) {

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -895,6 +895,7 @@ public:
         if (m_flow_cnt == 0 && !is_active()) {
             if (m_on_stopped_cb) {
                 m_on_stopped_cb(m_cb_data, m_profile_id);
+                m_on_stopped_cb = nullptr;
             }
         }
     }

--- a/src/44bsd/udp.cpp
+++ b/src/44bsd/udp.cpp
@@ -43,21 +43,21 @@ void CUdpStats::Resize(uint16_t new_num_of_tg_ids){
     Init(new_num_of_tg_ids);
 }
 
-void CUdpFlow::Create(CPerProfileCtx *ctx,
+void CUdpFlow::Create(CPerProfileCtx *pctx,
                       bool client, uint16_t tg_id){
-    CFlowBase::Create(ctx, tg_id);
+    CFlowBase::Create(pctx, tg_id);
     m_keep_alive_timer.reset();
     m_keep_alive_timer.m_type = ttUDP_FLOW; 
-    m_mbuf_socket = ctx->m_tcp_ctx->m_mbuf_socket;
+    m_mbuf_socket = pctx->m_ctx->m_mbuf_socket;
     if (client){
-        INC_UDP_STAT(m_ctx, m_tg_id, udps_connects);
+        INC_UDP_STAT(m_pctx, m_tg_id, udps_connects);
     }else{
-        INC_UDP_STAT(m_ctx, m_tg_id, udps_accepts);
+        INC_UDP_STAT(m_pctx, m_tg_id, udps_accepts);
     }
 }
 
 void CUdpFlow::Delete(){
-    INC_UDP_STAT(m_ctx, m_tg_id, udps_closed);
+    INC_UDP_STAT(m_pctx, m_tg_id, udps_closed);
     disconnect();
 }
 
@@ -70,7 +70,7 @@ void CUdpFlow::init(){
     m_keepaive_ticks  =  tw_time_msec_to_ticks(1000);
 
     m_keepalive=1;
-    m_ctx->m_tcp_ctx->m_timer_w.timer_start(&m_keep_alive_timer,m_keepaive_ticks);
+    m_pctx->m_ctx->m_timer_w.timer_start(&m_keep_alive_timer,m_keepaive_ticks);
 }
 
 
@@ -116,14 +116,14 @@ rte_mbuf_t   * CUdpFlow::alloc_and_build(CMbufBuffer *      buf){
     int hlen = ftp->m_offset_l4+UDP_HEADER_LEN;
     rte_mbuf_t * m;
     if ( (hlen+buf->m_t_bytes)>=MAX_PKT_SIZE){
-        INC_UDP_STAT(m_ctx, m_tg_id, udps_pkt_toobig);
+        INC_UDP_STAT(m_pctx, m_tg_id, udps_pkt_toobig);
         /* drop the packet */
         return(0);
     }
 
     m=pktmbuf_alloc(hlen);
     if (m==0) {
-        INC_UDP_STAT(m_ctx, m_tg_id, udps_nombuf);
+        INC_UDP_STAT(m_pctx, m_tg_id, udps_nombuf);
         /* drop the packet */
         return(0);
     }
@@ -154,7 +154,7 @@ rte_mbuf_t   * CUdpFlow::alloc_and_build(CMbufBuffer *      buf){
 
         rte_mbuf_t   * mi = pktmbuf_alloc_small();
         if (mi==0) {
-            INC_UDP_STAT(m_ctx, m_tg_id, udps_nombuf);
+            INC_UDP_STAT(m_pctx, m_tg_id, udps_nombuf);
             rte_pktmbuf_free(m);
             return(0);
         }
@@ -180,11 +180,11 @@ void CUdpFlow::send_pkt(CMbufBuffer *      buf){
     assert(utl_rte_pktmbuf_verify(m)==0);
     #endif
 
-    INC_UDP_STAT(m_ctx, m_tg_id, udps_sndpkt);
-    INC_UDP_STAT_CNT(m_ctx, m_tg_id, udps_sndbyte,buf->m_t_bytes);
+    INC_UDP_STAT(m_pctx, m_tg_id, udps_sndpkt);
+    INC_UDP_STAT_CNT(m_pctx, m_tg_id, udps_sndbyte,buf->m_t_bytes);
 
     /* send the packet */
-    m_ctx->m_tcp_ctx->m_cb->on_tx(m_ctx->m_tcp_ctx,0,m);
+    m_pctx->m_ctx->m_cb->on_tx(m_pctx->m_ctx,0,m);
 }
 
 
@@ -194,7 +194,7 @@ void CUdpFlow::disconnect(){
     }
     /* stop the timers, apps etc*/
     if (m_keep_alive_timer.is_running()){
-        m_ctx->m_tcp_ctx->m_timer_w.timer_stop(&m_keep_alive_timer);
+        m_pctx->m_ctx->m_timer_w.timer_stop(&m_keep_alive_timer);
     }
     m_closed=true;
 }
@@ -203,17 +203,17 @@ void CUdpFlow::set_keepalive(uint64_t  msec){
     m_keepalive=1;
     m_keepaive_ticks  =  tw_time_msec_to_ticks(msec);
     /* stop and restart the timer with new time */
-    m_ctx->m_tcp_ctx->m_timer_w.timer_stop(&m_keep_alive_timer);
-    m_ctx->m_tcp_ctx->m_timer_w.timer_start(&m_keep_alive_timer,m_keepaive_ticks);
+    m_pctx->m_ctx->m_timer_w.timer_stop(&m_keep_alive_timer);
+    m_pctx->m_ctx->m_timer_w.timer_start(&m_keep_alive_timer,m_keepaive_ticks);
 }
 
 
 void CUdpFlow::on_tick(){
     if (m_keepalive==0) {
         m_keepalive=1;
-        m_ctx->m_tcp_ctx->m_timer_w.timer_start(&m_keep_alive_timer,m_keepaive_ticks);
+        m_pctx->m_ctx->m_timer_w.timer_start(&m_keep_alive_timer,m_keepaive_ticks);
     }else{
-        INC_UDP_STAT(m_ctx, m_tg_id, udps_keepdrops);
+        INC_UDP_STAT(m_pctx, m_tg_id, udps_keepdrops);
         disconnect();
     }
 }
@@ -262,8 +262,8 @@ void CUdpFlow::on_rx_packet(struct rte_mbuf *m,
 
 
     udp_pktmbuf_fix_mbuf(m,(uint16_t)offset_l7,(uint16_t)total_l7_len);
-    INC_UDP_STAT(m_ctx, m_tg_id, udps_rcvpkt);
-    INC_UDP_STAT_CNT(m_ctx, m_tg_id, udps_rcvbyte,total_l7_len);
+    INC_UDP_STAT(m_pctx, m_tg_id, udps_rcvpkt);
+    INC_UDP_STAT_CNT(m_pctx, m_tg_id, udps_rcvbyte,total_l7_len);
     m_keepalive=0;
     m_app.on_bh_rx_pkts(0,m); /* count the packets */
 }

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -48,6 +48,7 @@ CAstfDB::CAstfDB(){
         exit(-1);
     }
     m_topo_mngr = new TopoMngr();
+    m_factor = -1.0;
 }
 
 
@@ -71,9 +72,12 @@ bool CAstfDB::validate_profile(Json::Value profile,std::string & err){
 
 
 
-static double cps_factor(double cps){
-    return ( CGlobalInfo::m_options.m_factor*cps );
-
+double CAstfDB::cps_factor(double cps){
+    if (m_factor > 0.0) {
+        return ( m_factor*cps );
+    } else {
+        return ( CGlobalInfo::m_options.m_factor*cps );
+    }
 }
 
 void CTcpTuneables::dump(FILE *fd) {

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -36,7 +36,7 @@ inline std::string methodName(const std::string& prettyFunction)
 #define __METHOD_NAME__ methodName(__PRETTY_FUNCTION__)
 
 // make the class singleton
-std::unordered_map<uint32_t, CAstfDB*> CAstfDB::m_pInstances;
+std::unordered_map<profile_id_t, CAstfDB*> CAstfDB::m_pInstances;
 
 
 CAstfDB::CAstfDB(){

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -36,7 +36,7 @@ inline std::string methodName(const std::string& prettyFunction)
 #define __METHOD_NAME__ methodName(__PRETTY_FUNCTION__)
 
 // make the class singleton
-std::unordered_map<profile_id_t, CAstfDB*> CAstfDB::m_pInstances;
+std::unordered_map<profile_id_t, CAstfDB> CAstfDB::m_instances;
 
 
 CAstfDB::CAstfDB(){

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -919,8 +919,9 @@ bool CAstfDB::read_tunables(CTcpTuneables *tune, Json::Value tune_json) {
 }
 
 ClientCfgDB  *CAstfDB::get_client_cfg_db() {
+    static ClientCfgDB g_dummy;
     if (m_client_config_info==0) {
-        return  &m_client_config_db;
+        return  &g_dummy;
     }else{
         return m_client_config_info;
     }

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -238,6 +238,7 @@ class CTcpDataAssocTranslation {
     void insert_vec(const CTcpDataAssocParams &params, CEmulAppProgram *prog, CTcpTuneables *tune, uint32_t temp_idx);
     void dump(FILE *fd);
     void clear();
+    void enumerate_server_ports(std::vector<uint16_t>& ports, bool is_stream);
 
  private:
     assoc_map_t m_map;
@@ -321,6 +322,10 @@ class CAstfDbRO {
 
     // for tests in simulation
     void set_test_assoc_table(uint16_t port, CEmulAppProgram *prog, CTcpTuneables *tune);
+
+    void enumerate_server_ports(std::vector<uint16_t>& ports, bool is_stream) {
+        m_assoc_trans.enumerate_server_ports(ports, is_stream);
+    }
  private:
     uint8_t                         m_init;
     double                          m_cps_sum;
@@ -367,23 +372,23 @@ class CAstfDB  : public CTRexDummyCommand  {
 
  public:
     // make the class singelton
-    static CAstfDB *instance() {
-        if (! m_pInstance) {
-            m_pInstance = new CAstfDB();
-            m_pInstance->m_json_initiated = false;
+    static CAstfDB *instance(uint32_t profile_id = 0) {
+        if (m_pInstances.find(profile_id) == m_pInstances.end()) {
+            m_pInstances[profile_id] = new CAstfDB();
+            m_pInstances[profile_id]->m_json_initiated = false;
         }
-        return m_pInstance;
+        return m_pInstances[profile_id];
     }
 
-    static void free_instance(){
-        if (m_pInstance){
-            delete m_pInstance;
-            m_pInstance=0;
+    static void free_instance(uint32_t profile_id = 0){
+        if (m_pInstances.find(profile_id) != m_pInstances.end()){
+            delete m_pInstances[profile_id];
+            m_pInstances.erase(profile_id);
         }
     }
 
-    static bool has_instance() {
-        return m_pInstance != nullptr;
+    static bool has_instance(uint32_t profile_id = 0) {
+        return m_pInstances.find(profile_id) != m_pInstances.end();
     }
 
     TopoMngr* get_topo() {
@@ -437,6 +442,7 @@ class CAstfDB  : public CTRexDummyCommand  {
     void set_client_cfg_db(ClientCfgDB * client_config_info){
         m_client_config_info = client_config_info;
     }
+    ClientCfgDB  *get_client_cfg_db();
 
     // called *once* by each core, using socket_id associated with the core 
     // multi-threaded need to be protected / per socket read-only data 
@@ -446,7 +452,7 @@ class CAstfDB  : public CTRexDummyCommand  {
     // multi-threaded need to be protected 
     CAstfTemplatesRW *get_db_template_rw(uint8_t socket_id, CTupleGeneratorSmart *g_gen,
                                              uint16_t thread_id, uint16_t max_threads, uint16_t dual_port_id);
-    void clear_db_ro_rw(CTupleGeneratorSmart *g_gen);
+    void clear_db_ro_rw(CTupleGeneratorSmart *g_gen, uint16_t thread_id=0);
     void get_latency_params(CTcpLatency &lat);
     CJsonData_err verify_data(uint16_t max_threads);
     CTcpTuneables *get_s_tune(uint32_t index) {return m_s_tuneables[index];}
@@ -476,7 +482,6 @@ private:
     float get_expected_bps() {return m_exp_bps;}
     bool is_initiated() {return m_json_initiated;}
     void dump();
-    ClientCfgDB  *get_client_db();
     std::string get_buf(uint32_t temp_index, uint32_t cmd_index, int side);
     bool convert_from_json(uint8_t socket_id);
     uint32_t get_buf_index(uint32_t program_index, uint32_t cmd_index);
@@ -569,7 +574,7 @@ private:
 
  private:
     bool m_json_initiated;
-    static CAstfDB *m_pInstance;
+    static std::unordered_map<uint32_t, CAstfDB*> m_pInstances;
     Json::Value  m_val;
     Json::Value  m_buffers;
 
@@ -581,6 +586,7 @@ private:
     // Data duplicated per memory socket
     CAstfDbRO           m_tcp_data[MAX_SOCKETS_SUPPORTED];
 
+    ClientCfgDB         m_client_config_db;
     ClientCfgDB        *m_client_config_info;
     CAstfJsonValidator *m_validator;
     TopoMngr           *m_topo_mngr;
@@ -588,6 +594,25 @@ private:
     uint16_t m_num_of_tg_ids;
     std::vector<std::string> m_tg_names; /* A vector that contains the names of the tg_ids 
     starting from tg_id = 1,2... . Remember that tg_id = 0 is unnamed */
+
+    std::unordered_map<uint16_t,CTupleGeneratorSmart*> m_smart_gen;
+public:
+    bool is_smart_gen(uint16_t thread_id) {
+        return (m_smart_gen.find(thread_id) != m_smart_gen.end());
+    }
+    CTupleGeneratorSmart* get_smart_gen(uint16_t thread_id) {
+        if (!is_smart_gen(thread_id)) {
+            m_smart_gen[thread_id] = new CTupleGeneratorSmart();
+        }
+        return m_smart_gen[thread_id];
+    }
+    void remove_smart_gen(uint16_t thread_id) {
+        if (is_smart_gen(thread_id)) {
+            m_smart_gen[thread_id]->Delete();
+            delete m_smart_gen[thread_id];
+            m_smart_gen.erase(thread_id);
+        }
+    }
 };
 
 #endif

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -372,7 +372,7 @@ class CAstfDB  : public CTRexDummyCommand  {
 
  public:
     // make the class singelton
-    static CAstfDB *instance(uint32_t profile_id = 0) {
+    static CAstfDB *instance(profile_id_t profile_id = 0) {
         if (m_pInstances.find(profile_id) == m_pInstances.end()) {
             m_pInstances[profile_id] = new CAstfDB();
             m_pInstances[profile_id]->m_json_initiated = false;
@@ -380,14 +380,14 @@ class CAstfDB  : public CTRexDummyCommand  {
         return m_pInstances[profile_id];
     }
 
-    static void free_instance(uint32_t profile_id = 0){
+    static void free_instance(profile_id_t profile_id = 0){
         if (m_pInstances.find(profile_id) != m_pInstances.end()){
             delete m_pInstances[profile_id];
             m_pInstances.erase(profile_id);
         }
     }
 
-    static bool has_instance(uint32_t profile_id = 0) {
+    static bool has_instance(profile_id_t profile_id = 0) {
         return m_pInstances.find(profile_id) != m_pInstances.end();
     }
 
@@ -574,7 +574,7 @@ private:
 
  private:
     bool m_json_initiated;
-    static std::unordered_map<uint32_t, CAstfDB*> m_pInstances;
+    static std::unordered_map<profile_id_t, CAstfDB*> m_pInstances;
     Json::Value  m_val;
     Json::Value  m_buffers;
 

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -373,22 +373,21 @@ class CAstfDB  : public CTRexDummyCommand  {
  public:
     // make the class singelton
     static CAstfDB *instance(profile_id_t profile_id = 0) {
-        if (m_pInstances.find(profile_id) == m_pInstances.end()) {
-            m_pInstances[profile_id] = new CAstfDB();
-            m_pInstances[profile_id]->m_json_initiated = false;
+        if (m_instances.find(profile_id) == m_instances.end()) {
+            CAstfDB& new_inst = m_instances[profile_id];
+            new_inst.m_json_initiated = false;
         }
-        return m_pInstances[profile_id];
+        return &m_instances[profile_id];
     }
 
     static void free_instance(profile_id_t profile_id = 0){
-        if (m_pInstances.find(profile_id) != m_pInstances.end()){
-            delete m_pInstances[profile_id];
-            m_pInstances.erase(profile_id);
+        if (m_instances.find(profile_id) != m_instances.end()){
+            m_instances.erase(profile_id);
         }
     }
 
     static bool has_instance(profile_id_t profile_id = 0) {
-        return m_pInstances.find(profile_id) != m_pInstances.end();
+        return m_instances.find(profile_id) != m_instances.end();
     }
 
     TopoMngr* get_topo() {
@@ -574,7 +573,7 @@ private:
 
  private:
     bool m_json_initiated;
-    static std::unordered_map<profile_id_t, CAstfDB*> m_pInstances;
+    static std::unordered_map<profile_id_t, CAstfDB> m_instances;
     Json::Value  m_val;
     Json::Value  m_buffers;
 

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -586,7 +586,6 @@ private:
     // Data duplicated per memory socket
     CAstfDbRO           m_tcp_data[MAX_SOCKETS_SUPPORTED];
 
-    ClientCfgDB         m_client_config_db;
     ClientCfgDB        *m_client_config_info;
     CAstfJsonValidator *m_validator;
     TopoMngr           *m_topo_mngr;

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -595,6 +595,8 @@ private:
     std::vector<std::string> m_tg_names; /* A vector that contains the names of the tg_ids 
     starting from tg_id = 1,2... . Remember that tg_id = 0 is unnamed */
 
+    double m_factor; /* initial multiplier factor */
+
     std::unordered_map<uint16_t,CTupleGeneratorSmart*> m_smart_gen;
 public:
     bool is_smart_gen(uint16_t thread_id) {
@@ -613,6 +615,9 @@ public:
             m_smart_gen.erase(thread_id);
         }
     }
+
+    void set_factor(double factor) { m_factor = factor; }
+    double cps_factor(double cps);
 };
 
 #endif

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -2778,9 +2778,7 @@ bool CFlowGenListPerThread::Create(uint32_t           thread_id,
     m_thread_id=thread_id;
 
     m_c_tcp=0;
-    m_c_tcp_io =0;
     m_s_tcp=0;
-    m_s_tcp_io=0;
     m_tcp_terminate=false;
     m_tcp_terminate_cnt=0;
     m_sched_accurate=false;

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -3745,7 +3745,7 @@ CNodeGenerator::handle_slow_messages(uint8_t type,
         break;
 
     case CGenNode::TCP_TX_FIF:
-        thread->handle_tx_fif(node,on_terminate);
+        thread->handle_tx_fif((CGenNodeTXFIF*)node,on_terminate);
         break;
 
     case CGenNode::TCP_TW:

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -621,7 +621,7 @@ class CPerProfileCtx;
 
 struct CGenNodeTXFIF : public CGenNodeBase {
 public:
-    CPerProfileCtx *    m_ctx;
+    CPerProfileCtx *    m_pctx;
 
     uint8_t             m_pad_end[104];
 
@@ -3118,7 +3118,7 @@ public:
     void unload_tcp_profile(uint32_t profile_id = 0, bool is_last = true);
     void Delete_tcp_ctx();
 
-    void generate_flow(bool &done, CPerProfileCtx * ctx);
+    void generate_flow(bool &done, CPerProfileCtx * pctx);
 
     void handle_rx_flush(CGenNode * node,bool on_terminate);
     void handle_tx_fif(CGenNodeTXFIF * node,bool on_terminate);

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -3114,8 +3114,9 @@ public:
     double tcp_get_tw_tick_in_sec();
 
     void Create_tcp_ctx();
-    void load_tcp_profile(uint32_t profile_id = 0, bool is_first = true);
-    void unload_tcp_profile(uint32_t profile_id = 0, bool is_last = true);
+    void load_tcp_profile(profile_id_t profile_id = 0, bool is_first = true);
+    void unload_tcp_profile(profile_id_t profile_id = 0, bool is_last = true);
+    void remove_tcp_profile(profile_id_t profile_id);
     void Delete_tcp_ctx();
 
     void generate_flow(bool &done, CPerProfileCtx * pctx);

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -619,6 +619,17 @@ public:
 
 class CPerProfileCtx;
 
+struct CGenNodeTXFIF : public CGenNodeBase {
+public:
+    CPerProfileCtx * m_ctx;
+
+    uint8_t             m_pad_end[104];
+
+    /* CACHE_LINE */
+    uint64_t            m_pad3[8];
+} __rte_cache_aligned;;
+
+
 struct CGenNode : public CGenNodeBase  {
 
 public:
@@ -651,10 +662,9 @@ public:
     uint16_t            m_nat_external_port; // NAT client port
     uint16_t            m_nat_pad[1];
     const ClientCfgBase *m_client_cfg;
-    CPerProfileCtx      *m_ctx;
     uint32_t            m_src_idx;
     uint32_t            m_dest_idx;
-    uint32_t            m_end_of_cache_line[4];
+    uint32_t            m_end_of_cache_line[6];
 
 
 public:
@@ -3111,7 +3121,7 @@ public:
     void generate_flow(bool &done, CPerProfileCtx * ctx);
 
     void handle_rx_flush(CGenNode * node,bool on_terminate);
-    void handle_tx_fif(CGenNode * node,bool on_terminate);
+    void handle_tx_fif(CGenNodeTXFIF * node,bool on_terminate);
     void handle_tw(CGenNode * node,bool on_terminate);
     uint16_t handle_rx_pkts(bool is_idle);
 
@@ -3384,6 +3394,7 @@ class CRXCoreIgnoreStat {
 static_assert(sizeof(CGenNodeCommand) == sizeof(CGenNode), "sizeof(CGenNodeCommand) != sizeof(CGenNode)" );
 static_assert(sizeof(CGenNodeNatInfo) == sizeof(CGenNode), "sizeof(CGenNodeNatInfo) != sizeof(CGenNode)" );
 static_assert(sizeof(CGenNodeLatencyPktInfo) == sizeof(CGenNode), "sizeof(CGenNodeLatencyPktInfo) != sizeof(CGenNode)" );
+static_assert(sizeof(CGenNodeTXFIF) == sizeof(CGenNode), "sizeof(CGenNodeTXFIF) != sizeof(CGenNode)" );
 
 static inline void rte_pause_or_delay_lowend() {
     if (unlikely( CGlobalInfo::m_options.m_is_sleepy_scheduler )) {

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -621,7 +621,7 @@ class CPerProfileCtx;
 
 struct CGenNodeTXFIF : public CGenNodeBase {
 public:
-    CPerProfileCtx * m_ctx;
+    CPerProfileCtx *    m_ctx;
 
     uint8_t             m_pad_end[104];
 
@@ -3114,8 +3114,8 @@ public:
     double tcp_get_tw_tick_in_sec();
 
     void Create_tcp_ctx();
-    void load_tcp_profile(uint32_t profile_id = 0);
-    void unload_tcp_profile(uint32_t profile_id = 0);
+    void load_tcp_profile(uint32_t profile_id = 0, bool is_first = true);
+    void unload_tcp_profile(uint32_t profile_id = 0, bool is_last = true);
     void Delete_tcp_ctx();
 
     void generate_flow(bool &done, CPerProfileCtx * ctx);

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -528,6 +528,10 @@ void CFlowGenListPerThread::load_tcp_profile(uint32_t profile_id, bool is_first)
 
         m_c_tcp->m_ft.reset_stats();
         m_s_tcp->m_ft.reset_stats();
+
+        // cleanup unused profile contexts (remained for stats references)
+        m_c_tcp->cleanup_inactive_profiles();
+        m_s_tcp->cleanup_inactive_profiles();
     }
     m_c_tcp->create_profile_ctx(profile_id);
     m_s_tcp->create_profile_ctx(profile_id);
@@ -573,10 +577,12 @@ void CFlowGenListPerThread::unload_tcp_profile(uint32_t profile_id, bool is_last
 
     if ( CAstfDB::has_instance(profile_id) ) {
         CAstfDB::instance(profile_id)->clear_db_ro_rw(nullptr, m_thread_id);
-    }
 
-    m_c_tcp->remove_profile_ctx(profile_id);
-    m_s_tcp->remove_profile_ctx(profile_id);
+        m_c_tcp->set_template_ro(nullptr, profile_id);
+        m_c_tcp->set_template_rw(nullptr, profile_id);
+        m_s_tcp->set_template_ro(nullptr, profile_id);
+        m_s_tcp->set_template_rw(nullptr, profile_id);
+    }
 
     if (is_last) {
         m_c_tcp->reset_tuneables();

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -521,17 +521,13 @@ void CFlowGenListPerThread::Create_tcp_ctx(void) {
     m_s_tcp->m_ft.set_udp_api(&m_udp_bh_api_impl_c);
 }
 
-void CFlowGenListPerThread::load_tcp_profile(uint32_t profile_id, bool is_first) {
+void CFlowGenListPerThread::load_tcp_profile(profile_id_t profile_id, bool is_first) {
     /* clear global statistics when new profile is started only */
     if (is_first) {
         m_stats.clear();    // moved from TrexAstfDpCore::create_tcp_batch()
 
-        m_c_tcp->m_ft.reset_stats();
-        m_s_tcp->m_ft.reset_stats();
-
-        // cleanup unused profile contexts (remained for stats references)
-        m_c_tcp->cleanup_inactive_profiles();
-        m_s_tcp->cleanup_inactive_profiles();
+        m_c_tcp->m_ft.m_sts.Clear();
+        m_s_tcp->m_ft.m_sts.Clear();
     }
     m_c_tcp->create_profile_ctx(profile_id);
     m_s_tcp->create_profile_ctx(profile_id);
@@ -574,7 +570,7 @@ void CFlowGenListPerThread::load_tcp_profile(uint32_t profile_id, bool is_first)
     m_s_tcp->call_startup(profile_id);
 }
 
-void CFlowGenListPerThread::unload_tcp_profile(uint32_t profile_id, bool is_last) {
+void CFlowGenListPerThread::unload_tcp_profile(profile_id_t profile_id, bool is_last) {
     m_s_tcp->remove_server_ports(profile_id);
 
     if ( CAstfDB::has_instance(profile_id) ) {
@@ -592,6 +588,11 @@ void CFlowGenListPerThread::unload_tcp_profile(uint32_t profile_id, bool is_last
 
         m_sched_accurate = false;
     }
+}
+
+void CFlowGenListPerThread::remove_tcp_profile(profile_id_t profile_id) {
+    m_s_tcp->remove_profile_ctx(profile_id);
+    m_c_tcp->remove_profile_ctx(profile_id);
 }
 
 void CFlowGenListPerThread::Delete_tcp_ctx(){

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -384,7 +384,7 @@ void CFlowGenListPerThread::generate_flow(bool &done, CPerProfileCtx * ctx){
     /* WARNING -- flow might be not valid here !!!! */
 }
 
-void CFlowGenListPerThread::handle_tx_fif(CGenNode * node,
+void CFlowGenListPerThread::handle_tx_fif(CGenNodeTXFIF * node,
                                               bool on_terminate){
     #ifdef TREX_SIM
     m_cur_time_sec =node->m_time;
@@ -411,12 +411,12 @@ void CFlowGenListPerThread::handle_tx_fif(CGenNode * node,
 
         if (!done) {
             node->m_time += node->m_ctx->m_fif_d_time;
-            m_node_gen.m_p_queue.push(node);
+            m_node_gen.m_p_queue.push((CGenNode*)node);
         }else{
-            free_node(node);
+            free_node((CGenNode*)node);
         }
     }else{
-        free_node(node);
+        free_node((CGenNode*)node);
     }
 }
 

--- a/src/gtest/bp_astf_interactive_gtest.cpp
+++ b/src/gtest/bp_astf_interactive_gtest.cpp
@@ -165,9 +165,79 @@ TEST_F(gt_astf_inter, astf_positive_6) {
 }
 
 
+TEST_F(gt_astf_inter, astf_positive_7) {
+    bool success;
+    CFlowGenList fl;
+    fl.Create();
+    fl.generate_p_thread_info(1);
+    CFlowGenListPerThread *lpt = fl.m_threads_info[0];
+    CAstfDB * lpastf;
 
+    uint32_t profile_id_1 = 0x12345678;
 
+    lpastf = CAstfDB::instance(profile_id_1);
+    success = lpastf->parse_file("automation/regression/data/astf_dns.json");
+    EXPECT_EQ(success, true);
 
+    try {
+        lpt->load_tcp_profile(profile_id_1); // DB 1 loaded
+        success = true;
+    } catch (const TrexException &ex) {
+        std::cerr << "ERROR in ASTF object creation: " << ex.what();
+        success = false;
+    }
+    EXPECT_EQ(success, true);
+
+    lpt->unload_tcp_profile(profile_id_1);
+
+    try {
+        lpt->load_tcp_profile(profile_id_1); // DB 1 loaded
+        success = true;
+    } catch (const TrexException &ex) {
+        std::cerr << "ERROR in ASTF object creation: " << ex.what();
+        success = false;
+    }
+    EXPECT_EQ(success, true);
+
+    uint32_t profile_id_2 = 0xfedcba98;
+
+    lpastf = CAstfDB::instance(profile_id_2);
+    success = lpastf->parse_file("automation/regression/data/astf_dns.json");
+    EXPECT_EQ(success, true);
+
+    try {
+        lpt->load_tcp_profile(profile_id_2); // DB 1 loaded again
+        success = true;
+    } catch (const TrexException &ex) {
+        std::cerr << "ERROR (as expected) in ASTF object creation: " << ex.what();
+        lpt->unload_tcp_profile(profile_id_2);
+        success = false;
+    }
+    EXPECT_EQ(success, false);
+
+    lpastf = CAstfDB::instance(profile_id_2);
+    success = lpastf->parse_file("automation/regression/data/astf_dns2.json");
+    EXPECT_EQ(success, true);
+
+    try {
+        lpt->load_tcp_profile(profile_id_2); // DB 2 loaded
+        success = true;
+    } catch (const TrexException &ex) {
+        std::cerr << "ERROR in ASTF object creation: " << ex.what();
+        success = false;
+    }
+    EXPECT_EQ(success, true);
+
+    /* TODO: run simulation of traffic here with --nc */
+
+    lpt->unload_tcp_profile(profile_id_1);
+    lpt->unload_tcp_profile(profile_id_2);
+
+    lpastf->free_instance(profile_id_1);
+    lpastf->free_instance(profile_id_2);
+    fl.clean_p_thread_info();
+    fl.Delete();
+}
 
 
 

--- a/src/gtest/bp_astf_interactive_gtest.cpp
+++ b/src/gtest/bp_astf_interactive_gtest.cpp
@@ -173,7 +173,7 @@ TEST_F(gt_astf_inter, astf_positive_7) {
     CFlowGenListPerThread *lpt = fl.m_threads_info[0];
     CAstfDB * lpastf;
 
-    uint32_t profile_id_1 = 0x12345678;
+    profile_id_t profile_id_1 = 0x12345678;
 
     lpastf = CAstfDB::instance(profile_id_1);
     success = lpastf->parse_file("automation/regression/data/astf_dns.json");
@@ -199,7 +199,7 @@ TEST_F(gt_astf_inter, astf_positive_7) {
     }
     EXPECT_EQ(success, true);
 
-    uint32_t profile_id_2 = 0xfedcba98;
+    profile_id_t profile_id_2 = 0xfedcba98;
 
     lpastf = CAstfDB::instance(profile_id_2);
     success = lpastf->parse_file("automation/regression/data/astf_dns.json");

--- a/src/gtest/bp_tcp_gtest.cpp
+++ b/src/gtest/bp_tcp_gtest.cpp
@@ -193,9 +193,9 @@ TEST_F(gt_tcp, tst5) {
     tst.m_verbose=true;
     tst.add_pkts(in_pkts);
     tst.expect(out_pkts,stdout);
-    tst.m_ctx.m_tcpstat.Dump(stdout);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoopack,2);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoobyte,40);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoopack,2);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoobyte,40);
 
     tst.Delete();
 }
@@ -218,12 +218,12 @@ TEST_F(gt_tcp, tst6) {
     tst.m_verbose=true;
     tst.add_pkts(in_pkts);
     tst.expect(out_pkts,stdout);
-    tst.m_ctx.m_tcpstat.Dump(stdout);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
 
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvduppack,1);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvdupbyte,20);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoopack,2);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoobyte,40);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvduppack,1);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvdupbyte,20);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoopack,2);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoobyte,40);
     tst.Delete();
 
 }
@@ -242,12 +242,12 @@ TEST_F(gt_tcp, tst7) {
     tst.m_verbose=true;
     tst.add_pkts(in_pkts);
     tst.expect(out_pkts,stdout);
-    tst.m_ctx.m_tcpstat.Dump(stdout);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
 
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvpartduppack,1);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvpartdupbyte,1);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoopack,2);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoobyte,40);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvpartduppack,1);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvpartdupbyte,1);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoopack,2);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoobyte,40);
 
     tst.Delete();
 }
@@ -267,12 +267,12 @@ TEST_F(gt_tcp, tst8) {
     tst.m_verbose=true;
     tst.add_pkts(in_pkts);
     tst.expect(out_pkts,stdout);
-    tst.m_ctx.m_tcpstat.Dump(stdout);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
 
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvduppack,2);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvdupbyte,40);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoopack,3);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoobyte,3040);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvduppack,2);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvdupbyte,40);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoopack,3);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoobyte,3040);
 
     tst.Delete();
 }
@@ -293,13 +293,13 @@ TEST_F(gt_tcp, tst9) {
     tst.m_verbose=true;
     tst.add_pkts(in_pkts);
     tst.expect(out_pkts,stdout);
-    tst.m_ctx.m_tcpstat.Dump(stdout);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
 
 
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvpartduppack,1);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvpartdupbyte,1);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoopack,3);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoobyte,61);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvpartduppack,1);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvpartdupbyte,1);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoopack,3);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoobyte,61);
     tst.Delete();
 }
 
@@ -324,11 +324,11 @@ TEST_F(gt_tcp, tst10) {
     tst.m_verbose=true;
     tst.add_pkts(in_pkts);
     tst.expect(out_pkts,stdout);
-    tst.m_ctx.m_tcpstat.Dump(stdout);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
 
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoopack,5);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoobyte,100);
-    EXPECT_EQ(tst.m_ctx.m_tcpstat.m_sts.tcps_rcvoopackdrop,1);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoopack,5);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoobyte,100);
+    EXPECT_EQ(tst.m_ctx.get_tcpstat()->m_sts.tcps_rcvoopackdrop,1);
     tst.Delete();
 }
 
@@ -349,7 +349,7 @@ TEST_F(gt_tcp, tst11) {
     tst.m_verbose=true;
     tst.add_pkts(in_pkts);
     tst.expect(out_pkts,stdout);
-    tst.m_ctx.m_tcpstat.Dump(stdout);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
     tst.Delete();
 }
 
@@ -385,7 +385,7 @@ TEST_F(gt_tcp, tst12) {
     EXPECT_EQ(tst.m_tcp_res.get_active_blocks(),0);
     EXPECT_EQ(tst.m_flow.m_tcp.rcv_nxt,500+560);
 
-    tst.m_ctx.m_tcpstat.Dump(stdout);
+    tst.m_ctx.get_tcpstat()->Dump(stdout);
     tst.Delete();
 }
 #endif
@@ -691,7 +691,7 @@ TEST_F(gt_tcp, tst17) {
     }
 
 
-    m_ctx.m_tcpstat.Dump(stdout);
+    m_ctx.get_tcpstat()->Dump(stdout);
 
 
     m_flow.Delete();
@@ -740,7 +740,7 @@ TEST_F(gt_tcp, tst18) {
     }
 
 
-    m_ctx.m_tcpstat.Dump(stdout);
+    m_ctx.get_tcpstat()->Dump(stdout);
 
     m_flow.Delete();
     m_ctx.Delete();
@@ -1719,7 +1719,7 @@ TEST_F(gt_tcp, tst42) {
     ti.ti_seq =0x1000+4000 ;
     tiflags = tcp_reass(&ctx,tp, &ti, (struct rte_mbuf *)0); 
 
-    ctx.m_tcpstat.Dump(stdout);
+    ctx.get_tcpstat()->Dump(stdout);
     printf(" tiflags:%x \n",tiflags);
 
     flow.Delete();
@@ -1802,7 +1802,7 @@ TEST_F(gt_tcp, tst43) {
     ti.ti_seq =0x1000+4000 ;
     tiflags = tcp_reass(&ctx,tp, &ti, (struct rte_mbuf *)0); 
 
-    ctx.m_tcpstat.Dump(stdout);
+    ctx.get_tcpstat()->Dump(stdout);
     printf(" tiflags:%x \n",tiflags);
 
     delete prog_s;

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4229,9 +4229,14 @@ void CGlobalTRex::update_stats(){
     m_last_total_cps = m_cps.add(total_open_flows);
 
     bool all_init=true;
-    CSTTCp  * lpstt;
-    lpstt = m_fl.m_stt_cp;
-    if ( lpstt ){
+    vector<CSTTCp *> sttcp_list;
+    if ( get_is_interactive() && get_is_tcp_mode() ) {
+        sttcp_list = get_astf_object()->get_sttcp_list();
+    }
+    else if ( m_fl.m_stt_cp ) {
+        sttcp_list.push_back(m_fl.m_stt_cp);
+    }
+    for ( auto lpstt : sttcp_list ) {
         if (!lpstt->m_init){
             /* check that we have all objects;*/
             for (i=0; i<get_cores_tx(); i++) {
@@ -4715,8 +4720,14 @@ CGlobalTRex::show_panel() {
 
     /* TCP stats */
     if (m_io_modes.m_g_mode == CTrexGlobalIoMode::gSTT) {
-        CSTTCp   * lpstt=m_fl.m_stt_cp;
-        if (lpstt) {
+        vector<CSTTCp *> sttcp_list;
+        if ( get_is_interactive() && get_is_tcp_mode() ) {
+            sttcp_list = get_astf_object()->get_sttcp_list();
+        }
+        else if ( m_fl.m_stt_cp ) {
+            sttcp_list.push_back(m_fl.m_stt_cp);
+        }
+        for ( auto lpstt : sttcp_list ) {
             if (lpstt->m_init) {
                 lpstt->DumpTable();
             }
@@ -5042,8 +5053,14 @@ int CGlobalTRex::stop_master(){
     dump_stats(stdout,CGlobalStats::dmpSTANDARD);
     dump_post_test_stats(stdout);
 
-    CSTTCp   * lpstt=m_fl.m_stt_cp;
-    if (lpstt) {
+    vector<CSTTCp *> sttcp_list;
+    if ( get_is_interactive() && get_is_tcp_mode() ) {
+        sttcp_list = get_astf_object()->get_sttcp_list();
+    }
+    else if ( m_fl.m_stt_cp ) {
+        sttcp_list.push_back(m_fl.m_stt_cp);
+    }
+    for ( auto lpstt : sttcp_list ) {
         assert(lpstt);
         assert(lpstt->m_init);
         lpstt->DumpTable();

--- a/src/publisher/trex_publisher.h
+++ b/src/publisher/trex_publisher.h
@@ -69,6 +69,9 @@ public:
         EVENT_ASTF_CLEANUP          = 55,
         */
 
+        EVENT_ASTF_PROFILE_STATE_CHG = 60,
+        EVENT_ASTF_PROFILE_CLEARED   = 61,
+
         EVENT_SERVER_STOPPED        = 100,
         
         

--- a/src/stt_cp.cpp
+++ b/src/stt_cp.cpp
@@ -52,11 +52,11 @@ void CSTTCpPerTGIDPerDir::update_counters(bool is_sum, uint16_t tg_id) {
         uint64_t *base_tcp;
         uint64_t *base_udp;
         if (is_sum) {
-            base_tcp = (uint64_t *)&lpctx->m_tcpstat.m_sts;
-            base_udp = (uint64_t *)&lpctx->m_udpstat.m_sts;
+            base_tcp = (uint64_t *)&lpctx->get_tcpstat()->m_sts;
+            base_udp = (uint64_t *)&lpctx->get_udpstat()->m_sts;
         } else {
-            base_tcp = (uint64_t *)&lpctx->m_tcpstat.m_sts_tg_id[tg_id];
-            base_udp = (uint64_t *)&lpctx->m_udpstat.m_sts_tg_id[tg_id];
+            base_tcp = (uint64_t *)&lpctx->get_tcpstat()->m_sts_tg_id[tg_id];
+            base_udp = (uint64_t *)&lpctx->get_udpstat()->m_sts_tg_id[tg_id];
         }
         CGCountersUtl64 tcp_ctx(base_tcp,sizeof(tcpstat_int_t)/sizeof(uint64_t));
         CGCountersUtl64 udp_ctx(base_udp,sizeof(udp_stat_int_t)/sizeof(uint64_t));

--- a/src/stt_cp.h
+++ b/src/stt_cp.h
@@ -47,7 +47,7 @@ typedef uint8_t tcp_dir_t;
 
 class CSTTCpPerTGIDPerDir {
 public:
-    bool Create(uint32_t time_msec);
+    bool Create(uint32_t stt_id, uint32_t time_msec);
     void Delete();
     void update_counters(bool is_sum, uint16_t tg_id=0);
     void clear_counters();
@@ -85,12 +85,15 @@ public:
     CGTblClmCounters    m_clm; /* utility for dump */
 
     std::vector<CTcpPerThreadCtx*>  m_tcp_ctx; /* vectors contexts*/
+
+private:
+    uint32_t m_stt_id;
 };
 
 class CSTTCp {
 
 public:
-    void Create(uint16_t num_of_tg_ids=1, bool first_time=true);
+    void Create(uint32_t stt_id=0, uint16_t num_of_tg_ids=1, bool first_time=true);
     void Delete(bool last_time=true);
     void Add(tcp_dir_t dir,CTcpPerThreadCtx* ctx);
     void Init(bool first_time=true);
@@ -114,6 +117,7 @@ public:
     uint16_t                            m_num_of_tg_ids;
     std::vector<std::string>            m_tg_names;
 private:
+    uint32_t m_stt_id;
 
 };
 

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -330,7 +330,8 @@ void TrexAstf::stop_transmit(cp_profile_id_t profile_id) {
     }
 
     pid->set_profile_stopping(true);
-    m_opts->preview.setNoCleanFlowClose(pid->get_nc_flow_close());
+    // TODO: apply nc_flow_close per each profile after changing DP code
+    m_opts->preview.setNoCleanFlowClose(true);
 
     TrexCpToDpMsgBase *msg = new TrexAstfDpStop(pid->get_dp_profile_id());
     send_message_to_all_dp(msg);
@@ -816,7 +817,7 @@ void TrexAstfPerProfile::cleanup() {
 
     m_astf_obj->handle_stop_latency();
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpDeleteTcp(m_dp_profile_id);
+    TrexCpToDpMsgBase *msg = new TrexAstfDpDeleteTcp(m_dp_profile_id, false);
     m_astf_obj->send_message_to_all_dp(msg);
 }
 

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -473,7 +473,7 @@ void TrexAstf::inc_epoch() {
     m_epoch++;
 }
 
-void TrexAstf::publish_astf_state(string err) {
+void TrexAstf::publish_astf_state(string &err) {
     /* Publish the state change of all profiles */
     int old_state = m_state;
 
@@ -485,8 +485,8 @@ void TrexAstf::publish_astf_state(string err) {
     Json::Value data;
     data["state"] = m_state;
     data["epoch"] = m_epoch;
-    if ( err != "" && !is_trans_state() ) {
-        data["error"] = err;
+    if ( !err.empty() && !is_trans_state() ) {
+        data["error"] = err.c_str();
     }
 
     get_publisher()->publish_event(TrexPublisher::EVENT_ASTF_STATE_CHG, data);
@@ -642,7 +642,8 @@ bool TrexAstfProfile::is_another_profile_busy(cp_profile_id_t profile_id) {
 /***********************************************************
  * TrexAstfPerProfile
  ***********************************************************/
-TrexAstfPerProfile::TrexAstfPerProfile(TrexAstf* astf_obj, uint32_t dp_profile_id,
+TrexAstfPerProfile::TrexAstfPerProfile(TrexAstf* astf_obj,
+                                       uint32_t dp_profile_id,
                                        cp_profile_id_t cp_profile_id) {
     m_dp_profile_id = dp_profile_id;
     m_cp_profile_id = cp_profile_id;

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -40,6 +40,9 @@ limitations under the License.
 
 using namespace std;
 
+/***********************************************************
+ * TrexAstf
+ ***********************************************************/
 TrexAstf::TrexAstf(const TrexSTXCfg &cfg) : TrexSTX(cfg) {
     /* API core version */
     const int API_VER_MAJOR = 1;
@@ -68,19 +71,11 @@ TrexAstf::TrexAstf(const TrexSTXCfg &cfg) : TrexSTX(cfg) {
 
     m_opts->m_astf_mode = CParserOption::OP_ASTF_MODE_CLIENT_MASK;
 
-    m_profile_buffer = "";
-    m_profile_hash = "";
-    m_profile_parsed = false;
-
     m_topo_buffer = "";
     m_topo_hash = "";
     m_topo_parsed = false;
 
-    m_states_names = {"Idle", "Loaded profile", "Parsing profile", "Setup traffic", "Transmitting", "Cleanup traffic"};
-    assert(m_states_names.size()==AMOUNT_OF_STATES);
-
     m_state = STATE_IDLE;
-    m_active_cores = 0;
     m_epoch = 0;
 
     /* create RX core */
@@ -124,30 +119,50 @@ void TrexAstf::shutdown() {
     send_msg_to_rx(new TrexRxQuit());
 }
 
-void TrexAstf::parse() {
-    change_state(STATE_PARSE);
+void TrexAstf::parse(string profile_id) {
+    if (is_another_profile_busy(profile_id)) {
+        add_cmd_in_wait_list(profile_id, CMD_PARSE);
+        return;
+    } else {
+        del_cmd_in_wait_list(profile_id);
+    }
 
-    string *prof = profile_needs_parsing() ? &m_profile_buffer : nullptr;
+    string *prof = profile_needs_parsing(profile_id) ? &(get_profile_by_id(profile_id)->m_profile_buffer) : nullptr;
     string *topo = topo_needs_parsing() ? &m_topo_buffer : nullptr;
     assert(prof||topo);
 
-    TrexCpToDpMsgBase *msg = new TrexAstfLoadDB(prof, topo);
+    profile_change_state(profile_id, STATE_PARSE);
+
+    uint32_t profile_index = get_profile_index_by_id(profile_id);
+    TrexCpToDpMsgBase *msg = new TrexAstfLoadDB(profile_index, prof, topo);
     send_message_to_dp(0, msg);
 }
 
-void TrexAstf::build() {
-    change_state(STATE_BUILD);
+void TrexAstf::build(string profile_id) {
+    if (is_another_profile_busy(profile_id)) {
+        add_cmd_in_wait_list(profile_id, CMD_BUILD);
+        return;
+    } else {
+        del_cmd_in_wait_list(profile_id);
+    }
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpCreateTcp();
+    profile_change_state(profile_id, STATE_BUILD);
+
+    m_opts->m_factor       = get_profile_by_id(profile_id)->m_factor;
+    uint32_t profile_index = get_profile_index_by_id(profile_id);
+    TrexCpToDpMsgBase *msg = new TrexAstfDpCreateTcp(profile_index);
     send_message_to_all_dp(msg);
 }
 
-void TrexAstf::transmit() {
+void TrexAstf::transmit(string profile_id, double duration) {
+    uint32_t profile_index = get_profile_index_by_id(profile_id);
 
-    m_fl->m_stt_cp->Resize(CAstfDB::instance()->get_num_of_tg_ids());   /* Resize the statistics vector depending on the number of template groups */
+    /* Resize the statistics vector depending on the number of template groups */
+    CSTTCp* lpstt = get_sttcp_by_id(profile_id);
+    lpstt->Resize(CAstfDB::instance(profile_index)->get_num_of_tg_ids());
 
     if ( m_lat_with_traffic ) {
-        CAstfDB *db = CAstfDB::instance();
+        CAstfDB *db = CAstfDB::instance(profile_index);
         lat_start_params_t args;
 
         try {
@@ -161,22 +176,33 @@ void TrexAstf::transmit() {
             args.ports_mask = 0xffffffff;
             start_transmit_latency(args);
         } catch (const TrexException &ex) {
-            m_error = ex.what();
-            cleanup();
+            get_profile_by_id(profile_id)->m_error = ex.what();
+            cleanup(profile_id);
             return;
         }
     }
 
-    change_state(STATE_TX);
-    set_barrier(0.5);
+    if (!is_another_profile_transmitting(profile_id)) {
+        set_barrier(0.5);
+    }
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpStart();
+    profile_change_state(profile_id, STATE_TX);
+
+    TrexCpToDpMsgBase *msg = new TrexAstfDpStart(profile_index, duration);
     send_message_to_all_dp(msg);
 }
 
 
-void TrexAstf::cleanup() {
-    change_state(STATE_CLEANUP);
+void TrexAstf::cleanup(string profile_id) {
+    if (is_another_profile_busy(profile_id)) {
+        add_cmd_in_wait_list(profile_id, CMD_CLEANUP);
+        return;
+    } else {
+        del_cmd_in_wait_list(profile_id);
+    }
+
+    profile_change_state(profile_id, STATE_CLEANUP);
+    get_profile_by_id(profile_id)->m_profile_stopping = true;
 
     if (m_lat_with_traffic && (m_l_state==STATE_L_WORK)) {
         m_latency_pps = 0;
@@ -184,16 +210,13 @@ void TrexAstf::cleanup() {
         stop_transmit_latency();
     }
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpDeleteTcp();
+    uint32_t profile_index = get_profile_index_by_id(profile_id);
+    TrexCpToDpMsgBase *msg = new TrexAstfDpDeleteTcp(profile_index);
     send_message_to_all_dp(msg);
 }
 
 bool TrexAstf::is_trans_state() {
     return m_state == STATE_PARSE || m_state == STATE_BUILD || m_state == STATE_CLEANUP;
-}
-
-bool TrexAstf::profile_needs_parsing() {
-    return m_profile_hash.size() && !m_profile_parsed;
 }
 
 bool TrexAstf::topo_needs_parsing() {
@@ -206,99 +229,178 @@ void TrexAstf::change_state(state_e new_state) {
 
     switch ( m_state ) {
         case STATE_IDLE:
-            m_active_cores = 0;
             port_state = TrexPort::PORT_STATE_IDLE;
             break;
         case STATE_LOADED:
-            m_active_cores = 0;
             port_state = TrexPort::PORT_STATE_ASTF_LOADED;
             break;
         case STATE_PARSE:
-            m_active_cores = 1;
             port_state = TrexPort::PORT_STATE_ASTF_PARSE;
             break;
         case STATE_BUILD:
-            m_active_cores = m_dp_core_count;
             port_state = TrexPort::PORT_STATE_ASTF_BUILD;
             break;
         case STATE_TX:
-            m_active_cores = m_dp_core_count;
             port_state = TrexPort::PORT_STATE_TX;
             break;
         case STATE_CLEANUP:
-            m_active_cores = m_dp_core_count;
             port_state = TrexPort::PORT_STATE_ASTF_CLEANUP;
             break;
         case AMOUNT_OF_STATES:
             assert(0);
     }
 
-    Json::Value data;
-    data["state"] = m_state;
-    data["epoch"] = m_epoch;
-    if ( is_error() && !is_trans_state() ) {
-        data["error"] = m_error;
-        m_error = "";
-    }
-    get_publisher()->publish_event(TrexPublisher::EVENT_ASTF_STATE_CHG, data);
     for (auto &port: get_port_map()) {
         port.second->change_state(port_state);
     }
 }
 
-void TrexAstf::all_dp_cores_finished() {
-    switch ( m_state ) {
+void TrexAstf::update_astf_state() {
+    int temp_state = 0;
+    vector<state_e> states = get_profile_state_list();
+
+    for (auto it : states) {
+        temp_state |= (0x01 << it);
+    }
+
+    if (temp_state & (0x01 << STATE_TX)) {
+        change_state(STATE_TX);
+    } else if (temp_state & (0x01 << STATE_BUILD)) {
+        change_state(STATE_BUILD);
+    } else if (temp_state & (0x01 << STATE_PARSE)) {
+        change_state(STATE_PARSE);
+    } else if (temp_state & (0x01 << STATE_CLEANUP)) {
+        change_state(STATE_CLEANUP);
+    } else if (temp_state & (0x01 << STATE_LOADED)) {
+        change_state(STATE_LOADED);
+    } else if (temp_state & (0x01 << STATE_IDLE)) {
+        change_state(STATE_IDLE);
+    }
+}
+
+void TrexAstf::publish_astf_state(string profile_id) {
+
+    /* Publish the state change of each profile */
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+
+    Json::Value data;
+    data["profile_id"] = profile_id;
+    data["state"] = mprof->m_profile_state;
+    data["epoch"] = m_epoch;
+    if ( is_error(profile_id) ) {
+        data["error"] = mprof->m_error;
+    }
+
+    get_publisher()->publish_event(TrexPublisher::EVENT_ASTF_PROFILE_STATE_CHG, data);
+
+
+    /* Publish the state change of all profiles */
+    int old_state = m_state;
+
+    update_astf_state();
+    if (old_state == m_state) {
+        mprof->m_error = "";
+        return;
+    }
+
+    data.clear();
+    data["state"] = m_state;
+    data["epoch"] = m_epoch;
+    if ( is_error(profile_id) && !is_trans_state() ) {
+        data["error"] = mprof->m_error;
+    }
+
+    mprof->m_error = "";
+
+    get_publisher()->publish_event(TrexPublisher::EVENT_ASTF_STATE_CHG, data);
+}
+
+void TrexAstf::publish_astf_profile_clear(string profile_id) {
+     Json::Value data;
+     data["profile_id"] = profile_id;
+     data["epoch"] = m_epoch;
+     get_publisher()->publish_event(TrexPublisher::EVENT_ASTF_PROFILE_CLEARED, data);
+}
+
+void TrexAstf::get_profiles_status(Json::Value &result) {
+    vector<string> profile_id_list = get_profile_id_list();
+    Json::Value get_profiles_status_json = Json::objectValue;
+
+    for (auto profile_id : profile_id_list) {
+        state_e j = get_profile_state_by_id(profile_id);
+        stringstream ss;
+        ss << profile_id;
+        get_profiles_status_json[ss.str()] = j;
+    }
+
+    result = get_profiles_status_json;
+}
+
+void TrexAstf::all_dp_cores_finished(uint32_t profile_index) {
+    string profile_id = get_profile_id_by_index(profile_index);
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+
+    switch ( mprof->m_profile_state ) {
         case STATE_PARSE:
-            if ( is_error() ) {
-                change_state(STATE_LOADED);
+            if ( is_error(profile_id) || mprof->m_profile_stopping ) {
+                profile_change_state(profile_id, STATE_LOADED);
+                del_cmd_in_wait_list(profile_id);
+                run_cmd_in_wait_list();
             } else {
-                m_profile_parsed = true;
+                mprof->m_profile_parsed = true;
                 m_topo_parsed = true;
-                build();
+                build(profile_id);
             }
             break;
         case STATE_BUILD:
-            if ( is_error() ) {
-                cleanup();
+            if ( is_error(profile_id) || mprof->m_profile_stopping ) {
+                del_cmd_in_wait_list(profile_id);
+                cleanup(profile_id);
             } else {
-                transmit();
+                transmit(profile_id, mprof->m_duration);
+                run_cmd_in_wait_list();
             }
             break;
         case STATE_TX:
-            cleanup();
+            cleanup(profile_id);
             break;
         case STATE_CLEANUP:
-            change_state(STATE_LOADED);
+            profile_change_state(profile_id, STATE_LOADED);
+            run_cmd_in_wait_list();
             break;
         default:
-            printf("DP cores should not report in state: %s", m_states_names[m_state].c_str());
+            printf("DP cores should not report in state: %s", m_states_names[mprof->m_profile_state].c_str());
             exit(1);
     }
 }
 
-void TrexAstf::dp_core_finished(int thread_id) {
-    m_active_cores--;
-    if ( m_active_cores == 0 ) {
-        all_dp_cores_finished();
+void TrexAstf::dp_core_finished(int thread_id, uint32_t profile_index) {
+    TrexAstfPerProfile* mprof = get_profile_by_id(get_profile_id_by_index(profile_index));
+
+    mprof->m_active_cores--;
+    if ( mprof->m_active_cores == 0 ) {
+        all_dp_cores_finished(profile_index);
     } else {
-        assert(m_active_cores>0);
+        assert(mprof->m_active_cores>0);
     }
 }
 
-void TrexAstf::dp_core_error(int thread_id, const string &err) {
-    switch ( m_state ) {
+void TrexAstf::dp_core_error(int thread_id, uint32_t profile_index, const string &err) {
+    TrexAstfPerProfile* mprof = get_profile_by_id(get_profile_id_by_index(profile_index));
+
+    switch ( mprof->m_profile_state ) {
         case STATE_PARSE:
-            m_error = err;
+            mprof->m_error = err;
             break;
         case STATE_BUILD:
-            m_error = err;
+            mprof->m_error = err;
             break;
         default:
-            printf("DP core should not report error in state: %s\n", m_states_names[m_state].c_str());
+            printf("DP core should not report error in state: %s\n", m_states_names[mprof->m_profile_state].c_str());
             printf("Error is: %s\n", err.c_str());
             exit(1);
     }
-    dp_core_finished(thread_id);
+    dp_core_finished(thread_id, profile_index);
 }
 
 
@@ -358,31 +460,6 @@ void TrexAstf::release_context() {
     get_owner().release();
 }
 
-bool TrexAstf::profile_cmp_hash(const string &hash) {
-    return m_profile_hash == hash;
-}
-
-void TrexAstf::profile_clear() {
-    check_whitelist_states({STATE_IDLE, STATE_LOADED});
-    if ( m_state == STATE_LOADED ) {
-        change_state(STATE_IDLE);
-    }
-    m_profile_buffer.clear();
-    m_profile_hash.clear();
-    m_profile_parsed = false;
-}
-
-void TrexAstf::profile_append(const string &fragment) {
-    check_whitelist_states({STATE_IDLE});
-    m_profile_buffer += fragment;
-}
-
-void TrexAstf::profile_set_loaded() {
-    check_whitelist_states({STATE_IDLE});
-    change_state(STATE_LOADED);
-    m_profile_hash = md5(m_profile_buffer);
-}
-
 bool TrexAstf::topo_cmp_hash(const string &hash) {
     return m_topo_hash == hash;
 }
@@ -415,8 +492,8 @@ bool TrexAstf::is_state_build() {
     return m_state == STATE_BUILD;
 }
 
-void TrexAstf::start_transmit(const start_params_t &args) {
-    check_whitelist_states({STATE_LOADED});
+void TrexAstf::start_transmit(string profile_id, const start_params_t &args) {
+    profile_check_whitelist_states(profile_id, {STATE_LOADED});
 
     if ( args.latency_pps ) {
         if (m_l_state != STATE_L_IDLE) {
@@ -426,42 +503,73 @@ void TrexAstf::start_transmit(const start_params_t &args) {
         m_lat_with_traffic = true;
     }
 
-    m_opts->m_factor           = args.mult;
-    m_opts->m_duration         = args.duration;
+    TrexAstfPerProfile* mprof  = get_profile_by_id(profile_id);
+    mprof->m_factor            = args.mult;
+    mprof->m_duration          = args.duration;
+
     m_opts->m_astf_client_mask = args.client_mask;
     m_opts->preview.setNoCleanFlowClose(args.nc);
     m_opts->preview.set_ipv6_mode_enable(args.ipv6);
 
-    if ( profile_needs_parsing() || topo_needs_parsing() ) {
-        parse();
+    if ( profile_needs_parsing(profile_id) || topo_needs_parsing() ) {
+        parse(profile_id);
     } else {
-        build();
+        build(profile_id);
     }
 }
 
-void TrexAstf::stop_transmit() {
-    if ( m_state == STATE_IDLE || m_state == STATE_LOADED ) {
+void TrexAstf::stop_transmit(string profile_id) {
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+
+    /* check already stopping */
+    if (mprof->m_profile_stopping) {
         return;
     }
 
+    /* check cmd in waiting list */
+    cmd_wait_e cmd = get_cmd_in_wait_list(profile_id);
+    if (cmd != AMOUNT_OF_CMDS) {
+        if (cmd != CMD_STOP) {
+            del_cmd_in_wait_list(profile_id);
+            profile_change_state(profile_id, STATE_LOADED);
+        }
+        return;
+    }
+
+    /* check state */
+    state_e state = get_profile_state_by_id(profile_id);
+    if (state == STATE_IDLE || state == STATE_LOADED) {
+        return;
+    } else if (state == STATE_TX && is_another_profile_busy(profile_id)) {
+        add_cmd_in_wait_list(profile_id, CMD_STOP);
+        return;
+    } else {
+        del_cmd_in_wait_list(profile_id);
+    }
+
+    mprof->m_profile_stopping = true;
     m_opts->preview.setNoCleanFlowClose(true);
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpStop();
-    send_message_to_all_dp(msg);
+    if ( state == STATE_TX ) {
+        uint32_t profile_index = get_profile_index_by_id(profile_id);
+        TrexCpToDpMsgBase *msg = new TrexAstfDpStop(profile_index);
+        send_message_to_all_dp(msg);
+    }
 }
 
-void TrexAstf::update_rate(double mult) {
-    check_whitelist_states({STATE_TX});
+void TrexAstf::update_rate(string profile_id, double mult) {
+    profile_check_whitelist_states(profile_id, {STATE_TX});
 
     // time interval for opening new flow will be multiplied by old_new_ratio
     // new mult higher => time is shorter
-    double old_new_ratio = m_opts->m_factor / mult;
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+    double old_new_ratio = mprof->m_factor / mult;
     if ( std::isnan(old_new_ratio) || std::isinf(old_new_ratio) ) {
         throw TrexException("Ratio between current rate and new one is invalid.");
     }
 
-    m_opts->m_factor = mult;
-    TrexCpToDpMsgBase *msg = new TrexAstfDpUpdate(old_new_ratio);
+    mprof->m_factor = mult;
+    TrexCpToDpMsgBase *msg = new TrexAstfDpUpdate(mprof->m_profile_index, old_new_ratio);
     send_message_to_all_dp(msg);
 }
 
@@ -532,5 +640,343 @@ void TrexAstf::inc_epoch() {
         throw TrexException("Can't increase epoch in current state: " + m_states_names[m_state]);
     }
     m_epoch++;
+}
+
+void TrexAstf::run_cmd_in_wait_list()
+{
+    /* Execute the first one in command waiting list */
+    if (!m_cmd_wait_list.empty()) {
+        string id = m_cmd_wait_list.begin()->first;
+        cmd_wait_e cmd = m_cmd_wait_list.begin()->second;
+        del_cmd_in_wait_list(id);
+        if (cmd == CMD_PARSE) {
+            parse(id);
+        } else if (cmd == CMD_BUILD) {
+            build(id);
+        } else if (cmd == CMD_STOP) {
+            stop_transmit(id);
+        } else if (cmd == CMD_CLEANUP) {
+            cleanup(id);
+        }
+    }
+}
+
+void TrexAstf::add_cmd_in_wait_list(string profile_id, cmd_wait_e cmd)
+{
+    for (auto i = m_cmd_wait_list.begin(); i != m_cmd_wait_list.end(); i++) {
+        if (i->first == profile_id) {
+            if (i->second == cmd) {
+                return;
+            }
+            m_cmd_wait_list.erase(i);
+            break;
+        }
+    }
+    m_cmd_wait_list.push_back(make_pair(profile_id, cmd));
+}
+
+void TrexAstf::del_cmd_in_wait_list(string profile_id)
+{
+    for (auto i = m_cmd_wait_list.begin(); i != m_cmd_wait_list.end(); i++) {
+        if (i->first == profile_id) {
+            m_cmd_wait_list.erase(i);
+            break;
+        }
+    }
+}
+
+TrexAstf::cmd_wait_e TrexAstf::get_cmd_in_wait_list(string profile_id)
+{
+    for (auto i = m_cmd_wait_list.begin(); i != m_cmd_wait_list.end(); i++) {
+        if (i->first == profile_id) {
+            return i->second;
+        }
+    }
+    return AMOUNT_OF_CMDS;
+}
+
+
+/***********************************************************
+ * TrexAstfProfile
+ ***********************************************************/
+TrexAstfProfile::TrexAstfProfile() {
+    m_states_names = {"Idle", "Loaded profile", "Parsing profile", "Setup traffic", "Transmitting", "Cleanup traffic"};
+    assert(m_states_names.size()==AMOUNT_OF_STATES);
+
+    m_profile_last_index = 0;
+    /* Create default profile for backward compatibility */
+    TrexAstfPerProfile* m_instance = new TrexAstfPerProfile(m_profile_last_index++);
+    m_profile_list.insert(map<string, TrexAstfPerProfile *>::value_type(
+                          DEFAULT_ASTF_PROFILE_ID, m_instance));
+}
+
+TrexAstfProfile::~TrexAstfProfile() {
+    for (auto mprofile : m_profile_list) {
+        delete mprofile.second;
+    }
+}
+
+void TrexAstfProfile::add_profile(string profile_id) {
+    if (is_valid_profile(profile_id)) {
+        return;
+    }
+
+    TrexAstfPerProfile* m_instance = new TrexAstfPerProfile(m_profile_last_index++);
+    m_profile_list.insert(map<string, TrexAstfPerProfile *>::value_type(
+                          profile_id, m_instance));
+
+    int i;
+    CSTTCp* lpstt = m_instance->m_stt_cp;
+    if (!lpstt->m_init){
+        CFlowGenList *m_fl = get_platform_api().get_fl();
+        CFlowGenListPerThread* lpt;
+        bool all_init=true;
+        for (i = 0; i < m_fl->m_threads_info.size(); i++) {
+            lpt = m_fl->m_threads_info[i];
+            if (lpt->m_c_tcp == 0 || lpt->m_s_tcp == 0) {
+                all_init=false;
+                break;
+            }
+        }
+        if (all_init) {
+            for (i = 0; i < m_fl->m_threads_info.size(); i++) {
+                lpt = m_fl->m_threads_info[i];
+                lpstt->Add(TCP_CLIENT_SIDE, lpt->m_c_tcp);
+                lpstt->Add(TCP_SERVER_SIDE, lpt->m_s_tcp);
+            }
+            lpstt->Init();
+            lpstt->m_init=true;
+        }
+    }
+}
+
+bool TrexAstfProfile::delete_profile(string profile_id)
+{
+    if (is_valid_profile(profile_id)) {
+        delete m_profile_list.find(profile_id)->second;
+        m_profile_list.erase(profile_id);
+        return true;
+    }
+
+    return false;
+}
+
+bool TrexAstfProfile::is_valid_profile(string profile_id) {
+    return m_profile_list.count(profile_id) ? true : false;
+}
+
+uint32_t TrexAstfProfile::get_num_profiles() {
+    return m_profile_list.size();
+}
+
+TrexAstfPerProfile* TrexAstfProfile::get_profile_by_id(string profile_id) {
+    if (is_valid_profile(profile_id)) {
+        return m_profile_list[profile_id];
+    }
+    else {
+        throw TrexException("ASTF profile_id " + profile_id + " does not exist");
+    }
+}
+
+uint32_t TrexAstfProfile::get_profile_index_by_id(string profile_id) {
+    return get_profile_by_id(profile_id)->m_profile_index;
+}
+
+TrexAstfProfile::state_e TrexAstfProfile::get_profile_state_by_id(string profile_id) {
+    return get_profile_by_id(profile_id)->m_profile_state;
+}
+
+string TrexAstfProfile::get_profile_id_by_index(uint32_t profile_index)
+{
+    for (auto mprofile : m_profile_list) {
+        if (mprofile.second->m_profile_index == profile_index) {
+            return mprofile.first;
+        }
+    }
+
+    return "";
+}
+
+CSTTCp* TrexAstfProfile::get_sttcp_by_id(string profile_id) {
+    return is_valid_profile(profile_id) ? get_profile_by_id(profile_id)->m_stt_cp : 0;
+}
+
+vector<string> TrexAstfProfile::get_profile_id_list()
+{
+    vector<string> profile_id_list;
+
+    for (auto mprofile : m_profile_list) {
+        profile_id_list.push_back(mprofile.first);
+    }
+
+    return profile_id_list;
+}
+
+vector<TrexAstfProfile::state_e> TrexAstfProfile::get_profile_state_list()
+{
+    vector<state_e> profile_state_list;
+
+    for (auto mprofile : m_profile_list) {
+        profile_state_list.push_back(mprofile.second->m_profile_state);
+    }
+
+    return profile_state_list;
+}
+
+vector<CSTTCp *> TrexAstfProfile::get_sttcp_list()
+{
+    vector<CSTTCp *> sttcp_list;
+
+    for (auto mprofile : m_profile_list) {
+        sttcp_list.push_back(mprofile.second->m_stt_cp);
+    }
+
+    return sttcp_list;
+}
+
+bool TrexAstfProfile::profile_needs_parsing(string profile_id) {
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+
+    return mprof->m_profile_hash.size() && !(mprof->m_profile_parsed) && (mprof->m_profile_state != STATE_PARSE);
+}
+
+trex_astf_hash_e TrexAstfProfile::profile_cmp_hash(string profile_id, const string &hash) {
+    for (auto mprofile : m_profile_list) {
+        if (mprofile.second->m_profile_hash == hash) {
+            if (mprofile.first == profile_id) {
+                return HASH_ON_SAME_PROFILE;
+            }
+            else {
+                return HASH_ON_OTHER_PROFILE;
+            }
+        }
+    }
+
+    return HASH_OK;
+}
+
+void TrexAstfProfile::profile_clear(string profile_id){
+    profile_init(profile_id);
+    if (profile_id != DEFAULT_ASTF_PROFILE_ID) {
+        delete_profile(profile_id);
+        publish_astf_profile_clear(profile_id);
+    }
+}
+
+void TrexAstfProfile::profile_init(string profile_id){
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+
+    profile_check_whitelist_states(profile_id, {STATE_IDLE, STATE_LOADED});
+    if ( mprof->m_profile_state == STATE_LOADED ) {
+        del_cmd_in_wait_list(profile_id);
+        profile_change_state(profile_id, STATE_IDLE);
+    }
+    mprof->m_profile_buffer.clear();
+    mprof->m_profile_hash.clear();
+    mprof->m_profile_parsed = false;
+}
+
+void TrexAstfProfile::profile_append(string profile_id, const string &fragment) {
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+
+    profile_check_whitelist_states(profile_id, {STATE_IDLE});
+    mprof->m_profile_buffer += fragment;
+}
+
+void TrexAstfProfile::profile_set_loaded(string profile_id) {
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+
+    profile_check_whitelist_states(profile_id, {STATE_IDLE});
+    profile_change_state(profile_id, STATE_LOADED);
+    mprof->m_profile_hash = md5(mprof->m_profile_buffer);
+}
+
+void TrexAstfProfile::profile_change_state(string profile_id, state_e new_state) {
+    TrexAstfPerProfile* mprof = get_profile_by_id(profile_id);
+    mprof->m_profile_state = new_state;
+
+    switch ( new_state ) {
+        case STATE_IDLE:
+            mprof->m_active_cores = 0;
+            break;
+        case STATE_LOADED:
+            mprof->m_profile_stopping = false;
+            mprof->m_active_cores = 0;
+            break;
+        case STATE_PARSE:
+            mprof->m_active_cores = 1;
+            break;
+        case STATE_BUILD:
+            mprof->m_active_cores = get_platform_api().get_dp_core_count();
+            break;
+        case STATE_TX:
+            mprof->m_active_cores = get_platform_api().get_dp_core_count();
+            break;
+        case STATE_CLEANUP:
+            mprof->m_active_cores = get_platform_api().get_dp_core_count();
+            break;
+        case AMOUNT_OF_STATES:
+            assert(0);
+    }
+
+    publish_astf_state(profile_id);
+}
+
+void TrexAstfProfile::profile_check_whitelist_states(string profile_id, const states_t &whitelist) {
+    state_e profile_state = get_profile_state_by_id(profile_id);
+
+    assert(whitelist.size());
+    for ( auto &state : whitelist ) {
+        if ( profile_state == state ) {
+            return;
+        }
+    }
+
+    string err = "Invalid state: " + m_states_names[profile_state] + ", should be";
+    if ( whitelist.size() > 1 ) {
+        err += " one of following";
+    }
+    bool first = true;
+    for ( auto &state : whitelist ) {
+        if ( first ) {
+            err += ": " + m_states_names[state];
+            first = false;
+        } else {
+            err += "," + m_states_names[state];
+        }
+    }
+    throw TrexException(err);
+}
+
+bool TrexAstfProfile::is_profile_state_build(string profile_id) {
+    return get_profile_state_by_id(profile_id) == STATE_BUILD;
+}
+
+bool TrexAstfProfile::is_another_profile_transmitting(string profile_id)
+{
+    for (auto id : get_profile_id_list()) {
+        if (id == profile_id) {
+            continue;
+        }
+        if (get_profile_state_by_id(id) == STATE_TX) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool TrexAstfProfile::is_another_profile_busy(string profile_id)
+{
+    for (auto id : get_profile_id_list()) {
+        if (id == profile_id) {
+            continue;
+        }
+        TrexAstfPerProfile* mprof = get_profile_by_id(id);
+        if (mprof->m_profile_state == STATE_PARSE || mprof->m_profile_state == STATE_BUILD ||
+            mprof->m_profile_stopping == true) {
+            return true;
+        }
+    }
+    return false;
 }
 

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -66,7 +66,8 @@ class TrexAstfPerProfile : public AstfProfileState {
 public:
     typedef std::vector<state_e> states_t;
 
-    TrexAstfPerProfile(uint32_t dp_profile_id=0,
+    TrexAstfPerProfile(TrexAstf* astf_obj,
+                       uint32_t dp_profile_id=0,
                        cp_profile_id_t cp_profile_id=DEFAULT_ASTF_PROFILE_ID);
     ~TrexAstfPerProfile();
 
@@ -181,9 +182,11 @@ public:
     bool is_another_profile_transmitting(cp_profile_id_t profile_id);
     bool is_another_profile_busy(cp_profile_id_t profile_id);
 
+protected:
+    std::unordered_map<std::string, TrexAstfPerProfile *> m_profile_list;
+
 private:
     uint32_t m_dp_profile_last_id;
-    std::unordered_map<std::string, TrexAstfPerProfile *> m_profile_list;
 };
 
 

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -23,9 +23,11 @@ limitations under the License.
 
 #include <stdint.h>
 #include <vector>
+#include <map>
 
 #include "common/trex_stx.h"
 #include "trex_astf_defs.h"
+#include "stt_cp.h"
 
 class TrexAstfPort;
 class CSyncBarrier;
@@ -33,11 +35,15 @@ class CRxAstfCore;
 
 typedef std::unordered_map<uint8_t, TrexAstfPort*> astf_port_map_t;
 
-/**
- * TRex adavanced stateful interactive object
- * 
- */
-class TrexAstf : public TrexSTX {
+const std::string DEFAULT_ASTF_PROFILE_ID = "_";
+
+typedef enum trex_astf_hash {
+    HASH_OK,
+    HASH_ON_SAME_PROFILE,
+    HASH_ON_OTHER_PROFILE,
+} trex_astf_hash_e;
+
+class AstfProfileState {
 public:
     enum state_e {
         STATE_IDLE,
@@ -48,14 +54,143 @@ public:
         STATE_CLEANUP, // by DP cores, not cancelable
         AMOUNT_OF_STATES,
     };
+};
+
+
+/***********************************************************
+ * TRex ASTF each profile in interactive
+ ***********************************************************/
+class TrexAstfPerProfile : public AstfProfileState {
+public:
+    TrexAstfPerProfile(uint32_t profile_index=0) {
+        m_profile_index = profile_index;
+        m_profile_state = STATE_IDLE;
+        m_profile_buffer = "";
+        m_profile_hash = "";
+        m_profile_parsed = false;
+        m_profile_stopping = false;
+
+        m_active_cores = 0;
+        m_duration = 0.0;
+        m_factor = 1.0;
+        m_error = "";
+
+        m_stt_cp = new CSTTCp();
+        m_stt_cp->Create(profile_index);
+    }
+
+    ~TrexAstfPerProfile() {
+        m_stt_cp->Delete();
+        delete m_stt_cp;
+        m_stt_cp=0;
+    }
+
+    /**
+     * CP sends a message to DP using profile_index(profile_id for DP),
+     * which is converted from string type profile_id to integer.
+     */
+    int32_t         m_profile_index;
+
+    state_e         m_profile_state;
+    std::string     m_profile_buffer;
+    std::string     m_profile_hash;
+    bool            m_profile_parsed;
+    bool            m_profile_stopping;
+
+    int16_t         m_active_cores;
+    double          m_duration;
+    double          m_factor;
+    std::string     m_error;
+    CSTTCp*         m_stt_cp;
+};
+
+
+/***********************************************************
+ * TRex ASTF dynamic multiple profiles in interactive
+ ***********************************************************/
+class TrexAstfProfile : public AstfProfileState {
+public:
+    typedef std::vector<state_e> states_t;
+
+    TrexAstfProfile();
+    ~TrexAstfProfile();
+
+    /**
+     * Handle dynamic multiple profiles
+     */
+    void add_profile(std::string profile_id);
+    bool delete_profile(std::string profile_id);
+    bool is_valid_profile(std::string profile_id);
+    uint32_t get_num_profiles();
+
+    TrexAstfPerProfile* get_profile_by_id(std::string profile_id);
+    uint32_t            get_profile_index_by_id(std::string profile_id);
+    state_e             get_profile_state_by_id(std::string profile_id);
+    std::string         get_profile_id_by_index(uint32_t profile_index);
+    CSTTCp*             get_sttcp_by_id(std::string profile_id);
+
+    std::vector<std::string> get_profile_id_list();
+    std::vector<state_e>     get_profile_state_list();
+    std::vector<CSTTCp *>    get_sttcp_list();
+
+    /**
+     * Profile-related:
+     * cmp - compare hash to loaded profile, true = matches (heavy profile will not be uploaded twice)
+     * clear - clears profile JSON string (if any)
+     * append - appends fragment to profile JSON string
+     * loaded - move state from idle to loaded
+     */
+    trex_astf_hash_e profile_cmp_hash(std::string profile_id, const std::string &hash);
+    void profile_clear(std::string profile_id);
+    void profile_init(std::string profile_id);
+    void profile_append(std::string profile_id, const std::string &fragment);
+    void profile_set_loaded(std::string profile_id);
+
+    /**
+     * Handle profile status
+     */
+    void profile_change_state(std::string profile_id, state_e new_state);
+    void profile_check_whitelist_states(std::string profile_id, const states_t &whitelist);
+    bool is_profile_state_build(std::string profile_id);
+
+    bool profile_needs_parsing(std::string profile_id);
+    bool is_error(std::string profile_id) {
+        return get_profile_by_id(profile_id)->m_error.size() > 0;
+    }
+
+protected:
+    std::vector<std::string> m_states_names;
+    bool is_another_profile_transmitting(std::string profile_id);
+    bool is_another_profile_busy(std::string profile_id);
+    virtual void del_cmd_in_wait_list(std::string profile_id) = 0;
+    virtual void publish_astf_state(std::string profile_id) = 0;
+    virtual void publish_astf_profile_clear(std::string profile_id) = 0;
+
+private:
+    uint32_t m_profile_last_index;
+    std::unordered_map<std::string, TrexAstfPerProfile *> m_profile_list;
+};
+
+
+/***********************************************************
+ * TRex adavanced stateful interactive object
+ ***********************************************************/
+class TrexAstf : public TrexAstfProfile, public TrexSTX {
+public:
+    enum cmd_wait_e {
+        CMD_PARSE,
+        CMD_BUILD,
+        CMD_START,
+        CMD_STOP,
+        CMD_CLEANUP,
+        AMOUNT_OF_CMDS,
+    };
 
     enum state_latency_e {
         STATE_L_IDLE,
         STATE_L_WORK,
         AMOUNT_OF_L_STATES,
     };
-
-    typedef std::vector<state_e> states_t;
 
     /** 
      * create ASTF object 
@@ -68,16 +203,15 @@ public:
      * 
      */
     void launch_control_plane();
-    
-    
+
     /**
      * shutdown ASTF
      * 
      */
     void shutdown();
 
-    void all_dp_cores_finished();
-    void dp_core_finished(int thread_id);
+    void all_dp_cores_finished(uint32_t profile_index);
+    void dp_core_finished(int thread_id, uint32_t profile_index);
 
     /**
      * async data sent for ASTF
@@ -115,18 +249,6 @@ public:
     void release_context();
 
     /**
-     * Profile-related:
-     * cmp - compare hash to loaded profile, true = matches (heavy profile will not be uploaded twice)
-     * clear - clears profile JSON string (if any)
-     * append - appends fragment to profile JSON string
-     * loaded - move state from idle to loaded
-     */
-    bool profile_cmp_hash(const std::string &hash);
-    void profile_clear();
-    void profile_append(const std::string &fragment);
-    void profile_set_loaded();
-
-    /**
      * Topology-related:
      * cmp - compare hash to loaded topo, true = matches (heavy topo will not be uploaded twice)
      * clear - clears topo JSON string (if any)
@@ -143,20 +265,21 @@ public:
      * Stats Related
      */
     bool is_state_build();
+
     /**
      * Start transmit
      */
-    void start_transmit(const start_params_t &args);
+    void start_transmit(std::string profile_id, const start_params_t &args);
 
     /**
      * Stop transmit
      */
-    void stop_transmit();
+    void stop_transmit(std::string profile_id);
 
     /**
      * Update traffic rate
      */
-    void update_rate(double mult);
+    void update_rate(std::string profile_id, double mult);
 
     TrexOwner& get_owner() {
         return m_owner;
@@ -187,7 +310,7 @@ public:
         return m_sync_b;
     }
 
-    void dp_core_error(int thread_id, const std::string &err);
+    void dp_core_error(int thread_id, uint32_t profile_index, const std::string &err);
 
     state_e get_state() {
         return m_state;
@@ -204,20 +327,37 @@ public:
         return((CRxAstfCore *)m_rx);
     }
 
-    bool profile_needs_parsing();
     bool topo_needs_parsing();
+
+    /**
+     * update_astf_state          : update state for all profiles
+     * get_profiles_status        : get JSON value list for all profiles id
+     * publish_astf_state         : publish state change event for profile
+     * publish_astf_profile_clear : publish clear event for profile
+     */
+    void update_astf_state();
+    void get_profiles_status(Json::Value &result);
+    void publish_astf_state(std::string profile_id);
+    void publish_astf_profile_clear(std::string profile_id);
+
+    /**
+     * run_cmd_in_wait_list : run the first command in m_cmd_wait_list
+     * add_cmd_in_wait_list : add command in m_cmd_wait_list
+     * del_cmd_in_wait_list : delete command in m_cmd_wait_list
+     * get_cmd_in_wait_list : get command in m_cmd_wait_list
+     */
+    void run_cmd_in_wait_list();
+    void add_cmd_in_wait_list(std::string profile_id, cmd_wait_e cmd);
+    void del_cmd_in_wait_list(std::string profile_id);
+    cmd_wait_e get_cmd_in_wait_list(std::string profile_id);
 
 protected:
     // message to DP involved:
-    void parse();
-    void build();
-    void transmit();
-    void cleanup();
+    void parse(std::string profile_id);
+    void build(std::string profile_id);
+    void transmit(std::string profile_id, double duration);
+    void cleanup(std::string profile_id);
     bool is_trans_state();
-
-    bool is_error() {
-        return m_error.size() > 0;
-    }
 
     void change_state(state_e new_state);
     void set_barrier(double timeout_sec);
@@ -235,21 +375,18 @@ protected:
 
     TrexOwner       m_owner;
     state_e         m_state;
-    int16_t         m_active_cores;
-    std::vector<std::string> m_states_names;
     CSyncBarrier   *m_sync_b;
     CFlowGenList   *m_fl;
     CParserOption  *m_opts;
-    std::string     m_error;
-    std::string     m_profile_buffer;
-    std::string     m_profile_hash;
-    bool            m_profile_parsed;
     std::string     m_topo_buffer;
     std::string     m_topo_hash;
     bool            m_topo_parsed;
     uint64_t        m_epoch;
-};
 
+private:
+    /* Waiting list to serialize mass command execution. <profile_id, cmd> */
+    std::vector<pair<std::string, cmd_wait_e>> m_cmd_wait_list;
+};
 
 static inline TrexAstf * get_astf_object() {
     return (TrexAstf *)get_stx();

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -52,6 +52,7 @@ public:
         STATE_BUILD, // by DP cores, not cancelable
         STATE_TX,
         STATE_CLEANUP, // by DP cores, not cancelable
+        STATE_DELETE,  // by DP core 0, not cancelable
         AMOUNT_OF_STATES,
     };
 };
@@ -98,6 +99,7 @@ public:
     bool            m_profile_stopping;
 
     int16_t         m_active_cores;
+    bool            m_nc_flow_close;
     double          m_duration;
     double          m_factor;
     std::string     m_error;
@@ -136,12 +138,11 @@ public:
     /**
      * Profile-related:
      * cmp - compare hash to loaded profile, true = matches (heavy profile will not be uploaded twice)
-     * clear - clears profile JSON string (if any)
+     * init - clears profile JSON string (if any)
      * append - appends fragment to profile JSON string
      * loaded - move state from idle to loaded
      */
     trex_astf_hash_e profile_cmp_hash(std::string profile_id, const std::string &hash);
-    void profile_clear(std::string profile_id);
     void profile_init(std::string profile_id);
     void profile_append(std::string profile_id, const std::string &fragment);
     void profile_set_loaded(std::string profile_id);
@@ -277,6 +278,11 @@ public:
     void stop_transmit(std::string profile_id);
 
     /**
+     * Clear profile
+     */
+    void profile_clear(std::string profile_id);
+
+    /**
      * Update traffic rate
      */
     void update_rate(std::string profile_id, double mult);
@@ -355,7 +361,7 @@ protected:
     // message to DP involved:
     void parse(std::string profile_id);
     void build(std::string profile_id);
-    void transmit(std::string profile_id, double duration);
+    void transmit(std::string profile_id);
     void cleanup(std::string profile_id);
     bool is_trans_state();
 

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -358,7 +358,7 @@ public:
      * get_profiles_status        : get JSON value list for all profiles id
      */
     void update_astf_state();
-    void publish_astf_state(std::string err);
+    void publish_astf_state(std::string &err);
     void get_profiles_status(Json::Value &result);
 
     void set_barrier(double timeout_sec);

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -292,8 +292,9 @@ void TrexAstfDpCore::parse_astf_json(profile_id_t profile_id, string *profile_bu
         try {
             TopoMngr *topo_mngr = db->get_topo();
             topo_mngr->from_json_str(*topo_buffer);
-            ClientCfgDB *m_cc_db = db->get_client_cfg_db();
-            m_cc_db->load_from_topo(topo_mngr);
+            ClientCfgDB &m_cc_db = m_flow_gen->m_flow_list->m_client_config_info;
+            m_cc_db.load_from_topo(topo_mngr);
+            db->set_client_cfg_db(&m_cc_db);
             //topo_mngr->dump();
         } catch (const TopoError &ex) {
             report_error(profile_id, ex.what());
@@ -399,6 +400,8 @@ void TrexAstfDpCore::start_transmit(profile_id_t profile_id, double duration) {
         report_error(profile_id, "Start of invalid profile state " + std::to_string(get_profile_state(profile_id)));
         return;
     }
+
+    set_profile_state(profile_id, pSTATE_STARTING);
 
     switch (m_state) {
     case STATE_IDLE:

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include "stt_cp.h"
 #include "utl_sync_barrier.h"
 #include "trex_messaging.h"
+#include "trex_astf_messaging.h"    /* TrexAstfDpStop */
 
 #include "trex_astf.h"
 #include "trex_astf_dp_core.h"
@@ -36,6 +37,8 @@ using namespace std;
 
 TrexAstfDpCore::TrexAstfDpCore(uint8_t thread_id, CFlowGenListPerThread *core) :
                 TrexDpCore(thread_id, core, STATE_IDLE) {
+    m_sched_param.m_flag = false;
+    m_sched_param.m_stopping = false;
     CSyncBarrier *sync_barrier = get_astf_object()->get_barrier();
     m_flow_gen = m_core;
     m_flow_gen->set_sync_barrier(sync_barrier);
@@ -54,15 +57,31 @@ bool TrexAstfDpCore::is_port_active(uint8_t port_id) {
     return m_state != STATE_IDLE;
 }
 
+void TrexAstfDpCore::add_profile_duration(uint32_t profile_id, double duration) {
+    if (duration > 0.0) {
+        CGenNodeCommand * node = (CGenNodeCommand*)m_core->create_node() ;
+        int stop_id = m_core->m_c_tcp->get_stop_id(profile_id);
 
-void TrexAstfDpCore::start_scheduler() {
+        node->m_type = CGenNode::COMMAND;
 
-    dsec_t d_time_flow;
+        /* make sure it will be scheduled after the current node */
+        node->m_time = m_core->m_cur_time_sec + duration ;
 
+        TrexAstfDpStop * cmd = new TrexAstfDpStop(profile_id, stop_id);
+
+        /* test this */
+        m_core->m_non_active_nodes++;
+        node->m_cmd = cmd;
+        cmd->set_core_ptr(m_core);
+
+        m_core->m_node_gen.add_node((CGenNode *)node);
+    }
+}
+
+void TrexAstfDpCore::get_scheduler_options(uint32_t profile_id, bool& disable_client, dsec_t& d_time_flow, double& d_phase) {
     CParserOption *go = &CGlobalInfo::m_options;
 
     /* do we need to disable this tread client port */
-    bool disable_client = false;
     if ( go->m_astf_mode == CParserOption::OP_ASTF_MODE_SERVR_ONLY ) {
         disable_client = true;
     } else {
@@ -76,15 +95,34 @@ void TrexAstfDpCore::start_scheduler() {
         }
     }
 
-    d_time_flow = m_flow_gen->m_c_tcp->m_fif_d_time; /* set by Create_tcp function */
+    d_time_flow = m_flow_gen->m_c_tcp->get_fif_d_time(profile_id); /* set by Create_tcp function */
 
-    double d_phase = 0.01 + (double)m_flow_gen->m_thread_id * d_time_flow / (double)m_flow_gen->m_max_threads;
+    d_phase = 0.01 + (double)m_flow_gen->m_thread_id * d_time_flow / (double)m_flow_gen->m_max_threads;
 
     if ( CGlobalInfo::is_realtime() ) {
         if (d_phase > 0.2 ) {
             d_phase =  0.01 + m_flow_gen->m_thread_id * 0.01;
         }
     }
+}
+
+void TrexAstfDpCore::start_scheduler() {
+
+    uint32_t profile_id = 0;
+    double duration = -1;
+
+    if (m_sched_param.m_flag) { /* set by start_transmit function */
+        profile_id = m_sched_param.m_profile_id;
+        duration = m_sched_param.m_duration;
+    }
+
+    dsec_t d_time_flow;
+    bool disable_client = false;
+    double d_phase;
+
+    get_scheduler_options(profile_id, disable_client, d_time_flow, d_phase);
+
+    CParserOption *go = &CGlobalInfo::m_options;
 
     double old_offset = 0.0;
     CGenNode *node;
@@ -93,7 +131,10 @@ void TrexAstfDpCore::start_scheduler() {
     if ( sync_barrier() ) {
         dsec_t now = now_sec();
         dsec_t c_stop_sec = -1;
-        if ( m_flow_gen->m_yaml_info.m_duration_sec > 0 ) {
+        if ( duration > 0.0 ) {
+            c_stop_sec = now + d_phase + duration;
+        }
+        else if ( m_flow_gen->m_yaml_info.m_duration_sec > 0 ) {
             c_stop_sec = now + d_phase + m_flow_gen->m_yaml_info.m_duration_sec;
         }
 
@@ -103,7 +144,24 @@ void TrexAstfDpCore::start_scheduler() {
             node = m_flow_gen->create_node();
             node->m_type = CGenNode::TCP_TX_FIF;
             node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
+            node->m_ctx = m_flow_gen->m_c_tcp->get_profile_ctx(profile_id);
             m_flow_gen->m_node_gen.add_node(node);
+        }
+
+        m_flow_gen->m_c_tcp->activate(profile_id);
+        m_flow_gen->m_s_tcp->activate(profile_id);
+        if (c_stop_sec > 0.0) {
+            add_profile_duration(profile_id, c_stop_sec - now);
+        }
+
+        if (m_sched_param.m_flag) {
+            for (auto param: m_sched_param.m_params) {
+                if (m_flow_gen->m_c_tcp->is_created(param.m_profile_id)) {
+                    start_profile_ctx(param.m_profile_id, param.m_duration);
+                }
+            }
+            m_sched_param.m_params.clear();
+            m_sched_param.m_flag = false;
         }
 
         node = m_flow_gen->create_node() ;
@@ -121,7 +179,7 @@ void TrexAstfDpCore::start_scheduler() {
         node->m_time = now;
         m_flow_gen->m_node_gen.add_node(node);
 
-        m_flow_gen->m_node_gen.flush_file(c_stop_sec, d_time_flow, false, m_flow_gen, old_offset);
+        m_flow_gen->m_node_gen.flush_file(-1, d_time_flow, false, m_flow_gen, old_offset);
 
         if ( !m_flow_gen->is_terminated_by_master() && !go->preview.getNoCleanFlowClose() ) { // close gracefully
             m_flow_gen->m_node_gen.flush_file(-1, d_time_flow, true, m_flow_gen, old_offset);
@@ -131,20 +189,119 @@ void TrexAstfDpCore::start_scheduler() {
         m_flow_gen->m_c_tcp->cleanup_flows();
         m_flow_gen->m_s_tcp->cleanup_flows();
     } else {
-        report_error("Could not sync DP thread for start, core ID: " + to_string(m_flow_gen->m_thread_id));
+        report_error(profile_id, "Could not sync DP thread for start, core ID: " + to_string(m_flow_gen->m_thread_id));
+
+        if (m_sched_param.m_flag) {
+            for (auto param: m_sched_param.m_params) {
+                if (m_flow_gen->m_c_tcp->is_created(param.m_profile_id)) {
+                    report_error(param.m_profile_id, "Could not sync DP thread for start, core ID: " + to_string(m_flow_gen->m_thread_id));
+                }
+            }
+            m_sched_param.m_params.clear();
+            m_sched_param.m_flag = false;
+        }
     }
 
     if ( m_state != STATE_TERMINATE ) {
-        report_finished();
-        m_state = STATE_IDLE;
+        std::vector<uint32_t> c_profile_ids;
+        std::vector<uint32_t> s_profile_ids;
+
+        m_flow_gen->m_c_tcp->set_all_stopped(c_profile_ids);
+        m_flow_gen->m_s_tcp->set_all_stopped(s_profile_ids);
+        assert(c_profile_ids.size() == s_profile_ids.size());
+        for (auto id: c_profile_ids) {
+            report_finished(id);
+        }
+
+        if (m_sched_param.m_stopping) {
+            m_sched_param.m_stopping = false;
+        }
+        if (m_sched_param.m_flag == false) {
+            m_state = STATE_IDLE;
+        }
     }
 }
 
-void TrexAstfDpCore::parse_astf_json(string *profile_buffer, string *topo_buffer) {
+void TrexAstfDpCore::start_profile_ctx(uint32_t profile_id, double duration) {
+
+    dsec_t d_time_flow;
+    bool disable_client = false;
+    double d_phase;
+
+    get_scheduler_options(profile_id, disable_client, d_time_flow, d_phase);
+
+    if ( !disable_client ) {
+        CGenNode *node = m_flow_gen->create_node();
+
+        node->m_type = CGenNode::TCP_TX_FIF;
+        node->m_time = m_core->m_cur_time_sec + d_phase + 0.1; /* phase the transmit a bit */
+        node->m_ctx = m_flow_gen->m_c_tcp->get_profile_ctx(profile_id);
+        m_flow_gen->m_node_gen.add_node(node);
+    }
+
+    m_flow_gen->m_c_tcp->activate(profile_id);
+    m_flow_gen->m_s_tcp->activate(profile_id);
+    if ( duration > 0 ) {
+        add_profile_duration(profile_id, d_phase + duration);
+    }
+}
+
+void TrexAstfDpCore::stop_profile_ctx(uint32_t profile_id, uint32_t stop_id) {
+    CParserOption *go = &CGlobalInfo::m_options;
+    bool immediate_stop = true;
+
+    /* skip already stopped profile */
+    if (m_flow_gen->m_c_tcp->is_stopped(profile_id) && m_flow_gen->m_s_tcp->is_stopped(profile_id)) {
+        return;
+    }
+
+    /* skip unmatched stop_id profile - used only client side's value */
+    if (stop_id && m_flow_gen->m_c_tcp->get_stop_id(profile_id) != stop_id) {
+        return;
+    }
+
+    if (m_flow_gen->m_c_tcp->is_active(profile_id) && m_flow_gen->m_s_tcp->is_active(profile_id)) {
+        if ((m_flow_gen->m_c_tcp->profile_flow_cnt(profile_id) > 0) ||
+            (m_flow_gen->m_s_tcp->profile_flow_cnt(profile_id) > 0)) {
+            immediate_stop = false;
+        }
+    }
+    m_flow_gen->m_c_tcp->deactivate(profile_id);
+    m_flow_gen->m_s_tcp->deactivate(profile_id);
+
+    if (m_sched_param.m_stopping == true) { // is stopping whole profiles
+        return;
+    }
+    if (m_sched_param.m_flag == true) { // will enter into node scheduler
+        add_profile_duration(profile_id, 0.0001); // to stop in the node scheduler
+        return;
+    }
+
+    if ((m_flow_gen->m_c_tcp->active_profile_cnt() == 0) || m_flow_gen->is_terminated_by_master()) {
+        /* last profile should trigger exit scheduler */
+        add_global_duration(0.0001);
+        m_sched_param.m_stopping = true;
+    }
+    else if (immediate_stop || go->preview.getNoCleanFlowClose()) {
+        m_flow_gen->flush_tx_queue();
+        m_flow_gen->m_c_tcp->cleanup_flows(profile_id);
+        m_flow_gen->m_s_tcp->cleanup_flows(profile_id);
+
+        m_flow_gen->m_c_tcp->set_stopped(profile_id);
+        m_flow_gen->m_s_tcp->set_stopped(profile_id);
+        report_finished(profile_id);
+    }
+    else {
+        // stop profile gracefully, second stop will be done immediately
+        add_profile_duration(profile_id, 2.0);  // wait 2.0 sec, aligned with handle_rx_flush()
+    }
+}
+
+void TrexAstfDpCore::parse_astf_json(uint32_t profile_id, string *profile_buffer, string *topo_buffer) {
     TrexWatchDog::IOFunction dummy;
     (void)dummy;
 
-    CAstfDB *db = CAstfDB::instance();
+    CAstfDB *db = CAstfDB::instance(profile_id);
     string err = "";
     bool rc;
 
@@ -152,24 +309,23 @@ void TrexAstfDpCore::parse_astf_json(string *profile_buffer, string *topo_buffer
         try {
             TopoMngr *topo_mngr = db->get_topo();
             topo_mngr->from_json_str(*topo_buffer);
-            ClientCfgDB &m_cc_db = m_flow_gen->m_flow_list->m_client_config_info;
-            m_cc_db.load_from_topo(topo_mngr);
-            db->set_client_cfg_db(&m_cc_db);
+            ClientCfgDB *m_cc_db = db->get_client_cfg_db();
+            m_cc_db->load_from_topo(topo_mngr);
             //topo_mngr->dump();
         } catch (const TopoError &ex) {
-            report_error(ex.what());
+            report_error(profile_id, ex.what());
             return;
         }
     }
 
     if ( !profile_buffer ) {
-        report_finished();
+        report_finished(profile_id);
         return;
     }
 
     rc = db->set_profile_one_msg(*profile_buffer, err);
     if ( !rc ) {
-        report_error("Profile parsing error: " + err);
+        report_error(profile_id, "Profile parsing error: " + err);
         return;
     }
 
@@ -179,68 +335,85 @@ void TrexAstfDpCore::parse_astf_json(string *profile_buffer, string *topo_buffer
     CJsonData_err err_obj = db->verify_data(num_dp_cores);
 
     if ( err_obj.is_error() ) {
-        report_error("Profile split to DP cores error: " + err_obj.description());
+        report_error(profile_id, "Profile split to DP cores error: " + err_obj.description());
     } else {
-        report_finished();
+        report_finished(profile_id);
     }
 }
 
-void TrexAstfDpCore::create_tcp_batch() {
+void TrexAstfDpCore::create_tcp_batch(uint32_t profile_id) {
     TrexWatchDog::IOFunction dummy;
     (void)dummy;
 
     CParserOption *go = &CGlobalInfo::m_options;
 
-    m_flow_gen->m_cur_flow_id = 1;
-    m_flow_gen->m_stats.clear();
+#if 0
+    m_flow_gen->m_cur_flow_id = 1;      /* not used in ASTF mode */
+    m_flow_gen->m_stats.clear();        /* need to be global operation */
+#endif
     m_flow_gen->m_yaml_info.m_duration_sec = go->m_duration;
 
     try {
-        m_flow_gen->load_tcp_profile();
+        m_flow_gen->load_tcp_profile(profile_id);
     } catch (const TrexException &ex) {
-        report_error("Could not create ASTF batch: " + string(ex.what()));
+        report_error(profile_id, "Could not create ASTF batch: " + string(ex.what()));
         return;
     }
 
-    report_finished();
+    report_finished(profile_id);
 }
 
-void TrexAstfDpCore::delete_tcp_batch() {
+void TrexAstfDpCore::delete_tcp_batch(uint32_t profile_id) {
     TrexWatchDog::IOFunction dummy;
     (void)dummy;
 
-    m_flow_gen->unload_tcp_profile();
-    report_finished();
+    m_flow_gen->unload_tcp_profile(profile_id);
+    report_finished(profile_id);
 }
 
-void TrexAstfDpCore::start_transmit() {
-    assert(m_state==STATE_IDLE);
-    m_state = STATE_TRANSMITTING;
+void TrexAstfDpCore::start_transmit(uint32_t profile_id, double duration) {
+    assert((m_state==STATE_IDLE) || (m_state==STATE_TRANSMITTING));
+
+    if (m_sched_param.m_flag == true) {
+        m_sched_param.m_params.push_back({ profile_id, duration });
+    }
+    else if (m_state == STATE_IDLE || m_sched_param.m_stopping == true) {
+        m_state = STATE_TRANSMITTING;
+
+        /* save profile_id/duration as start_scheduler() parameters */
+        m_sched_param.m_flag = true;
+        m_sched_param.m_profile_id = profile_id;
+        m_sched_param.m_duration = duration;
+    }
+    else {
+        start_profile_ctx(profile_id, duration);
+    }
 }
 
-void TrexAstfDpCore::stop_transmit() {
+void TrexAstfDpCore::stop_transmit(uint32_t profile_id, uint32_t stop_id) {
     if ( m_state == STATE_IDLE ) { // is stopped, just ack
         return;
     }
 
-    add_global_duration(0.0001);
+    stop_profile_ctx(profile_id, stop_id);
 }
 
-void TrexAstfDpCore::update_rate(double old_new_ratio) {
-    m_flow_gen->m_c_tcp->m_fif_d_time *= old_new_ratio;
+void TrexAstfDpCore::update_rate(uint32_t profile_id, double old_new_ratio) {
+    double fif_d_time = m_flow_gen->m_c_tcp->get_fif_d_time(profile_id);
+    m_flow_gen->m_c_tcp->set_fif_d_time(fif_d_time*old_new_ratio, profile_id);
 }
 
 bool TrexAstfDpCore::sync_barrier() {
     return (m_flow_gen->get_sync_b()->sync_barrier(m_flow_gen->m_thread_id) == 0);
 }
 
-void TrexAstfDpCore::report_finished() {
-    TrexDpToCpMsgBase *msg = new TrexDpCoreStopped(m_flow_gen->m_thread_id);
+void TrexAstfDpCore::report_finished(uint32_t profile_id) {
+    TrexDpToCpMsgBase *msg = new TrexDpCoreStopped(m_flow_gen->m_thread_id, profile_id);
     m_ring_to_cp->Enqueue((CGenNode *)msg);
 }
 
-void TrexAstfDpCore::report_error(const string &error) {
-    TrexDpToCpMsgBase *msg = new TrexDpCoreError(m_flow_gen->m_thread_id, error);
+void TrexAstfDpCore::report_error(uint32_t profile_id, const string &error) {
+    TrexDpToCpMsgBase *msg = new TrexDpCoreError(m_flow_gen->m_thread_id, profile_id, error);
     m_ring_to_cp->Enqueue((CGenNode *)msg);
 }
 

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -237,7 +237,7 @@ void TrexAstfDpCore::start_profile_ctx(uint32_t profile_id, double duration) {
 
         tx_node->m_type = CGenNode::TCP_TX_FIF;
         tx_node->m_time = m_core->m_cur_time_sec + d_phase + 0.1; /* phase the transmit a bit */
-        tx_node->m_ctx = m_flow_gen->m_c_tcp->get_profile_ctx(profile_id);
+        tx_node->m_pctx = m_flow_gen->m_c_tcp->get_profile_ctx(profile_id);
         m_flow_gen->m_node_gen.add_node((CGenNode*)tx_node);
     }
 

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -69,7 +69,6 @@ void TrexAstfDpCore::set_profile_stopping(uint32_t profile_id) {
     set_profile_state(profile_id, pSTATE_WAIT);
     m_flow_gen->m_c_tcp->deactivate_profile_ctx(profile_id);
     m_flow_gen->m_s_tcp->deactivate_profile_ctx(profile_id);
-    set_profile_stop_event(profile_id);
 }
 
 void TrexAstfDpCore::on_profile_stop_event(uint32_t profile_id) {
@@ -263,15 +262,15 @@ void TrexAstfDpCore::stop_profile_ctx(uint32_t profile_id, uint32_t stop_id) {
         return;
     }
 
-    CParserOption *go = &CGlobalInfo::m_options;
-
-    if (go->preview.getNoCleanFlowClose() ||
-        ((m_flow_gen->m_c_tcp->profile_flow_cnt(profile_id) == 0) &&
-         (m_flow_gen->m_s_tcp->profile_flow_cnt(profile_id) == 0))) {
+    if ((m_flow_gen->m_c_tcp->profile_flow_cnt(profile_id) == 0) &&
+        (m_flow_gen->m_s_tcp->profile_flow_cnt(profile_id) == 0)) {
         m_flow_gen->flush_tx_queue();
 
         set_profile_state(profile_id, pSTATE_LOADED);
         report_finished(profile_id);
+    }
+    else {
+        set_profile_stop_event(profile_id);
     }
 }
 

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -255,11 +255,9 @@ void TrexAstfDpCore::stop_profile_ctx(uint32_t profile_id, uint32_t stop_id) {
         return;
     }
 
-    if (m_flow_gen->m_c_tcp->is_active(profile_id) && m_flow_gen->m_s_tcp->is_active(profile_id)) {
-        if ((m_flow_gen->m_c_tcp->profile_flow_cnt(profile_id) > 0) ||
-            (m_flow_gen->m_s_tcp->profile_flow_cnt(profile_id) > 0)) {
-            immediate_stop = false;
-        }
+    if ((m_flow_gen->m_c_tcp->profile_flow_cnt(profile_id) > 0) ||
+        (m_flow_gen->m_s_tcp->profile_flow_cnt(profile_id) > 0)) {
+        immediate_stop = false;
     }
     m_flow_gen->m_c_tcp->deactivate(profile_id);
     m_flow_gen->m_s_tcp->deactivate(profile_id);
@@ -279,8 +277,6 @@ void TrexAstfDpCore::stop_profile_ctx(uint32_t profile_id, uint32_t stop_id) {
     }
     else if (immediate_stop || go->preview.getNoCleanFlowClose()) {
         m_flow_gen->flush_tx_queue();
-        m_flow_gen->m_c_tcp->cleanup_flows(profile_id);
-        m_flow_gen->m_s_tcp->cleanup_flows(profile_id);
 
         m_flow_gen->m_c_tcp->set_stopped(profile_id);
         m_flow_gen->m_s_tcp->set_stopped(profile_id);

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -51,9 +51,10 @@ public:
     void start_transmit(uint32_t profile_id, double duration);
     void stop_transmit(uint32_t profile_id, uint32_t stop_id);
     void update_rate(uint32_t profile_id, double ratio);
-    void create_tcp_batch(uint32_t profile_id);
+    void create_tcp_batch(uint32_t profile_id, double factor);
     void delete_tcp_batch(uint32_t profile_id);
     void parse_astf_json(uint32_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
+    void remove_astf_json(uint32_t profile_id);
 
 protected:
     virtual bool rx_for_idle();

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -78,7 +78,8 @@ protected:
     enum profile_state_e {
         pSTATE_FREE,    // by create or delete_tcp_batch
         pSTATE_LOADED,  // by create_tcp_batch or stop_transmit
-        pSTATE_ACTIVE,  // by start_transmit
+        pSTATE_STARTING,// by start_transmit
+        pSTATE_ACTIVE,  // by start_profile_ctx
         pSTATE_WAIT     // by stop_transmit
     };
 

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -42,21 +42,41 @@ public:
      */
     virtual bool is_port_active(uint8_t port_id);
 
-    void start_transmit();
-    void stop_transmit();
-    void update_rate(double ratio);
-    void create_tcp_batch();
-    void delete_tcp_batch();
-    void parse_astf_json(std::string *profile_buffer, std::string *topo_buffer);
+    void start_transmit(uint32_t profile_id, double duration);
+    void stop_transmit(uint32_t profile_id, uint32_t stop_id);
+    void update_rate(uint32_t profile_id, double ratio);
+    void create_tcp_batch(uint32_t profile_id);
+    void delete_tcp_batch(uint32_t profile_id);
+    void parse_astf_json(uint32_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
 
 protected:
     virtual bool rx_for_idle();
-    void report_finished();
-    void report_error(const std::string &error);
+    void report_finished(uint32_t profile_id = 0);
+    void report_error(uint32_t profile_id, const std::string &error);
     bool sync_barrier();
     CFlowGenListPerThread *m_flow_gen;
 
     virtual void start_scheduler() override;
+
+    void add_profile_duration(uint32_t profile_id, double duration);
+    void get_scheduler_options(uint32_t profile_id, bool& disable_client, double& d_time_flow, double& d_phase);
+    void start_profile_ctx(uint32_t profile_id, double duration);
+    void stop_profile_ctx(uint32_t profile_id, uint32_t stop_id);
+
+    /* scheduling profile parameters */
+    struct profile_param {
+        uint32_t    m_profile_id;
+        double      m_duration;
+    };
+    struct {
+        bool        m_flag; /* starting */
+
+        uint32_t    m_profile_id;
+        double      m_duration;
+        std::vector<struct profile_param> m_params;
+
+        bool        m_stopping;
+    } m_sched_param;
 };
 
 #endif /* __TREX_ASTF_DP_CORE_H__ */

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -127,9 +127,11 @@ protected:
         return m_profile_stop_id;
     }
 
+    void set_profile_stop_event(profile_id_t profile_id);
+    void clear_profile_stop_event_all();
+
 public:
     void on_profile_stop_event(profile_id_t profile_id);
-    void set_profile_stop_event(profile_id_t profile_id);
 };
 
 #endif /* __TREX_ASTF_DP_CORE_H__ */

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -25,6 +25,44 @@ limitations under the License.
 #include <string>
 #include "trex_dp_core.h"
 
+struct profile_param {
+    uint32_t    m_profile_id;
+    double      m_duration;
+};
+
+class DpCoreSchedParam {
+private:
+    bool        m_flag; /* starting */
+
+    uint32_t    m_profile_id;
+    double      m_duration;
+    std::vector<struct profile_param> m_params;
+
+    bool        m_stopping;
+public:
+    void set_starting_param(uint32_t profile_id, double duration) {
+        m_flag = true;
+        m_profile_id = profile_id;
+        m_duration = duration;
+    }
+    void append_starting_param(uint32_t profile_id, double duration) {
+        m_params.push_back({profile_id, duration});
+    }
+    void get_starting_param(uint32_t& profile_id, double& duration) {
+        profile_id = m_profile_id;
+        duration = m_duration;
+    }
+    std::vector<struct profile_param> get_addendum_params() { return m_params; }
+
+    void clear_starting() { m_flag = false; m_params.clear(); }
+    bool is_starting() { return m_flag; }
+
+    void set_stopping() { m_stopping = true; }
+    void clear_stopping() { m_stopping = false; }
+    bool is_stopping() { return m_stopping; }
+};
+
+
 class TrexAstfDpCore : public TrexDpCore {
 
 public:
@@ -63,20 +101,7 @@ protected:
     void start_profile_ctx(uint32_t profile_id, double duration);
     void stop_profile_ctx(uint32_t profile_id, uint32_t stop_id);
 
-    /* scheduling profile parameters */
-    struct profile_param {
-        uint32_t    m_profile_id;
-        double      m_duration;
-    };
-    struct {
-        bool        m_flag; /* starting */
-
-        uint32_t    m_profile_id;
-        double      m_duration;
-        std::vector<struct profile_param> m_params;
-
-        bool        m_stopping;
-    } m_sched_param;
+    DpCoreSchedParam    m_sched_param;
 };
 
 #endif /* __TREX_ASTF_DP_CORE_H__ */

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -34,88 +34,107 @@ TrexAstfDpCore* astf_core(TrexDpCore *dp_core) {
 /*************************
   start traffic message
  ************************/
-TrexAstfDpStart::TrexAstfDpStart() {
+TrexAstfDpStart::TrexAstfDpStart(uint32_t profile_id, double duration) {
+    m_profile_id = profile_id;
+    m_duration = duration;
 }
 
 
 bool TrexAstfDpStart::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->start_transmit();
+    astf_core(dp_core)->start_transmit(m_profile_id, m_duration);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpStart::clone() {
-    return new TrexAstfDpStart();
+    return new TrexAstfDpStart(m_profile_id, m_duration);
 }
 
 /*************************
   stop traffic message
  ************************/
-TrexAstfDpStop::TrexAstfDpStop() {}
+TrexAstfDpStop::TrexAstfDpStop(uint32_t profile_id, uint32_t stop_id) {
+    m_profile_id = profile_id;
+    m_core = NULL;
+    m_stop_id = stop_id;
+}
 
 bool TrexAstfDpStop::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->stop_transmit();
+    astf_core(dp_core)->stop_transmit(m_profile_id, m_stop_id);
     return true;
 }
 
+void TrexAstfDpStop::on_node_remove() {
+    if (m_core) {
+        assert(m_core->m_non_active_nodes>0);
+        m_core->m_non_active_nodes--;
+    }
+}
+
 TrexCpToDpMsgBase* TrexAstfDpStop::clone() {
-    return new TrexAstfDpStop();
+    return new TrexAstfDpStop(m_profile_id, m_stop_id);
 }
 
 /*************************
   update traffic message
  ************************/
-TrexAstfDpUpdate::TrexAstfDpUpdate(double old_new_ratio) {
+TrexAstfDpUpdate::TrexAstfDpUpdate(uint32_t profile_id, double old_new_ratio) {
+    m_profile_id    = profile_id;
     m_old_new_ratio = old_new_ratio;
 }
 
 bool TrexAstfDpUpdate::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->update_rate(m_old_new_ratio);
+    astf_core(dp_core)->update_rate(m_profile_id, m_old_new_ratio);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpUpdate::clone() {
-    return new TrexAstfDpUpdate(m_old_new_ratio);
+    return new TrexAstfDpUpdate(m_profile_id, m_old_new_ratio);
 }
 
 /*************************
   create tcp batch
  ************************/
-TrexAstfDpCreateTcp::TrexAstfDpCreateTcp() {}
+TrexAstfDpCreateTcp::TrexAstfDpCreateTcp(uint32_t profile_id) {
+    m_profile_id = profile_id;
+}
 
 bool TrexAstfDpCreateTcp::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->create_tcp_batch();
+    astf_core(dp_core)->create_tcp_batch(m_profile_id);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpCreateTcp::clone() {
-    return new TrexAstfDpCreateTcp();
+    return new TrexAstfDpCreateTcp(m_profile_id);
 }
 
 /*************************
   delete tcp batch
  ************************/
-TrexAstfDpDeleteTcp::TrexAstfDpDeleteTcp() {}
+TrexAstfDpDeleteTcp::TrexAstfDpDeleteTcp(uint32_t profile_id) {
+    m_profile_id = profile_id;
+}
 
 bool TrexAstfDpDeleteTcp::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->delete_tcp_batch();
+    astf_core(dp_core)->delete_tcp_batch(m_profile_id);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpDeleteTcp::clone() {
-    return new TrexAstfDpDeleteTcp();
+    return new TrexAstfDpDeleteTcp(m_profile_id);
 }
 
 
 /*************************
   parse ASTF JSON from string
  ************************/
-TrexAstfLoadDB::TrexAstfLoadDB(string *profile_buffer, string *topo_buffer) {
+TrexAstfLoadDB::TrexAstfLoadDB(uint32_t profile_id, string *profile_buffer, string *topo_buffer) {
+    m_profile_id     = profile_id;
     m_profile_buffer = profile_buffer;
     m_topo_buffer    = topo_buffer;
 }
 
 bool TrexAstfLoadDB::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->parse_astf_json(m_profile_buffer, m_topo_buffer);
+    astf_core(dp_core)->parse_astf_json(m_profile_id, m_profile_buffer, m_topo_buffer);
     return true;
 }
 

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -94,17 +94,18 @@ TrexCpToDpMsgBase* TrexAstfDpUpdate::clone() {
 /*************************
   create tcp batch
  ************************/
-TrexAstfDpCreateTcp::TrexAstfDpCreateTcp(uint32_t profile_id) {
+TrexAstfDpCreateTcp::TrexAstfDpCreateTcp(uint32_t profile_id, double factor) {
     m_profile_id = profile_id;
+    m_factor = factor;
 }
 
 bool TrexAstfDpCreateTcp::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->create_tcp_batch(m_profile_id);
+    astf_core(dp_core)->create_tcp_batch(m_profile_id, m_factor);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpCreateTcp::clone() {
-    return new TrexAstfDpCreateTcp(m_profile_id);
+    return new TrexAstfDpCreateTcp(m_profile_id, m_factor);
 }
 
 /*************************
@@ -143,3 +144,19 @@ TrexCpToDpMsgBase* TrexAstfLoadDB::clone() {
     return nullptr;
 }
 
+/*************************
+  remove ASTF JSON and DB
+ ************************/
+TrexAstfDeleteDB::TrexAstfDeleteDB(uint32_t profile_id) {
+    m_profile_id     = profile_id;
+}
+
+bool TrexAstfDeleteDB::handle(TrexDpCore *dp_core) {
+    astf_core(dp_core)->remove_astf_json(m_profile_id);
+    return true;
+}
+
+TrexCpToDpMsgBase* TrexAstfDeleteDB::clone() {
+    assert(0); // should not be cloned [and sent to several cores]
+    return nullptr;
+}

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -34,7 +34,7 @@ TrexAstfDpCore* astf_core(TrexDpCore *dp_core) {
 /*************************
   start traffic message
  ************************/
-TrexAstfDpStart::TrexAstfDpStart(uint32_t profile_id, double duration) {
+TrexAstfDpStart::TrexAstfDpStart(profile_id_t profile_id, double duration) {
     m_profile_id = profile_id;
     m_duration = duration;
 }
@@ -52,7 +52,7 @@ TrexCpToDpMsgBase* TrexAstfDpStart::clone() {
 /*************************
   stop traffic message
  ************************/
-TrexAstfDpStop::TrexAstfDpStop(uint32_t profile_id, uint32_t stop_id) {
+TrexAstfDpStop::TrexAstfDpStop(profile_id_t profile_id, uint32_t stop_id) {
     m_profile_id = profile_id;
     m_core = NULL;
     m_stop_id = stop_id;
@@ -77,7 +77,7 @@ TrexCpToDpMsgBase* TrexAstfDpStop::clone() {
 /*************************
   update traffic message
  ************************/
-TrexAstfDpUpdate::TrexAstfDpUpdate(uint32_t profile_id, double old_new_ratio) {
+TrexAstfDpUpdate::TrexAstfDpUpdate(profile_id_t profile_id, double old_new_ratio) {
     m_profile_id    = profile_id;
     m_old_new_ratio = old_new_ratio;
 }
@@ -94,7 +94,7 @@ TrexCpToDpMsgBase* TrexAstfDpUpdate::clone() {
 /*************************
   create tcp batch
  ************************/
-TrexAstfDpCreateTcp::TrexAstfDpCreateTcp(uint32_t profile_id, double factor) {
+TrexAstfDpCreateTcp::TrexAstfDpCreateTcp(profile_id_t profile_id, double factor) {
     m_profile_id = profile_id;
     m_factor = factor;
 }
@@ -111,24 +111,25 @@ TrexCpToDpMsgBase* TrexAstfDpCreateTcp::clone() {
 /*************************
   delete tcp batch
  ************************/
-TrexAstfDpDeleteTcp::TrexAstfDpDeleteTcp(uint32_t profile_id) {
+TrexAstfDpDeleteTcp::TrexAstfDpDeleteTcp(profile_id_t profile_id, bool do_remove) {
     m_profile_id = profile_id;
+    m_do_remove = do_remove; 
 }
 
 bool TrexAstfDpDeleteTcp::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->delete_tcp_batch(m_profile_id);
+    astf_core(dp_core)->delete_tcp_batch(m_profile_id, m_do_remove);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpDeleteTcp::clone() {
-    return new TrexAstfDpDeleteTcp(m_profile_id);
+    return new TrexAstfDpDeleteTcp(m_profile_id, m_do_remove);
 }
 
 
 /*************************
   parse ASTF JSON from string
  ************************/
-TrexAstfLoadDB::TrexAstfLoadDB(uint32_t profile_id, string *profile_buffer, string *topo_buffer) {
+TrexAstfLoadDB::TrexAstfLoadDB(profile_id_t profile_id, string *profile_buffer, string *topo_buffer) {
     m_profile_id     = profile_id;
     m_profile_buffer = profile_buffer;
     m_topo_buffer    = topo_buffer;
@@ -147,7 +148,7 @@ TrexCpToDpMsgBase* TrexAstfLoadDB::clone() {
 /*************************
   remove ASTF JSON and DB
  ************************/
-TrexAstfDeleteDB::TrexAstfDeleteDB(uint32_t profile_id) {
+TrexAstfDeleteDB::TrexAstfDeleteDB(profile_id_t profile_id) {
     m_profile_id     = profile_id;
 }
 

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -113,7 +113,7 @@ TrexCpToDpMsgBase* TrexAstfDpCreateTcp::clone() {
  ************************/
 TrexAstfDpDeleteTcp::TrexAstfDpDeleteTcp(profile_id_t profile_id, bool do_remove) {
     m_profile_id = profile_id;
-    m_do_remove = do_remove; 
+    m_do_remove = do_remove;
 }
 
 bool TrexAstfDpDeleteTcp::handle(TrexDpCore *dp_core) {

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -29,24 +29,25 @@ limitations under the License.
 // create tcp batch per DP core
 class TrexAstfDpCreateTcp : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpCreateTcp(uint32_t profile_id, double factor);
+    TrexAstfDpCreateTcp(profile_id_t profile_id, double factor);
     TrexAstfDpCreateTcp() : TrexAstfDpCreateTcp(0, -1) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
     double m_factor;
 };
 
 // delete tcp batch per DP core
 class TrexAstfDpDeleteTcp : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpDeleteTcp(uint32_t profile_id);
-    TrexAstfDpDeleteTcp() : TrexAstfDpDeleteTcp(0) {}
+    TrexAstfDpDeleteTcp(profile_id_t profile_id, bool do_remove);
+    TrexAstfDpDeleteTcp() : TrexAstfDpDeleteTcp(0, false) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
+    bool m_do_remove;   // to remove profile context explicitly
 };
 
 /**
@@ -55,12 +56,12 @@ private:
  */
 class TrexAstfDpStart : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpStart(uint32_t profile_id, double duration);
+    TrexAstfDpStart(profile_id_t profile_id, double duration);
     TrexAstfDpStart() : TrexAstfDpStart(0, -1) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
     double m_duration;
 };
 
@@ -70,8 +71,8 @@ private:
  */
 class TrexAstfDpStop : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpStop(uint32_t profile_id, uint32_t stop_id);
-    TrexAstfDpStop(uint32_t profile_id) : TrexAstfDpStop(profile_id, 0) {}
+    TrexAstfDpStop(profile_id_t profile_id, uint32_t stop_id);
+    TrexAstfDpStop(profile_id_t profile_id) : TrexAstfDpStop(profile_id, 0) {}
     TrexAstfDpStop() : TrexAstfDpStop(0, 0) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
@@ -79,7 +80,7 @@ public:
     void set_core_ptr(CFlowGenListPerThread* core) { m_core = core; }
 private:
     CFlowGenListPerThread* m_core;
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
     uint32_t m_stop_id;
 };
 
@@ -89,12 +90,12 @@ private:
  */
 class TrexAstfDpUpdate : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpUpdate(uint32_t profile_id, double old_new_ratio);
+    TrexAstfDpUpdate(profile_id_t profile_id, double old_new_ratio);
     TrexAstfDpUpdate(double old_new_ratio) : TrexAstfDpUpdate(0, old_new_ratio) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
     double m_old_new_ratio;
 };
 
@@ -104,12 +105,12 @@ private:
  */
 class TrexAstfLoadDB : public TrexCpToDpMsgBase {
 public:
-    TrexAstfLoadDB(uint32_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
+    TrexAstfLoadDB(profile_id_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
     TrexAstfLoadDB(std::string *profile_buffer, std::string *topo_buffer) : TrexAstfLoadDB(0, profile_buffer, topo_buffer) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
     std::string *m_profile_buffer;
     std::string *m_topo_buffer;
 };
@@ -120,11 +121,11 @@ private:
  */
 class TrexAstfDeleteDB : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDeleteDB(uint32_t profile_id);
+    TrexAstfDeleteDB(profile_id_t profile_id);
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
 };
 
 

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -29,12 +29,13 @@ limitations under the License.
 // create tcp batch per DP core
 class TrexAstfDpCreateTcp : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpCreateTcp(uint32_t profile_id);
-    TrexAstfDpCreateTcp() : TrexAstfDpCreateTcp(0) {}
+    TrexAstfDpCreateTcp(uint32_t profile_id, double factor);
+    TrexAstfDpCreateTcp() : TrexAstfDpCreateTcp(0, -1) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
     uint32_t m_profile_id;
+    double m_factor;
 };
 
 // delete tcp batch per DP core
@@ -98,7 +99,7 @@ private:
 };
 
 /**
- * a message to stop traffic
+ * a message to load DB
  *
  */
 class TrexAstfLoadDB : public TrexCpToDpMsgBase {
@@ -113,6 +114,18 @@ private:
     std::string *m_topo_buffer;
 };
 
+/**
+ * a message to remove DB
+ *
+ */
+class TrexAstfDeleteDB : public TrexCpToDpMsgBase {
+public:
+    TrexAstfDeleteDB(uint32_t profile_id);
+    virtual TrexCpToDpMsgBase* clone();
+    virtual bool handle(TrexDpCore *dp_core);
+private:
+    uint32_t m_profile_id;
+};
 
 
 

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -29,17 +29,23 @@ limitations under the License.
 // create tcp batch per DP core
 class TrexAstfDpCreateTcp : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpCreateTcp();
+    TrexAstfDpCreateTcp(uint32_t profile_id);
+    TrexAstfDpCreateTcp() : TrexAstfDpCreateTcp(0) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
+private:
+    uint32_t m_profile_id;
 };
 
 // delete tcp batch per DP core
 class TrexAstfDpDeleteTcp : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpDeleteTcp();
+    TrexAstfDpDeleteTcp(uint32_t profile_id);
+    TrexAstfDpDeleteTcp() : TrexAstfDpDeleteTcp(0) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
+private:
+    uint32_t m_profile_id;
 };
 
 /**
@@ -48,9 +54,13 @@ public:
  */
 class TrexAstfDpStart : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpStart();
+    TrexAstfDpStart(uint32_t profile_id, double duration);
+    TrexAstfDpStart() : TrexAstfDpStart(0, -1) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
+private:
+    uint32_t m_profile_id;
+    double m_duration;
 };
 
 /**
@@ -59,9 +69,17 @@ public:
  */
 class TrexAstfDpStop : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpStop();
+    TrexAstfDpStop(uint32_t profile_id, uint32_t stop_id);
+    TrexAstfDpStop(uint32_t profile_id) : TrexAstfDpStop(profile_id, 0) {}
+    TrexAstfDpStop() : TrexAstfDpStop(0, 0) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
+    virtual void on_node_remove();
+    void set_core_ptr(CFlowGenListPerThread* core) { m_core = core; }
+private:
+    CFlowGenListPerThread* m_core;
+    uint32_t m_profile_id;
+    uint32_t m_stop_id;
 };
 
 /**
@@ -70,10 +88,12 @@ public:
  */
 class TrexAstfDpUpdate : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpUpdate(double old_new_ratio);
+    TrexAstfDpUpdate(uint32_t profile_id, double old_new_ratio);
+    TrexAstfDpUpdate(double old_new_ratio) : TrexAstfDpUpdate(0, old_new_ratio) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
+    uint32_t m_profile_id;
     double m_old_new_ratio;
 };
 
@@ -83,10 +103,12 @@ private:
  */
 class TrexAstfLoadDB : public TrexCpToDpMsgBase {
 public:
-    TrexAstfLoadDB(std::string *profile_buffer, std::string *topo_buffer);
+    TrexAstfLoadDB(uint32_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
+    TrexAstfLoadDB(std::string *profile_buffer, std::string *topo_buffer) : TrexAstfLoadDB(0, profile_buffer, topo_buffer) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
+    uint32_t m_profile_id;
     std::string *m_profile_buffer;
     std::string *m_topo_buffer;
 };

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -95,6 +95,8 @@ TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStart, "start");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStop, "stop");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfUpdate, "update");
 
+TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfProfileList, "get_profile_list");
+
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStartLatency, "start_latency");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStopLatency, "stop_latency");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfUpdateLatency, "update_latency");
@@ -114,17 +116,24 @@ TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfTopoClear, "topo_clear");
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfSync::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result, "");
     TrexAstf *stx = get_astf_object();
 
     Json::Value &res = result["result"];
     res["epoch"] = stx->get_epoch();
     res["state"] = stx->get_state();
 
+    if ( profile_id != "" ) {
+        Json::Value state_profile =  Json::objectValue;
+        stx->get_profiles_status(state_profile);
+        res["state_profile"] = state_profile;
+    }
     return (TREX_RPC_CMD_OK);
 }
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfIncEpoch::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     TrexAstf *stx = get_astf_object();
     try {
         stx->inc_epoch();
@@ -156,8 +165,16 @@ TrexRpcCmdAstfAcquire::_run(const Json::Value &params, Json::Value &result) {
         res["ports"][to_string(port.first)] = handler;
     }
 
-    if ( stx->profile_needs_parsing() ) {
-        stx->profile_clear();
+    stringstream ss;
+    vector<string> profile_list = stx->get_profile_id_list();
+    for ( auto profile_id : profile_list ) {
+        try {
+            if ( stx->profile_needs_parsing(profile_id) ) {
+                stx->profile_init(profile_id);
+            }
+        } catch (const TrexException &ex) {
+            res["exception"][profile_id] = ex.what();
+        }
     }
 
     if ( stx->topo_needs_parsing() ) {
@@ -177,16 +194,24 @@ TrexRpcCmdAstfRelease::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfProfileFragment::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     const bool frag_first = parse_bool(params, "frag_first", result, false);
     const bool frag_last = parse_bool(params, "frag_last", result, false);
 
     TrexAstf *stx = get_astf_object();
 
+    stx->add_profile(profile_id);
+
     if ( frag_first && !frag_last) {
         const string hash = parse_string(params, "md5", result);
-        if ( stx->profile_cmp_hash(hash) ) {
-            result["result"]["matches_loaded"] = true;
-            return TREX_RPC_CMD_OK;
+        switch ( stx->profile_cmp_hash(profile_id, hash) ) {
+            case HASH_ON_SAME_PROFILE:
+                result["result"]["matches_loaded"] = true;
+                return TREX_RPC_CMD_OK;
+            case HASH_ON_OTHER_PROFILE:
+                generate_execute_err(result, "Fragment already added on other profile_id");
+            default:
+                break;
         }
     }
 
@@ -194,13 +219,13 @@ TrexRpcCmdAstfProfileFragment::_run(const Json::Value &params, Json::Value &resu
 
     try {
         if ( frag_first ) {
-            stx->profile_clear();
+            stx->profile_init(profile_id);
         }
 
-        stx->profile_append(fragment);
+        stx->profile_append(profile_id, fragment);
 
         if ( frag_last ) {
-            stx->profile_set_loaded();
+            stx->profile_set_loaded(profile_id);
         }
 
     } catch (const TrexException &ex) {
@@ -212,8 +237,9 @@ TrexRpcCmdAstfProfileFragment::_run(const Json::Value &params, Json::Value &resu
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfProfileClear::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     try {
-        get_astf_object()->profile_clear();
+        get_astf_object()->profile_clear(profile_id);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -223,6 +249,7 @@ TrexRpcCmdAstfProfileClear::_run(const Json::Value &params, Json::Value &result)
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     start_params_t args;
     args.duration = parse_double(params, "duration", result);
     args.mult = parse_double(params, "mult", result);
@@ -232,7 +259,7 @@ TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
     args.client_mask = parse_uint32(params, "client_mask", result);
 
     try {
-        get_astf_object()->start_transmit(args);
+        get_astf_object()->start_transmit(profile_id, args);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -242,8 +269,9 @@ TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfStop::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     try {
-        get_astf_object()->stop_transmit();
+        get_astf_object()->stop_transmit(profile_id);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -253,10 +281,11 @@ TrexRpcCmdAstfStop::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfUpdate::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     const double mult = parse_double(params, "mult", result);
 
     try {
-        get_astf_object()->update_rate(mult);
+        get_astf_object()->update_rate(profile_id, mult);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -264,6 +293,19 @@ TrexRpcCmdAstfUpdate::_run(const Json::Value &params, Json::Value &result) {
     return (TREX_RPC_CMD_OK);
 }
 
+trex_rpc_cmd_rc_e
+TrexRpcCmdAstfProfileList::_run(const Json::Value &params, Json::Value &result) {
+    vector<string> profile_list = get_astf_object()->get_profile_id_list();
+    Json::Value json_profile_list = Json::arrayValue;
+
+    for (auto &profile_id : profile_list) {
+        json_profile_list.append(profile_id);
+    }
+
+    result["result"] = json_profile_list;
+
+    return (TREX_RPC_CMD_OK);
+}
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfStartLatency::_run(const Json::Value &params, Json::Value &result) {
@@ -376,7 +418,9 @@ TrexRpcCmdAstfGetLatencyStats::_run(const Json::Value &params, Json::Value &resu
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfGetTrafficDist::_run(const Json::Value &params, Json::Value &result) {
-    auto db = CAstfDB::instance();
+    string profile_id = parse_profile(params, result);
+    uint32_t profile_index = get_astf_object()->get_profile_index_by_id(profile_id);
+    auto db = CAstfDB::instance(profile_index);
     auto stx = get_astf_object();
     auto &api = get_platform_api();
 
@@ -416,11 +460,15 @@ TrexRpcCmdAstfGetTrafficDist::_run(const Json::Value &params, Json::Value &resul
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfCountersDesc::_run(const Json::Value &params, Json::Value &result) {
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
-    if (lpstt) {
-        if (lpstt->m_init) {
+    string profile_id = parse_profile(params, result);
+    if (!get_astf_object()->is_valid_profile(profile_id)) {
+        generate_execute_err(result, "Invalid profile : " + profile_id);
+    }
+    CSTTCp *lpstt = get_astf_object()->get_sttcp_by_id(profile_id);
+    if (lpstt && lpstt->m_init) {
             lpstt->m_dtbl.dump_meta("counter desc", result["result"]);
-        }
+    } else {
+        generate_execute_err(result, "Statistics are not initialized yet");
     }
 
     return (TREX_RPC_CMD_OK);
@@ -428,11 +476,12 @@ TrexRpcCmdAstfCountersDesc::_run(const Json::Value &params, Json::Value &result)
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfCountersValues::_run(const Json::Value &params, Json::Value &result) {
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
-    if (lpstt) {
-        if (lpstt->m_init) {
-            lpstt->m_dtbl.dump_values("counter vals", false, result["result"]);
-        }
+    string profile_id = parse_profile(params, result);
+    CSTTCp *lpstt = get_astf_object()->get_sttcp_by_id(profile_id);
+    if (lpstt && lpstt->m_init) {
+        lpstt->m_dtbl.dump_values("counter vals", false, result["result"]);
+    } else {
+        generate_execute_err(result, "Statistics are not initialized yet");
     }
 
     return (TREX_RPC_CMD_OK);
@@ -440,21 +489,28 @@ TrexRpcCmdAstfCountersValues::_run(const Json::Value &params, Json::Value &resul
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfGetTGNames::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
+    if (!get_astf_object()->is_valid_profile(profile_id)) {
+        generate_execute_err(result, "Invalid profile : " + profile_id);
+    }
     bool initialized = parse_bool(params, "initialized", result);
     uint64_t epoch = 0;
     if (initialized) {
         epoch = parse_uint64(params, "epoch", result);
     }
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
+    CSTTCp *lpstt = get_astf_object()->get_sttcp_by_id(profile_id);
     if (lpstt && lpstt->m_init) {
-        if (!get_astf_object()->is_state_build()) {
-            lpstt->UpdateTGNames(CAstfDB::instance()->get_tg_names());
+        if (!get_astf_object()->is_profile_state_build(profile_id)) {
+            uint32_t profile_index = get_astf_object()->get_profile_index_by_id(profile_id);
+            lpstt->UpdateTGNames(CAstfDB::instance(profile_index)->get_tg_names());
         }
         uint64_t server_epoch = lpstt->m_epoch;
         result["result"]["epoch"] = server_epoch;
         if ( (initialized && server_epoch != epoch) || !initialized)  {
             lpstt->DumpTGNames(result["result"]);
         }
+    } else {
+        generate_execute_err(result, "Statistics are not initialized yet for TGs");
     }
 
     return (TREX_RPC_CMD_OK);
@@ -462,10 +518,11 @@ TrexRpcCmdAstfGetTGNames::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     vector<uint16_t> tgids_arr;
     uint64_t epoch = parse_uint64(params, "epoch", result);
     const Json::Value &tgids = parse_array(params, "tg_ids", result);
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
+    CSTTCp *lpstt = get_astf_object()->get_sttcp_by_id(profile_id);
     try {
         if (tgids.size() > MAX_TG_ALLOWED_AT_ONCE) {
             generate_execute_err(result, "Trying to get statistics for too many TGs. Max allowed is "
@@ -486,11 +543,13 @@ TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
             uint64_t server_epoch = lpstt->m_epoch;
             result["result"]["epoch"] = server_epoch;
             if (server_epoch == epoch) {
-                if (!get_astf_object()->is_state_build()) {
+                if (!get_astf_object()->is_profile_state_build(profile_id)) {
                     lpstt->UpdateTGStats(tgids_arr);
                 }
                 lpstt->DumpTGStats(result["result"], tgids_arr);
             }
+        } else {
+            generate_execute_err(result, "Statistics are not initialized yet for TGs");
         }
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
@@ -571,6 +630,7 @@ TrexRpcCmdsASTF::TrexRpcCmdsASTF() : TrexRpcComponent("ASTF") {
     m_cmds.push_back(new TrexRpcCmdAstfStart(this));
     m_cmds.push_back(new TrexRpcCmdAstfStop(this));
     m_cmds.push_back(new TrexRpcCmdAstfUpdate(this));
+    m_cmds.push_back(new TrexRpcCmdAstfProfileList(this));
     m_cmds.push_back(new TrexRpcCmdAstfStartLatency(this));
     m_cmds.push_back(new TrexRpcCmdAstfStopLatency(this));
     m_cmds.push_back(new TrexRpcCmdAstfUpdateLatency(this));

--- a/src/stx/astf_batch/trex_astf_batch.cpp
+++ b/src/stx/astf_batch/trex_astf_batch.cpp
@@ -63,7 +63,7 @@ TrexDpCoreAstfBatch::start_astf() {
         return;
     }
 
-    d_time_flow = m_core->m_c_tcp->m_fif_d_time; /* set by Create_tcp function */
+    d_time_flow = m_core->m_c_tcp->get_fif_d_time(0); /* set by Create_tcp function */
 
     double d_phase= 0.01 + (double)m_core->m_thread_id * d_time_flow / (double)m_core->m_max_threads;
 
@@ -99,8 +99,11 @@ TrexDpCoreAstfBatch::start_astf() {
         node = m_core->create_node();
         node->m_type = CGenNode::TCP_TX_FIF;
         node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
+        node->m_ctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
         m_core->m_node_gen.add_node(node);
     }
+    m_core->m_c_tcp->activate();
+    m_core->m_s_tcp->activate();
 
     node = m_core->create_node() ;
     node->m_type = CGenNode::TCP_RX_FLUSH;

--- a/src/stx/astf_batch/trex_astf_batch.cpp
+++ b/src/stx/astf_batch/trex_astf_batch.cpp
@@ -96,11 +96,11 @@ TrexDpCoreAstfBatch::start_astf() {
     CGenNode *node=0;
 
     if (!disable_client){
-        node = m_core->create_node();
-        node->m_type = CGenNode::TCP_TX_FIF;
-        node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
-        node->m_ctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
-        m_core->m_node_gen.add_node(node);
+        CGenNodeTXFIF *tx_node = (CGenNodeTXFIF*)m_core->create_node();
+        tx_node->m_type = CGenNode::TCP_TX_FIF;
+        tx_node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
+        tx_node->m_ctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
+        m_core->m_node_gen.add_node((CGenNode*)tx_node);
     }
     m_core->m_c_tcp->activate();
     m_core->m_s_tcp->activate();

--- a/src/stx/astf_batch/trex_astf_batch.cpp
+++ b/src/stx/astf_batch/trex_astf_batch.cpp
@@ -102,8 +102,6 @@ TrexDpCoreAstfBatch::start_astf() {
         tx_node->m_ctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
         m_core->m_node_gen.add_node((CGenNode*)tx_node);
     }
-    m_core->m_c_tcp->activate();
-    m_core->m_s_tcp->activate();
 
     node = m_core->create_node() ;
     node->m_type = CGenNode::TCP_RX_FLUSH;

--- a/src/stx/astf_batch/trex_astf_batch.cpp
+++ b/src/stx/astf_batch/trex_astf_batch.cpp
@@ -99,7 +99,7 @@ TrexDpCoreAstfBatch::start_astf() {
         CGenNodeTXFIF *tx_node = (CGenNodeTXFIF*)m_core->create_node();
         tx_node->m_type = CGenNode::TCP_TX_FIF;
         tx_node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
-        tx_node->m_ctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
+        tx_node->m_pctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
         m_core->m_node_gen.add_node((CGenNode*)tx_node);
     }
 

--- a/src/stx/common/trex_dp_core.cpp
+++ b/src/stx/common/trex_dp_core.cpp
@@ -127,12 +127,14 @@ TrexDpCore::start() {
         case STATE_IDLE:
             idle_state_loop();
             break;
-            
+
+        case STATE_STARTING:
         case STATE_TRANSMITTING:
         case STATE_PCAP_TX:
             start_scheduler();
             break;
-            
+
+        case STATE_STOPPING:
         case STATE_TERMINATE:
             return;
         }

--- a/src/stx/common/trex_dp_core.h
+++ b/src/stx/common/trex_dp_core.h
@@ -46,7 +46,9 @@ public:
     /* states */
     enum state_e {
         STATE_IDLE,
+        STATE_STARTING,
         STATE_TRANSMITTING,
+        STATE_STOPPING,
         STATE_PCAP_TX,
         STATE_TERMINATE
     };

--- a/src/stx/common/trex_messaging.cpp
+++ b/src/stx/common/trex_messaging.cpp
@@ -109,13 +109,13 @@ TrexDpPortEventMsg::handle() {
 
 bool
 TrexDpCoreStopped::handle(void) {
-    get_stx()->dp_core_finished(m_thread_id);
+    get_stx()->dp_core_finished(m_thread_id, m_profile_id);
     return true;
 }
 
 bool
 TrexDpCoreError::handle(void) {
-    get_stx()->dp_core_error(m_thread_id, m_err);
+    get_stx()->dp_core_error(m_thread_id, m_profile_id, m_err);
     return true;
 }
 

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -277,15 +277,18 @@ private:
 class TrexDpCoreStopped : public TrexDpToCpMsgBase {
 public:
 
-    TrexDpCoreStopped(int thread_id) {
+    TrexDpCoreStopped(int thread_id, uint32_t profile_id) {
         m_thread_id = thread_id;
+        m_profile_id = profile_id;
     }
+
+    TrexDpCoreStopped(int thread_id) : TrexDpCoreStopped(thread_id, 0) {}
 
     virtual bool handle(void);
 
 private:
     int m_thread_id;
-
+    uint32_t m_profile_id;
 };
 
 /**
@@ -294,8 +297,9 @@ private:
 class TrexDpCoreError : public TrexDpToCpMsgBase {
 public:
 
-    TrexDpCoreError(int thread_id, const std::string &err) {
+    TrexDpCoreError(int thread_id, uint32_t profile_id, const std::string &err) {
         m_thread_id = thread_id;
+        m_profile_id = profile_id;
         m_err       = err;
     }
 
@@ -303,6 +307,7 @@ public:
 
 private:
     int          m_thread_id;
+    uint32_t     m_profile_id;
     std::string  m_err;
 
 };

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -303,6 +303,9 @@ public:
         m_err       = err;
     }
 
+    TrexDpCoreError(int thread_id, const std::string &err): TrexDpCoreError(thread_id, 0, err) {
+    }
+
     virtual bool handle(void);
 
 private:

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -277,7 +277,7 @@ private:
 class TrexDpCoreStopped : public TrexDpToCpMsgBase {
 public:
 
-    TrexDpCoreStopped(int thread_id, uint32_t profile_id) {
+    TrexDpCoreStopped(int thread_id, profile_id_t profile_id) {
         m_thread_id = thread_id;
         m_profile_id = profile_id;
     }
@@ -288,7 +288,7 @@ public:
 
 private:
     int m_thread_id;
-    uint32_t m_profile_id;
+    profile_id_t m_profile_id;
 };
 
 /**
@@ -297,7 +297,7 @@ private:
 class TrexDpCoreError : public TrexDpToCpMsgBase {
 public:
 
-    TrexDpCoreError(int thread_id, uint32_t profile_id, const std::string &err) {
+    TrexDpCoreError(int thread_id, profile_id_t profile_id, const std::string &err) {
         m_thread_id = thread_id;
         m_profile_id = profile_id;
         m_err       = err;
@@ -307,7 +307,7 @@ public:
 
 private:
     int          m_thread_id;
-    uint32_t     m_profile_id;
+    profile_id_t m_profile_id;
     std::string  m_err;
 
 };

--- a/src/stx/common/trex_stx.cpp
+++ b/src/stx/common/trex_stx.cpp
@@ -161,11 +161,11 @@ TrexSTX::check_for_dp_message_from_core(int thread_id) {
 }
 
 void
-TrexSTX::dp_core_finished(int thread_id) {
+TrexSTX::dp_core_finished(int thread_id, uint32_t profile_id) {
 }
 
 void
-TrexSTX::dp_core_error(int thread_id, const std::string &err) {
+TrexSTX::dp_core_error(int thread_id, uint32_t profile_id, const std::string &err) {
 }
 
 /**

--- a/src/stx/common/trex_stx.h
+++ b/src/stx/common/trex_stx.h
@@ -145,12 +145,12 @@ public:
     /**
      * DP core has finished
      */
-    virtual void dp_core_finished(int thread_id);
+    virtual void dp_core_finished(int thread_id, uint32_t profile_id);
 
     /**
      * DP core encountered error
      */
-    virtual void dp_core_error(int thread_id, const std::string &err);
+    virtual void dp_core_error(int thread_id, uint32_t profile_id, const std::string &err);
 
     virtual void set_capture_feature(const std::set<uint8_t>& rx_cores) {};
 

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -36,27 +36,6 @@ class TrexStatelessDpPerPort;
 class TrexCpToDpMsgBase;
 class CFlowGenListPerThread;
 
-struct CGenNodeCommand : public CGenNodeBase  {
-
-friend class TrexStatelessDpCore;
-
-public:
-    TrexCpToDpMsgBase  *m_cmd;
-
-    uint8_t             m_pad_end[104];
-
-    /* CACHE_LINE */
-    uint64_t            m_pad3[8];
-
-
-public:
-    void free_command();
-
-} __rte_cache_aligned;;
-
-
-static_assert(sizeof(CGenNodeCommand) == sizeof(CGenNode), "sizeof(CGenNodeCommand) != sizeof(CGenNode)" );
-
 
 struct CGenNodeCacheMbuf {
     rte_mbuf_t *  m_mbuf_const;

--- a/src/trex_defs.h
+++ b/src/trex_defs.h
@@ -109,4 +109,6 @@ typedef struct {
 typedef std::map<uint64_t,async_ticket_task_t> async_ticket_map_t;
 // end async related
 
+typedef uint32_t profile_id_t;
+
 #endif


### PR DESCRIPTION
I added CP code for ASTF dynamic multiple profile with DP code which already pull requested.
Major changes is as below.

1.  Classes
- class TrexAstfPerProfile -> Handling state, buffer, hash, etc per each profile
- class TrexAstfProfile -> Management for related profiles
- class TrexAstf -> Others except profiles

2. Handling commands requested from Client
- Added m_cmd_wait_list to handle mass start or stop commands at the same time.
- This waiting list is used to avoid DP overload due to mass messages between CP and DP.

3. New event through asynchronous port.
- EVENT_ASTF_PROFILE_STATE_CHG = 60, -> event for profile state change
- EVENT_ASTF_PROFILE_CLEARED   = 61,  -> event for profile cleared (profile DB remove)

4. Profile clear for remove database
- Added TrexAstfDeleteDB message between CP and DP to remove .
- It will delete CAstfDB in DP and TrexAstfPerProfile instance in CP by profile_clear RPC command.
