### PR TITLE
fix hanging during stop a profile with flow stat

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -227,25 +227,18 @@ class STLClient(TRexClient):
     @validate_port_input("ports")
     def _remove_rx_filters (self, ports, rx_delay_ms):
 
-        rx_profiles = []
-        port_id_list = parse_ports_from_profiles(ports)
-
-        # get the enabled RX ports
-        rx_ports = [port_id for port_id in port_id_list if self.ports[port_id].has_rx_enabled()]
+        # get the enabled RX profiles
+        rx_ports = [p for p in ports if self.ports[p.port_id].has_profile_rx_enabled(p.profile_id)]
 
         if not rx_ports:
             return RC_OK()
 
-        # block while any RX configured port has not yet have it's delay expired
-        while any([not self.ports[port_id].has_rx_delay_expired(rx_delay_ms) for port_id in rx_ports]):
+        # block while any RX configured profile has not yet have it's delay expired
+        while any([not self.ports[p.port_id].has_rx_delay_expired(p.profile_id, rx_delay_ms) for p in rx_ports]):
             time.sleep(0.01)
 
-        for port in ports:
-            if int(port) in rx_ports:
-                rx_profiles.append(port)
-
         # remove RX filters
-        return self._for_each_port('remove_rx_filters', rx_profiles)
+        return self._for_each_port('remove_rx_filters', rx_ports)
 
     # Check console API ports argument
     def validate_profile_input(self, input_profiles):

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -900,13 +900,20 @@ class STLPort(Port):
     def has_rx_enabled (self):
         return self.has_rx_streams
 
+    # return True if profile has any stream configured with RX stats
+    def has_profile_rx_enabled (self, profile_id):
+        streams = [self.streams[stream_id] for stream_id in self.profile_stream_list.get(profile_id) if self.streams.get(stream_id)]
+        return any([stream.has_flow_stats() for stream in streams])
 
-    # return true if rx_delay_ms has passed since the last port stop
-    def has_rx_delay_expired (self, rx_delay_ms):
-        assert(self.has_rx_enabled())
+    def is_profile_active(self, profile_id):
+        return self.profile_state_list.get(profile_id) in (self.STATE_TX, self.STATE_PAUSE, self.STATE_PCAP_TX, self.STATE_ASTF_PARSE, self.STATE_ASTF_BUILD, self.STATE_ASTF_CLEANUP)
+
+    # return true if rx_delay_ms has passed since the last profile stop
+    def has_rx_delay_expired (self, profile_id, rx_delay_ms):
+        assert(self.has_profile_rx_enabled(profile_id))
 
         # if active - it's not safe to remove RX filters
-        if self.is_active():
+        if self.is_profile_active(profile_id):
             return False
 
         # either no timestamp present or time has already passed
@@ -915,7 +922,7 @@ class STLPort(Port):
 
     @writeable
     def remove_rx_filters (self, profile_id = DEFAULT_PROFILE_ID):
-        assert(self.has_rx_enabled())
+        assert(self.has_profile_rx_enabled(profile_id))
 
         if self.state == self.STATE_IDLE:
             return self.ok()

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -902,7 +902,7 @@ class STLPort(Port):
 
     # return True if profile has any stream configured with RX stats
     def has_profile_rx_enabled (self, profile_id):
-        streams = [self.streams[stream_id] for stream_id in self.profile_stream_list.get(profile_id) if self.streams.get(stream_id)]
+        streams = [self.streams[stream_id] for stream_id in self.profile_stream_list.get(profile_id, []) if self.streams.get(stream_id)]
         return any([stream.has_flow_stats() for stream in streams])
 
     def is_profile_active(self, profile_id):


### PR DESCRIPTION
This commit is fixing the profile stop hanging issue when flow stat stream is used.
> start -f stl/flow_stats.py -p 0.flow
> start -f stl/udp_1pkt.py -p 0.udp
> stop -p 0.flow

The reason was that remove_rx_filters during stopping in the client-side checked port state.
I implemented to check the state per profile.