### PR TITLE
-a option added for stop command (remove all profiles * when -a is used) TRAVIS CHECK

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -2014,7 +2014,7 @@ class STLClient(TRexClient):
         parser = parsing_opts.gen_parser(self,
                                          "stop",
                                          self.stop_line.__doc__,
-                                         parsing_opts.PROFILE_LIST,
+                                         parsing_opts.PROFILE_LIST_WITH_ALL,
                                          parsing_opts.REMOVE)
 
         opts = parser.parse_args(line.split(), default_ports = self.get_profiles_with_state("active"), verify_acquired = True, allow_empty = True)

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -591,6 +591,15 @@ class OPTIONS_DB_ARGS:
          'help': "Set this flag to apply the command on all available ports",
          'default': False})
 
+
+    ALL_PROFILES = ArgumentPack(
+        ['-a'],
+        {"action": "store_true",
+         "dest": "all_profiles",
+         'help': "Set this flag to apply the command on all available dynamic profiles",
+         'default': False})
+
+
     DURATION = ArgumentPack(
         ['-d'],
         {'action': "store",
@@ -1012,6 +1021,15 @@ class OPTIONS_DB_GROUPS:
         ],
         {'required': False})
 
+    # advanced options
+    PROFILE_LIST_WITH_ALL = ArgumentGroup(
+        MUTEX,
+        [
+            PROFILE_LIST,
+            ALL_PROFILES
+        ],
+        {'required': False})
+
     VLAN_CFG = ArgumentGroup(
         MUTEX,
         [
@@ -1164,7 +1182,7 @@ class CCmdArgParser(argparse.ArgumentParser):
         raise ValueError(message)
 
     def has_ports_cfg (self, opts):
-        return hasattr(opts, "all_ports") or hasattr(opts, "ports")
+        return hasattr(opts, "all_ports") or hasattr(opts, "ports") or hasattr(opts, "all_profiles")
 
     def parse_args(self, args=None, namespace=None, default_ports=None, verify_acquired=False, allow_empty=True):
         try:
@@ -1180,6 +1198,10 @@ class CCmdArgParser(argparse.ArgumentParser):
             # explicit -a means ALL ports
             if (getattr(opts, "all_ports", None) == True):
                 opts.ports = self.client.get_all_ports()
+
+            # explicit -a means ALL profiles
+            elif (getattr(opts, "all_profiles", None) == True):
+                opts.ports = self.client.get_profiles_with_state("all")
 
             # default ports
             elif (getattr(opts, "ports", None) == []):


### PR DESCRIPTION
This is a follow up from [pr 244](https://github.com/cisco-system-traffic-generator/trex-core/pull/244)