### PR TITLE
Solution for STL Regression test case, "test_latency_pause_resume_dynamic_profile" and its explanation. 

### DIFF
--- a/scripts/automation/regression/stateless_tests/stl_client_test.py
+++ b/scripts/automation/regression/stateless_tests/stl_client_test.py
@@ -43,7 +43,9 @@ class STLClient_Test(CStlGeneral_Test):
         self.tx_port, self.rx_port = CTRexScenario.ports_map['bi'][0]
 
         self.c.connect()
-        self.c.reset(ports = [self.tx_port, self.rx_port])
+#        self.c.reset(ports = [self.tx_port, self.rx_port])
+        for tx_port, rx_port in CTRexScenario.ports_map['map'].items():
+            self.c.reset(ports = [tx_port, rx_port])
 
         port_info = self.c.get_port_info(ports = self.rx_port)[0]
 
@@ -65,7 +67,9 @@ class STLClient_Test(CStlGeneral_Test):
         
     def cleanup (self):
         self.c.remove_all_captures()
-        self.c.reset(ports = [self.tx_port, self.rx_port])
+#        self.c.reset(ports = [self.tx_port, self.rx_port])
+        for tx_port, rx_port in CTRexScenario.ports_map['map'].items():
+            self.c.reset(ports = [tx_port, rx_port])
         
             
     @classmethod
@@ -858,26 +862,18 @@ class STLClient_Test(CStlGeneral_Test):
     def test_latency_pause_resume_dynamic_profile (self):
 
         try:
-            print("\n1) Check pre-existing pg_ids")
-            self.c.show_stats_line("-l")
-
             profile_id = 1
             num_profiles = 100
             tx_profile_list = []
             tx_all_profile = str(self.tx_port) + str(".*")
-            tx_dict = {}
 
             while profile_id <= num_profiles:
                 tx_profile_name = str(self.tx_port) + str(".profile_") + str(profile_id)
                 tx_profile_list.append(tx_profile_name)
                 profile_id = profile_id + 1
 
-            print("\n2) Add streams (make sure pg_ids do not overlap")
             for index, tx_profile in enumerate(tx_profile_list):
                 pg_index = index * num_profiles + self.tx_port
-                tx_dict[pg_index] = tx_profile
-                print("  pg_index : %s" %pg_index)
-                print("  tx_profile : %s\n" %tx_profile)
                 stream = STLStream(name = 'latency',
                                packet = self.pkt,
                                mode = STLTXCont(pps = 5),
@@ -896,9 +892,8 @@ class STLClient_Test(CStlGeneral_Test):
             self.c.stop()
 
         except STLError as e:
-            assert False , '{}'.format(tx_dict)
+            assert False , '{0}'.format(e)
 
         finally:
-            print(tx_dict)
             self.cleanup()
 

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -87,6 +87,10 @@ class STLPort(Port):
             del self.profile_stream_list[profile_id]
             del self.profile_state_list[profile_id]
         else:
+            if profile_id in self.profile_state_list:
+                del self.profile_state_list[profile_id]
+            if profile_id in self.profile_stream_list:
+                del self.profile_stream_list[profile_id]
             stream_ids = []
         #return None if not found
         return stream_ids
@@ -922,6 +926,9 @@ class STLPort(Port):
 
         profile_state = self.profile_state_list.get(profile_id)
         if not profile_state:
+            return self.ok()
+
+        if profile_state == self.STATE_IDLE:
             return self.ok()
 
         params = {"handler": self.handler,


### PR DESCRIPTION
Hi Hanoh. 
This thread is extended from #224 , #262 , #272 , #273 .
As you know, the problem has been with the new regression test case, **"test_latency_pause_resume_dynamic_profile"**
> AssertionError: Port 0 : *** For payload rules: Can't have two streams with same pg_id, or same stream on more than one port

The problem above has been taking place even though the assigned pg_ids are all unique in the new test case. 
However, I think we have found the solution for this problem. 

First of all, as you have mentioned in #262 trex-08 setup is like this. 
> trex-08 does not work (XL710) while trex-09 (X710) works.
> it might be related to the fact that trex-08 is connected like this
> 
> 0->3
> 1->2
> 2->1
> 3->0

In the previous test cases before **test_latency_pause_resume_dynamic_profile**,
test case, **test_core_pinning_latency** assigns pg_id, 3 to port 0 and pg_id, 4 to port 1. 

This is what's causing the problem. 
Instead of assigning each pg_id to self.tx_port and self.rx_port it uses **hard-coded integer** 0 and 1 as port numbers. 

**Neither cleanUp nor setUp function will reset port 1 in this case, because both functions only reset self.tx_port(0) and self.rx_port(3) in this trex-08 setup.** 

**Therefore pg_id, 4, is left uncleaned in port 1.** 

When I try the new test case "test_latency_pause_resume_dynamic_profile", I also assigned pg_id 4 to self.tx_port. 
**However, this pg_id is already occupied by port 1.** 
Therefore such error has taken place. 

I have updated the code so that it uses other pg_ids. 
I think it's going to pass the regression. 

However, there are several ways to solve this problem. 
1) **test_core_pinning_latency** uses designated ports, self.tx_port and self.rx_port, instead of 0 and 1 (as well as other test cases)
2) **test_latency_pause_resume_dynamic_profile** uses different pg_ids as implemented now. 
3) **setUp** and **cleanup** function reset all ports, not just self.tx_port and self.rx_port

