### PR TITLE
ASTF Dynamic Multiple Profile in Client side 

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -179,8 +179,9 @@ class ASTFClient(TRexClient):
         if error and not self.sync_waiting:
             self.ctx.logger.error('Last command failed: %s' % error)
 
-        # remove profile
+        # remove profile and template group name
         self.astf_profile_state.pop(profile_id, None)
+        self.traffic_stats._clear_tg_name(profile_id) 
 
         if error:
             return Event('server', 'error', 'Can\'t remove profile %s after error: %s' % (profile_id, error))
@@ -337,7 +338,6 @@ class ASTFClient(TRexClient):
                 self.remove_rx_queue(ports)
                 self.remove_all_captures()
                 self._for_each_port('stop_capture_port', ports)
-
             self.ctx.logger.post_cmd(RC_OK())
 
         except TRexError as e:
@@ -1084,7 +1084,7 @@ class ASTFClient(TRexClient):
 
     @console_api('start', 'ASTF', True)
     def start_line(self, line):
-        '''start traffic command'''
+        '''Start traffic command'''
 
         parser = parsing_opts.gen_parser(
             self,
@@ -1125,7 +1125,7 @@ class ASTFClient(TRexClient):
 
     @console_api('stop', 'ASTF', True)
     def stop_line(self, line):
-        '''stop traffic command'''
+        '''Stop traffic command'''
 
         parser = parsing_opts.gen_parser(
             self,
@@ -1141,7 +1141,7 @@ class ASTFClient(TRexClient):
 
     @console_api('update', 'ASTF', True)
     def update_line(self, line):
-        '''u traffic multiplier'''
+        '''Update traffic multiplier'''
 
         parser = parsing_opts.gen_parser(
             self,

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -355,11 +355,11 @@ class TRexClient(object):
         raise NotImplementedError()
 
 
-    def _on_astf_profile_state_chg(self, dynamic_profile, ctx_state, error, epoch):
+    def _on_astf_profile_state_chg(self, profile_id, ctx_state, error, epoch):
         raise NotImplementedError()
 
 
-    def _on_astf_profile_cleared(self, dynamic_profile, error, epoch):
+    def _on_astf_profile_cleared(self, profile_id, error, epoch):
         raise NotImplementedError()
 
 
@@ -3190,10 +3190,10 @@ class TRexClient(object):
                                          "clear",
                                          self.clear_stats_line.__doc__,
                                          parsing_opts.PORT_LIST_WITH_ALL,
-                                         parsing_opts.ASTF_DYNAMIC_PROFILE_DEFAULT_LIST)
+                                         parsing_opts.ASTF_PROFILE_DEFAULT_LIST)
 
         opts = parser.parse_args(line.split())
-        self.clear_stats(opts.ports, dynamic_profile = opts.profiles)
+        self.clear_stats(opts.ports, pid_input = opts.profiles)
 
         return RC_OK()
 

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -3189,11 +3189,10 @@ class TRexClient(object):
         parser = parsing_opts.gen_parser(self,
                                          "clear",
                                          self.clear_stats_line.__doc__,
-                                         parsing_opts.PORT_LIST_WITH_ALL,
-                                         parsing_opts.ASTF_PROFILE_DEFAULT_LIST)
+                                         parsing_opts.PORT_LIST_WITH_ALL)
 
         opts = parser.parse_args(line.split())
-        self.clear_stats(opts.ports, pid_input = opts.profiles)
+        self.clear_stats(opts.ports)
 
         return RC_OK()
 

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -38,8 +38,6 @@ from .services.trex_service_arp import ServiceARP
 from .services.trex_service_ipv6 import ServiceICMPv6, ServiceIPv6Scan
 from .stats.trex_ns import CNsStats
 
-
-
 from scapy.layers.l2 import Ether, Packet
 from scapy.layers.inet import IP, UDP
 from scapy.utils import RawPcapWriter
@@ -170,6 +168,8 @@ class TRexClient(object):
         self.ctx.event_handler.register_event_handler("port attr chg", self._on_port_attr_chg)
 
         self.ctx.event_handler.register_event_handler("astf state changed", self._on_astf_state_chg)
+        self.ctx.event_handler.register_event_handler("astf profile state changed", self._on_astf_profile_state_chg)
+        self.ctx.event_handler.register_event_handler("astf profile cleared", self._on_astf_profile_cleared)
 
         self.ctx.event_handler.register_event_handler("global stats update", lambda *args, **kwargs: None)
 
@@ -352,6 +352,14 @@ class TRexClient(object):
 
 
     def _on_astf_state_chg(self, ctx_state, error, epoch):
+        raise NotImplementedError()
+
+
+    def _on_astf_profile_state_chg(self, dynamic_profile, ctx_state, error, epoch):
+        raise NotImplementedError()
+
+
+    def _on_astf_profile_cleared(self, dynamic_profile, error, epoch):
         raise NotImplementedError()
 
 
@@ -3181,11 +3189,11 @@ class TRexClient(object):
         parser = parsing_opts.gen_parser(self,
                                          "clear",
                                          self.clear_stats_line.__doc__,
-                                         parsing_opts.PORT_LIST_WITH_ALL)
+                                         parsing_opts.PORT_LIST_WITH_ALL,
+                                         parsing_opts.ASTF_DYNAMIC_PROFILE_DEFAULT_LIST)
 
         opts = parser.parse_args(line.split())
-
-        self.clear_stats(opts.ports)
+        self.clear_stats(opts.ports, dynamic_profile = opts.profiles)
 
         return RC_OK()
 

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
@@ -161,6 +161,8 @@ class ServerEventsIDs(object):
     EVENT_PROFILE_ERROR         = 17
 
     EVENT_ASTF_STATE_CHG = 50
+    EVENT_ASTF_PROFILE_STATE_CHG = 60
+    EVENT_ASTF_PROFILE_CLEARED   = 61
 
     EVENT_SERVER_STOPPED = 100
 
@@ -506,6 +508,23 @@ class TRexSubscriber():
             self.ctx.event_handler.on_event('astf state changed', state, error, epoch)
 
 
+        # ASTF profile state changed
+        elif event_id == ServerEventsIDs.EVENT_ASTF_PROFILE_STATE_CHG:
+            profile_id = data['profile_id']
+            state = data['state']
+            error = data.get('error', '')
+            epoch = data.get('epoch')
+            self.ctx.event_handler.on_event('astf profile state changed', profile_id, state, error, epoch)
+
+
+        # ASTF profile state changed
+        elif event_id == ServerEventsIDs.EVENT_ASTF_PROFILE_CLEARED:
+            profile_id = data['profile_id']
+            error = data.get('error', '')
+            epoch = data.get('epoch')
+            self.ctx.event_handler.on_event('astf profile cleared', profile_id, error, epoch)
+
+
         # server stopped
         elif event_id == ServerEventsIDs.EVENT_SERVER_STOPPED:
             cause = data['cause']
@@ -516,7 +535,6 @@ class TRexSubscriber():
         # unhandled
         else:
             print('Unhandled event %d' % event_id)
-
 
 
 

--- a/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
@@ -267,6 +267,7 @@ class TrexTUIAstfTrafficStats(TrexTUIPanel):
         self.max_lines = TrexTUI.MIN_ROWS - 16 # 16 is size of panels below and above
         self.num_lines = 0
         self.tgid = 0
+        self.is_sum = True if self.client.is_dynamic else False
 
         self.key_actions = OrderedDict()
 
@@ -282,10 +283,10 @@ class TrexTUIAstfTrafficStats(TrexTUIPanel):
 
         buf = StringIO()
         try:
-            self.client._show_traffic_stats(False, buffer = buf, tgid = self.tgid)
+            self.client._show_traffic_stats(False, buffer = buf, tgid = self.tgid, is_sum = self.is_sum)
         except ASTFErrorBadTG:
             self.tgid = 0
-            self.client._show_traffic_stats(False, buffer = buf, tgid = self.tgid)
+            self.client._show_traffic_stats(False, buffer = buf, tgid = self.tgid, is_sum = self.is_sum)
         buf.seek(0)
         out_lines = buf.readlines()
         self.num_lines = len(out_lines)

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -71,9 +71,9 @@ dynamic_profile_help = """A list of profiles on which to apply the command.
                           Profile expression is used as <port id>.<profile id>.
                           Default profile id is \"_\" when not specified.
                        """
-astf_dynamic_profile_help = """A list of profiles on which to apply the command.
-                            Default profile id is \"_\" when not specified.
-                            """
+astf_profile_help = """A list of profiles on which to apply the command.
+                       Default profile id is \"_\" when not specified.
+                    """
 
 
 # decodes multiplier
@@ -469,22 +469,22 @@ class OPTIONS_DB_ARGS:
          'default': None,
          'type': str})
 
-    ASTF_DYNAMIC_PROFILE_LIST = ArgumentPack(
+    ASTF_PROFILE_LIST = ArgumentPack(
         ['--pid'],
         {"nargs": 1,
          'dest':'profiles',
          'metavar': 'PROFILE',
          'type': str,
-         'help': astf_dynamic_profile_help,
+         'help': astf_profile_help,
          'default': [DEFAULT_PROFILE_ID]})
 
-    ASTF_DYNAMIC_PROFILE_DEFAULT_LIST = ArgumentPack(
+    ASTF_PROFILE_DEFAULT_LIST = ArgumentPack(
         ['--pid'],
         {"nargs": '+',
          'dest':'profiles',
          'metavar': 'PROFILE',
          'type': str,
-         'help': astf_dynamic_profile_help,
+         'help': astf_profile_help,
          'default': [DEFAULT_PROFILE_ID]})
 
     ASTF_NC = ArgumentPack(

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -838,7 +838,7 @@ class OPTIONS_DB_ARGS:
          'dest':'pfname',
          'metavar': 'PROFILE',
          'type': str,
-         'default': DEFAULT_PROFILE_ID,
+         'default': None,
          'help': "ASTF Profile ID: When using --pid option, Should use with -a or --za option"})
 
     STREAMS_MASK = ArgumentPack(

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -613,6 +613,13 @@ class OPTIONS_DB_ARGS:
          'help': "Set this flag to apply the command on all available ports",
          'default': False})
 
+    ALL_PROFILES = ArgumentPack(
+        ['-a'],
+        {"action": "store_true",
+         "dest": "all_profiles",
+         'help': "Set this flag to apply the command on all available dynamic profiles",
+         'default': False})
+
     DURATION = ArgumentPack(
         ['-d'],
         {'action': "store",
@@ -1043,6 +1050,15 @@ class OPTIONS_DB_GROUPS:
         ],
         {'required': False})
 
+    # advanced options
+    PROFILE_LIST_WITH_ALL = ArgumentGroup(
+        MUTEX,
+        [
+            PROFILE_LIST,
+            ALL_PROFILES
+        ],
+        {'required': False})
+
     VLAN_CFG = ArgumentGroup(
         MUTEX,
         [
@@ -1195,7 +1211,7 @@ class CCmdArgParser(argparse.ArgumentParser):
         raise ValueError(message)
 
     def has_ports_cfg (self, opts):
-        return hasattr(opts, "all_ports") or hasattr(opts, "ports")
+        return hasattr(opts, "all_ports") or hasattr(opts, "ports") or hasattr(opts, "all_profiles")
 
     def parse_args(self, args=None, namespace=None, default_ports=None, verify_acquired=False, allow_empty=True):
         try:
@@ -1211,7 +1227,9 @@ class CCmdArgParser(argparse.ArgumentParser):
             # explicit -a means ALL ports
             if (getattr(opts, "all_ports", None) == True):
                 opts.ports = self.client.get_all_ports()
-
+            # explicit -a means ALL profiles
+            elif (getattr(opts, "all_profiles", None) == True):
+                opts.ports = self.client.get_profiles_with_state("all")
             # default ports
             elif (getattr(opts, "ports", None) == []):
                 opts.ports = self.client.get_acquired_ports() if default_ports is None else default_ports


### PR DESCRIPTION
Hi,
@egwakim @ejaecki @Kangphil @yonghwan007 @jsmoon @JunsubHan4rmEricsson @youngjun1 @Cyborn-Minjae-Lee

I added client code for ASTF dynamic multiple profile. 
Major changes is as below.

1) Added "--pid" option/ dynamic_profile argument to APIs
   - "--pid profile_name(‘_’ is default, ‘*’ is all)" and “no option” means default ‘--pid “_”’
   - the changed APIs : 
     reset : added profiles clear/ stop : added "--remove" option/ profiles(new API)/ get_profiles(new API)
	 start/ load_profile/ stop/ clear/ clear_stats/ clear_traffic_stats/ update/ clear_profile
     stats/ get_stats/ template_group names/ get_tg_names/ template_group stats/ get_traffic_tg_stats
2) Added handling new event (60, 61)
   - EVENT_ASTF_PROFILE_STATE_CHG(60) -> Update profile state in astf_profile_state dictionary
   - EVENT_ASTF_PROFILE_CLEARED(61) -> Remove profile_id in astf_profile_state dictionary