### PR TITLE
ASTF dynamic profile is available in CP side

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4229,9 +4229,14 @@ void CGlobalTRex::update_stats(){
     m_last_total_cps = m_cps.add(total_open_flows);
 
     bool all_init=true;
-    CSTTCp  * lpstt;
-    lpstt = m_fl.m_stt_cp;
-    if ( lpstt ){
+    vector<CSTTCp *> sttcp_list;
+    if ( get_is_interactive() && get_is_tcp_mode() ) {
+        sttcp_list = get_astf_object()->get_sttcp_list();
+    }
+    else if ( m_fl.m_stt_cp ) {
+        sttcp_list.push_back(m_fl.m_stt_cp);
+    }
+    for ( auto lpstt : sttcp_list ) {
         if (!lpstt->m_init){
             /* check that we have all objects;*/
             for (i=0; i<get_cores_tx(); i++) {
@@ -4715,8 +4720,14 @@ CGlobalTRex::show_panel() {
 
     /* TCP stats */
     if (m_io_modes.m_g_mode == CTrexGlobalIoMode::gSTT) {
-        CSTTCp   * lpstt=m_fl.m_stt_cp;
-        if (lpstt) {
+        vector<CSTTCp *> sttcp_list;
+        if ( get_is_interactive() && get_is_tcp_mode() ) {
+            sttcp_list = get_astf_object()->get_sttcp_list();
+        }
+        else if ( m_fl.m_stt_cp ) {
+            sttcp_list.push_back(m_fl.m_stt_cp);
+        }
+        for ( auto lpstt : sttcp_list ) {
             if (lpstt->m_init) {
                 lpstt->DumpTable();
             }
@@ -5042,8 +5053,14 @@ int CGlobalTRex::stop_master(){
     dump_stats(stdout,CGlobalStats::dmpSTANDARD);
     dump_post_test_stats(stdout);
 
-    CSTTCp   * lpstt=m_fl.m_stt_cp;
-    if (lpstt) {
+    vector<CSTTCp *> sttcp_list;
+    if ( get_is_interactive() && get_is_tcp_mode() ) {
+        sttcp_list = get_astf_object()->get_sttcp_list();
+    }
+    else if ( m_fl.m_stt_cp ) {
+        sttcp_list.push_back(m_fl.m_stt_cp);
+    }
+    for ( auto lpstt : sttcp_list ) {
         assert(lpstt);
         assert(lpstt->m_init);
         lpstt->DumpTable();

--- a/src/publisher/trex_publisher.h
+++ b/src/publisher/trex_publisher.h
@@ -69,6 +69,9 @@ public:
         EVENT_ASTF_CLEANUP          = 55,
         */
 
+        EVENT_ASTF_PROFILE_STATE_CHG = 60,
+        EVENT_ASTF_PROFILE_CLEARED   = 61,
+
         EVENT_SERVER_STOPPED        = 100,
         
         

--- a/src/stt_cp.h
+++ b/src/stt_cp.h
@@ -47,7 +47,7 @@ typedef uint8_t tcp_dir_t;
 
 class CSTTCpPerTGIDPerDir {
 public:
-    bool Create(uint32_t time_msec);
+    bool Create(uint32_t stt_id, uint32_t time_msec);
     void Delete();
     void update_counters(bool is_sum, uint16_t tg_id=0);
     void clear_counters();
@@ -85,12 +85,15 @@ public:
     CGTblClmCounters    m_clm; /* utility for dump */
 
     std::vector<CTcpPerThreadCtx*>  m_tcp_ctx; /* vectors contexts*/
+
+private:
+    uint32_t m_stt_id;
 };
 
 class CSTTCp {
 
 public:
-    void Create(uint16_t num_of_tg_ids=1, bool first_time=true);
+    void Create(uint32_t stt_id=0, uint16_t num_of_tg_ids=1, bool first_time=true);
     void Delete(bool last_time=true);
     void Add(tcp_dir_t dir,CTcpPerThreadCtx* ctx);
     void Init(bool first_time=true);
@@ -114,6 +117,7 @@ public:
     uint16_t                            m_num_of_tg_ids;
     std::vector<std::string>            m_tg_names;
 private:
+    uint32_t m_stt_id;
 
 };
 

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -23,21 +23,29 @@ limitations under the License.
 
 #include <stdint.h>
 #include <vector>
+#include <map>
 
 #include "common/trex_stx.h"
 #include "trex_astf_defs.h"
+#include "stt_cp.h"
 
 class TrexAstfPort;
 class CSyncBarrier;
 class CRxAstfCore;
+class TrexAstf;
 
 typedef std::unordered_map<uint8_t, TrexAstfPort*> astf_port_map_t;
+typedef std::string cp_profile_id_t;
 
-/**
- * TRex adavanced stateful interactive object
- * 
- */
-class TrexAstf : public TrexSTX {
+const std::string DEFAULT_ASTF_PROFILE_ID = "_";
+
+typedef enum trex_astf_hash {
+    HASH_OK,
+    HASH_ON_SAME_PROFILE,
+    HASH_ON_OTHER_PROFILE,
+} trex_astf_hash_e;
+
+class AstfProfileState {
 public:
     enum state_e {
         STATE_IDLE,
@@ -46,16 +54,152 @@ public:
         STATE_BUILD, // by DP cores, not cancelable
         STATE_TX,
         STATE_CLEANUP, // by DP cores, not cancelable
+        STATE_DELETE,  // by DP core 0, not cancelable
         AMOUNT_OF_STATES,
     };
+};
 
+/***********************************************************
+ * TRex ASTF each profile in interactive
+ ***********************************************************/
+class TrexAstfPerProfile : public AstfProfileState {
+public:
+    typedef std::vector<state_e> states_t;
+
+    TrexAstfPerProfile(TrexAstf* astf_obj,
+                       uint32_t dp_profile_id=0,
+                       cp_profile_id_t cp_profile_id=DEFAULT_ASTF_PROFILE_ID);
+    ~TrexAstfPerProfile();
+
+    /**
+     * Profile-related:
+     * cmp - compare hash to loaded profile, true = matches (heavy profile will not be uploaded twice)
+     * init - clears profile JSON string (if any)
+     * append - appends fragment to profile JSON string
+     * loaded - move state from idle to loaded
+     */
+    trex_astf_hash_e profile_cmp_hash(const std::string &hash);
+    void profile_init();
+    void profile_append(const std::string &fragment);
+    void profile_set_loaded();
+
+    /**
+     * Handle profile status
+     */
+    void profile_change_state(state_e new_state);
+    void profile_check_whitelist_states(const states_t &whitelist);
+    bool is_profile_state_build();
+
+    bool profile_needs_parsing();
+    bool is_error() {
+        return m_error.size() > 0;
+    }
+
+    /*
+     * involved message between CP and DP
+     */
+    void parse();
+    void build();
+    void transmit();
+    void cleanup();
+    void all_dp_cores_finished();
+    void dp_core_finished();
+    void dp_core_error(const std::string &err);
+
+    /*
+     * publish event for each profile
+     */
+    void publish_astf_profile_state();
+    void publish_astf_profile_clear();
+
+    /*
+     * For private variables
+     */
+    int32_t get_dp_profile_id() { return m_dp_profile_id; }
+    state_e get_profile_state() { return m_profile_state; }
+    bool    get_profile_stopping() { return m_profile_stopping; }
+    bool    get_nc_flow_close() { return m_nc_flow_close; }
+    double  get_duration() { return m_duration; }
+    double  get_factor() { return m_factor; }
+    CSTTCp* get_stt_cp() { return m_stt_cp; }
+
+    void    set_profile_stopping(bool stopping) { m_profile_stopping = stopping; }
+    void    set_nc_flow_close(bool nc) { m_nc_flow_close = nc; }
+    void    set_duration(double duration) { m_duration = duration; }
+    void    set_factor(double mult) { m_factor = mult; }
+
+private:
+    state_e         m_profile_state;
+    std::string     m_profile_buffer;
+    std::string     m_profile_hash;
+    bool            m_profile_parsed;
+    bool            m_profile_stopping;
+
+    int16_t         m_active_cores;
+    bool            m_nc_flow_close;
+    double          m_duration;
+    double          m_factor;
+    std::string     m_error;
+
+    int32_t         m_dp_profile_id;
+    cp_profile_id_t m_cp_profile_id;
+
+    CSTTCp*         m_stt_cp;
+    TrexAstf*       m_astf_obj;
+};
+
+
+/***********************************************************
+ * TRex ASTF dynamic multiple profiles in interactive
+ ***********************************************************/
+class TrexAstfProfile : public AstfProfileState {
+public:
+    typedef std::vector<state_e> states_t;
+
+    TrexAstfProfile();
+    ~TrexAstfProfile();
+
+    /**
+     * Handle dynamic multiple profiles
+     */
+    void add_profile(cp_profile_id_t profile_id);
+    bool delete_profile(cp_profile_id_t profile_id);
+    bool is_valid_profile(cp_profile_id_t profile_id);
+    uint32_t get_num_profiles();
+    std::unordered_map<std::string, TrexAstfPerProfile *> get_profile_list() {
+        return m_profile_list;
+    }
+
+    TrexAstfPerProfile* get_profile(cp_profile_id_t profile_id);
+    cp_profile_id_t get_profile_id(uint32_t dp_profile_id);
+
+    std::vector<std::string> get_profile_id_list();
+    std::vector<state_e>     get_profile_state_list();
+    std::vector<CSTTCp *>    get_sttcp_list();
+
+    std::vector<std::string> m_states_names;
+
+    bool is_another_profile_transmitting(cp_profile_id_t profile_id);
+    bool is_another_profile_busy(cp_profile_id_t profile_id);
+
+protected:
+    std::unordered_map<std::string, TrexAstfPerProfile *> m_profile_list;
+
+private:
+    uint32_t m_dp_profile_last_id;
+};
+
+
+/***********************************************************
+ * TRex adavanced stateful interactive object
+ ***********************************************************/
+class TrexAstf : public TrexAstfProfile, public TrexSTX {
+public:
     enum state_latency_e {
         STATE_L_IDLE,
         STATE_L_WORK,
         AMOUNT_OF_L_STATES,
     };
-
-    typedef std::vector<state_e> states_t;
 
     /** 
      * create ASTF object 
@@ -68,16 +212,14 @@ public:
      * 
      */
     void launch_control_plane();
-    
-    
+
     /**
      * shutdown ASTF
      * 
      */
     void shutdown();
 
-    void all_dp_cores_finished();
-    void dp_core_finished(int thread_id);
+    void dp_core_finished(int thread_id, uint32_t dp_profile_id);
 
     /**
      * async data sent for ASTF
@@ -115,18 +257,6 @@ public:
     void release_context();
 
     /**
-     * Profile-related:
-     * cmp - compare hash to loaded profile, true = matches (heavy profile will not be uploaded twice)
-     * clear - clears profile JSON string (if any)
-     * append - appends fragment to profile JSON string
-     * loaded - move state from idle to loaded
-     */
-    bool profile_cmp_hash(const std::string &hash);
-    void profile_clear();
-    void profile_append(const std::string &fragment);
-    void profile_set_loaded();
-
-    /**
      * Topology-related:
      * cmp - compare hash to loaded topo, true = matches (heavy topo will not be uploaded twice)
      * clear - clears topo JSON string (if any)
@@ -143,20 +273,26 @@ public:
      * Stats Related
      */
     bool is_state_build();
+
     /**
      * Start transmit
      */
-    void start_transmit(const start_params_t &args);
+    void start_transmit(cp_profile_id_t profile_id, const start_params_t &args);
 
     /**
      * Stop transmit
      */
-    void stop_transmit();
+    void stop_transmit(cp_profile_id_t profile_id);
+
+    /**
+     * Clear profile
+     */
+    void profile_clear(cp_profile_id_t profile_id);
 
     /**
      * Update traffic rate
      */
-    void update_rate(double mult);
+    void update_rate(cp_profile_id_t profile_id, double mult);
 
     TrexOwner& get_owner() {
         return m_owner;
@@ -183,11 +319,21 @@ public:
      */
     void update_latency_rate(double mult);
 
+    /**
+     * start latency traffic if latency option is available
+     */
+    std::string handle_start_latency(int32_t dp_profile_id);
+
+    /**
+     * stop latency traffic if latency option is available
+     */
+    void handle_stop_latency();
+
     CSyncBarrier* get_barrier() {
         return m_sync_b;
     }
 
-    void dp_core_error(int thread_id, const std::string &err);
+    void dp_core_error(int thread_id, uint32_t dp_profile_id, const std::string &err);
 
     state_e get_state() {
         return m_state;
@@ -204,26 +350,27 @@ public:
         return((CRxAstfCore *)m_rx);
     }
 
-    bool profile_needs_parsing();
     bool topo_needs_parsing();
 
-protected:
-    // message to DP involved:
-    void parse();
-    void build();
-    void transmit();
-    void cleanup();
-    bool is_trans_state();
+    /**
+     * update_astf_state          : update state for all profiles
+     * publish_astf_state         : publish state for all profiles
+     * get_profiles_status        : get JSON value list for all profiles id
+     */
+    void update_astf_state();
+    void publish_astf_state(std::string &err);
+    void get_profiles_status(Json::Value &result);
 
-    bool is_error() {
-        return m_error.size() > 0;
-    }
-
-    void change_state(state_e new_state);
     void set_barrier(double timeout_sec);
     void send_message_to_dp(uint8_t core_id, TrexCpToDpMsgBase *msg, bool clone = false);
     void send_message_to_all_dp(TrexCpToDpMsgBase *msg);
+    bool is_trans_state();
 
+    std::string* get_topo_buffer() { return &m_topo_buffer; }
+    void         set_topo_parsed(bool topo) { m_topo_parsed = topo; }
+
+protected:
+    void change_state(state_e new_state);
     void check_whitelist_states(const states_t &whitelist);
     //void check_blacklist_states(const states_t &blacklist);
 
@@ -235,21 +382,14 @@ protected:
 
     TrexOwner       m_owner;
     state_e         m_state;
-    int16_t         m_active_cores;
-    std::vector<std::string> m_states_names;
     CSyncBarrier   *m_sync_b;
     CFlowGenList   *m_fl;
     CParserOption  *m_opts;
-    std::string     m_error;
-    std::string     m_profile_buffer;
-    std::string     m_profile_hash;
-    bool            m_profile_parsed;
     std::string     m_topo_buffer;
     std::string     m_topo_hash;
     bool            m_topo_parsed;
     uint64_t        m_epoch;
 };
-
 
 static inline TrexAstf * get_astf_object() {
     return (TrexAstf *)get_stx();

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -95,12 +95,15 @@ TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStart, "start");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStop, "stop");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfUpdate, "update");
 
+TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfProfileList, "get_profile_list");
+
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStartLatency, "start_latency");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfStopLatency, "stop_latency");
 TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfUpdateLatency, "update_latency");
 
 TREX_RPC_CMD(TrexRpcCmdAstfCountersDesc, "get_counter_desc");
 TREX_RPC_CMD(TrexRpcCmdAstfCountersValues, "get_counter_values");
+TREX_RPC_CMD(TrexRpcCmdAstfTotalCountersValues, "get_total_counter_values");
 TREX_RPC_CMD(TrexRpcCmdAstfGetTGNames, "get_tg_names");
 TREX_RPC_CMD(TrexRpcCmdAstfGetTGStats, "get_tg_id_stats");
 TREX_RPC_CMD(TrexRpcCmdAstfGetLatencyStats, "get_latency_stats");
@@ -114,17 +117,24 @@ TREX_RPC_CMD_ASTF_OWNED(TrexRpcCmdAstfTopoClear, "topo_clear");
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfSync::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result, "");
     TrexAstf *stx = get_astf_object();
 
     Json::Value &res = result["result"];
     res["epoch"] = stx->get_epoch();
     res["state"] = stx->get_state();
 
+    if ( profile_id != "" ) {
+        Json::Value state_profile =  Json::objectValue;
+        stx->get_profiles_status(state_profile);
+        res["state_profile"] = state_profile;
+    }
     return (TREX_RPC_CMD_OK);
 }
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfIncEpoch::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     TrexAstf *stx = get_astf_object();
     try {
         stx->inc_epoch();
@@ -156,8 +166,17 @@ TrexRpcCmdAstfAcquire::_run(const Json::Value &params, Json::Value &result) {
         res["ports"][to_string(port.first)] = handler;
     }
 
-    if ( stx->profile_needs_parsing() ) {
-        stx->profile_clear();
+    stringstream ss;
+    vector<string> profile_list = stx->get_profile_id_list();
+    for ( auto profile_id : profile_list ) {
+        TrexAstfPerProfile *pid = stx->get_profile(profile_id);
+        try {
+            if ( pid->profile_needs_parsing() ) {
+                pid->profile_init();
+            }
+        } catch (const TrexException &ex) {
+            res["exception"][profile_id] = ex.what();
+        }
     }
 
     if ( stx->topo_needs_parsing() ) {
@@ -177,16 +196,25 @@ TrexRpcCmdAstfRelease::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfProfileFragment::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     const bool frag_first = parse_bool(params, "frag_first", result, false);
     const bool frag_last = parse_bool(params, "frag_last", result, false);
 
     TrexAstf *stx = get_astf_object();
 
+    stx->add_profile(profile_id);
+    TrexAstfPerProfile *pid = stx->get_profile(profile_id);
+
     if ( frag_first && !frag_last) {
         const string hash = parse_string(params, "md5", result);
-        if ( stx->profile_cmp_hash(hash) ) {
-            result["result"]["matches_loaded"] = true;
-            return TREX_RPC_CMD_OK;
+        switch ( pid->profile_cmp_hash(hash) ) {
+            case HASH_ON_SAME_PROFILE:
+                result["result"]["matches_loaded"] = true;
+                return TREX_RPC_CMD_OK;
+            case HASH_ON_OTHER_PROFILE:
+                generate_execute_err(result, "Fragment already added on other profile_id");
+            default:
+                break;
         }
     }
 
@@ -194,13 +222,13 @@ TrexRpcCmdAstfProfileFragment::_run(const Json::Value &params, Json::Value &resu
 
     try {
         if ( frag_first ) {
-            stx->profile_clear();
+            pid->profile_init();
         }
 
-        stx->profile_append(fragment);
+        pid->profile_append(fragment);
 
         if ( frag_last ) {
-            stx->profile_set_loaded();
+            pid->profile_set_loaded();
         }
 
     } catch (const TrexException &ex) {
@@ -212,8 +240,9 @@ TrexRpcCmdAstfProfileFragment::_run(const Json::Value &params, Json::Value &resu
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfProfileClear::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     try {
-        get_astf_object()->profile_clear();
+        get_astf_object()->profile_clear(profile_id);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -223,6 +252,7 @@ TrexRpcCmdAstfProfileClear::_run(const Json::Value &params, Json::Value &result)
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     start_params_t args;
     args.duration = parse_double(params, "duration", result);
     args.mult = parse_double(params, "mult", result);
@@ -232,7 +262,7 @@ TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
     args.client_mask = parse_uint32(params, "client_mask", result);
 
     try {
-        get_astf_object()->start_transmit(args);
+        get_astf_object()->start_transmit(profile_id, args);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -242,8 +272,9 @@ TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfStop::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     try {
-        get_astf_object()->stop_transmit();
+        get_astf_object()->stop_transmit(profile_id);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -253,10 +284,11 @@ TrexRpcCmdAstfStop::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfUpdate::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     const double mult = parse_double(params, "mult", result);
 
     try {
-        get_astf_object()->update_rate(mult);
+        get_astf_object()->update_rate(profile_id, mult);
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
     }
@@ -264,6 +296,19 @@ TrexRpcCmdAstfUpdate::_run(const Json::Value &params, Json::Value &result) {
     return (TREX_RPC_CMD_OK);
 }
 
+trex_rpc_cmd_rc_e
+TrexRpcCmdAstfProfileList::_run(const Json::Value &params, Json::Value &result) {
+    vector<string> profile_list = get_astf_object()->get_profile_id_list();
+    Json::Value json_profile_list = Json::arrayValue;
+
+    for (auto &profile_id : profile_list) {
+        json_profile_list.append(profile_id);
+    }
+
+    result["result"] = json_profile_list;
+
+    return (TREX_RPC_CMD_OK);
+}
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfStartLatency::_run(const Json::Value &params, Json::Value &result) {
@@ -376,7 +421,9 @@ TrexRpcCmdAstfGetLatencyStats::_run(const Json::Value &params, Json::Value &resu
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfGetTrafficDist::_run(const Json::Value &params, Json::Value &result) {
-    auto db = CAstfDB::instance();
+    string profile_id = parse_profile(params, result);
+    TrexAstfPerProfile *pid = get_astf_object()->get_profile(profile_id);
+    auto db = CAstfDB::instance(pid->get_dp_profile_id());
     auto stx = get_astf_object();
     auto &api = get_platform_api();
 
@@ -416,11 +463,17 @@ TrexRpcCmdAstfGetTrafficDist::_run(const Json::Value &params, Json::Value &resul
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfCountersDesc::_run(const Json::Value &params, Json::Value &result) {
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
-    if (lpstt) {
-        if (lpstt->m_init) {
+    string profile_id = parse_profile(params, result);
+    TrexAstf *stx = get_astf_object();
+    if (!stx->is_valid_profile(profile_id)) {
+        generate_execute_err(result, "Invalid profile : " + profile_id);
+    }
+    TrexAstfPerProfile *pid = stx->get_profile(profile_id);
+    CSTTCp *lpstt = pid->get_stt_cp();
+    if (lpstt && lpstt->m_init) {
             lpstt->m_dtbl.dump_meta("counter desc", result["result"]);
-        }
+    } else {
+        generate_execute_err(result, "Statistics are not initialized yet");
     }
 
     return (TREX_RPC_CMD_OK);
@@ -428,33 +481,88 @@ TrexRpcCmdAstfCountersDesc::_run(const Json::Value &params, Json::Value &result)
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfCountersValues::_run(const Json::Value &params, Json::Value &result) {
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
-    if (lpstt) {
-        if (lpstt->m_init) {
-            lpstt->m_dtbl.dump_values("counter vals", false, result["result"]);
-        }
+    string profile_id = parse_profile(params, result);
+    TrexAstfPerProfile *pid = get_astf_object()->get_profile(profile_id);
+    CSTTCp *lpstt = pid->get_stt_cp();
+    if (lpstt && lpstt->m_init) {
+        lpstt->m_dtbl.dump_values("counter vals", false, result["result"]);
+    } else {
+        generate_execute_err(result, "Statistics are not initialized yet");
     }
 
     return (TREX_RPC_CMD_OK);
 }
 
 trex_rpc_cmd_rc_e
+TrexRpcCmdAstfTotalCountersValues::_run(const Json::Value &params, Json::Value &result) {
+    TrexAstf *stx = get_astf_object();
+    vector<CSTTCp *> sttcp_list = stx->get_sttcp_list();
+    Json::Value temp;
+
+    for (auto lpstt : sttcp_list) {
+        if (lpstt->m_init) {
+            temp.clear();
+            lpstt->m_dtbl.dump_values("counter vals", false, temp);
+
+            /* Member : client, server */
+            for (auto i : temp.getMemberNames()) {
+                if (!temp[i].isObject()) {
+                    continue;
+                }
+                if (!result["result"].isMember(i)) {
+                    result["result"][i] = Json::objectValue;
+                }
+
+                /* Member : counters id */
+                for (auto j : temp[i].getMemberNames()) {
+                    if (!result["result"][i].isMember(j)) {
+                        result["result"][i][j] = 0;
+                    }
+                    if (temp[i][j].isInt64()) {
+                        result["result"][i][j] = result["result"][i][j].asInt64() +
+                                                 temp[i][j].asInt64();
+                    } else {
+                        result["result"][i][j] = result["result"][i][j].asDouble() +
+                                                 temp[i][j].asDouble();
+                    }
+                }
+            }
+        } else {
+            generate_execute_err(result, "Statistics are not initialized yet");
+        }
+    }
+
+    result["result"]["name"] = "counter vals";
+    result["result"]["epoch"] = stx->get_epoch();
+
+    return (TREX_RPC_CMD_OK);
+}
+
+trex_rpc_cmd_rc_e
 TrexRpcCmdAstfGetTGNames::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
+    TrexAstf *stx = get_astf_object();
+    if (!stx->is_valid_profile(profile_id)) {
+        generate_execute_err(result, "Invalid profile : " + profile_id);
+    }
     bool initialized = parse_bool(params, "initialized", result);
     uint64_t epoch = 0;
     if (initialized) {
         epoch = parse_uint64(params, "epoch", result);
     }
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
+    TrexAstfPerProfile *pid = stx->get_profile(profile_id);
+    CSTTCp *lpstt = pid->get_stt_cp();
     if (lpstt && lpstt->m_init) {
-        if (!get_astf_object()->is_state_build()) {
-            lpstt->UpdateTGNames(CAstfDB::instance()->get_tg_names());
+        if (!pid->is_profile_state_build()) {
+            lpstt->UpdateTGNames(CAstfDB::instance(pid->get_dp_profile_id())->get_tg_names());
         }
         uint64_t server_epoch = lpstt->m_epoch;
         result["result"]["epoch"] = server_epoch;
         if ( (initialized && server_epoch != epoch) || !initialized)  {
             lpstt->DumpTGNames(result["result"]);
         }
+    } else {
+        generate_execute_err(result, "Statistics are not initialized yet for TGs");
     }
 
     return (TREX_RPC_CMD_OK);
@@ -462,10 +570,12 @@ TrexRpcCmdAstfGetTGNames::_run(const Json::Value &params, Json::Value &result) {
 
 trex_rpc_cmd_rc_e
 TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
     vector<uint16_t> tgids_arr;
     uint64_t epoch = parse_uint64(params, "epoch", result);
     const Json::Value &tgids = parse_array(params, "tg_ids", result);
-    CSTTCp *lpstt = get_platform_api().get_fl()->m_stt_cp;
+    TrexAstfPerProfile *pid = get_astf_object()->get_profile(profile_id);
+    CSTTCp *lpstt = pid->get_stt_cp();
     try {
         if (tgids.size() > MAX_TG_ALLOWED_AT_ONCE) {
             generate_execute_err(result, "Trying to get statistics for too many TGs. Max allowed is "
@@ -486,11 +596,13 @@ TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
             uint64_t server_epoch = lpstt->m_epoch;
             result["result"]["epoch"] = server_epoch;
             if (server_epoch == epoch) {
-                if (!get_astf_object()->is_state_build()) {
+                if (!pid->is_profile_state_build()) {
                     lpstt->UpdateTGStats(tgids_arr);
                 }
                 lpstt->DumpTGStats(result["result"], tgids_arr);
             }
+        } else {
+            generate_execute_err(result, "Statistics are not initialized yet for TGs");
         }
     } catch (const TrexException &ex) {
         generate_execute_err(result, ex.what());
@@ -571,6 +683,7 @@ TrexRpcCmdsASTF::TrexRpcCmdsASTF() : TrexRpcComponent("ASTF") {
     m_cmds.push_back(new TrexRpcCmdAstfStart(this));
     m_cmds.push_back(new TrexRpcCmdAstfStop(this));
     m_cmds.push_back(new TrexRpcCmdAstfUpdate(this));
+    m_cmds.push_back(new TrexRpcCmdAstfProfileList(this));
     m_cmds.push_back(new TrexRpcCmdAstfStartLatency(this));
     m_cmds.push_back(new TrexRpcCmdAstfStopLatency(this));
     m_cmds.push_back(new TrexRpcCmdAstfUpdateLatency(this));
@@ -578,6 +691,7 @@ TrexRpcCmdsASTF::TrexRpcCmdsASTF() : TrexRpcComponent("ASTF") {
     m_cmds.push_back(new TrexRpcCmdAstfGetTrafficDist(this));
     m_cmds.push_back(new TrexRpcCmdAstfCountersDesc(this));
     m_cmds.push_back(new TrexRpcCmdAstfCountersValues(this));
+    m_cmds.push_back(new TrexRpcCmdAstfTotalCountersValues(this));
     m_cmds.push_back(new TrexRpcCmdAstfGetTGNames(this));
     m_cmds.push_back(new TrexRpcCmdAstfGetTGStats(this));
     m_cmds.push_back(new TrexRpcCmdAstfTopoGet(this));

--- a/src/stx/common/trex_messaging.cpp
+++ b/src/stx/common/trex_messaging.cpp
@@ -109,13 +109,13 @@ TrexDpPortEventMsg::handle() {
 
 bool
 TrexDpCoreStopped::handle(void) {
-    get_stx()->dp_core_finished(m_thread_id);
+    get_stx()->dp_core_finished(m_thread_id, m_profile_id);
     return true;
 }
 
 bool
 TrexDpCoreError::handle(void) {
-    get_stx()->dp_core_error(m_thread_id, m_err);
+    get_stx()->dp_core_error(m_thread_id, m_profile_id, m_err);
     return true;
 }
 

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -303,6 +303,9 @@ public:
         m_err       = err;
     }
 
+    TrexDpCoreError(int thread_id, const std::string &err): TrexDpCoreError(thread_id, 0, err) {
+    }
+
     virtual bool handle(void);
 
 private:

--- a/src/stx/common/trex_stx.cpp
+++ b/src/stx/common/trex_stx.cpp
@@ -161,11 +161,11 @@ TrexSTX::check_for_dp_message_from_core(int thread_id) {
 }
 
 void
-TrexSTX::dp_core_finished(int thread_id) {
+TrexSTX::dp_core_finished(int thread_id, uint32_t profile_id) {
 }
 
 void
-TrexSTX::dp_core_error(int thread_id, const std::string &err) {
+TrexSTX::dp_core_error(int thread_id, uint32_t profile_id, const std::string &err) {
 }
 
 /**

--- a/src/stx/common/trex_stx.h
+++ b/src/stx/common/trex_stx.h
@@ -145,12 +145,12 @@ public:
     /**
      * DP core has finished
      */
-    virtual void dp_core_finished(int thread_id);
+    virtual void dp_core_finished(int thread_id, uint32_t profile_id);
 
     /**
      * DP core encountered error
      */
-    virtual void dp_core_error(int thread_id, const std::string &err);
+    virtual void dp_core_error(int thread_id, uint32_t profile_id, const std::string &err);
 
     virtual void set_capture_feature(const std::set<uint8_t>& rx_cores) {};
 


### PR DESCRIPTION
The summary of dynamic multiple profile in CP side.

1. Support multiple profiles in CP side
2. Support statisctics for each profile
3. Added new RPC command 'get_total_counter_values' for statistics summary of all profiles
4. Added new event through asynchronous port.
 - EVENT_ASTF_PROFILE_STATE_CHG = 60 : event for each profile state change
 - EVENT_ASTF_PROFILE_CLEARED   = 61 : event for each rofile clear(remove database)
5. Added TrexAstfDeleteDB message between CP and DP to remove CAstfDB.

I have done regression test in our environment.
