### PR TITLE
revert __rte_raw_cksum change does not work properly at big-endian machine

### DIFF
--- a/src/dpdk/lib/librte_net/rte_ip.h
+++ b/src/dpdk/lib/librte_net/rte_ip.h
@@ -126,7 +126,7 @@ __rte_raw_cksum(const void *buf, size_t len, uint32_t sum)
 
 	/* if length is in odd bytes */
 	if (len == 1)
-		sum += *((const uint8_t *)u16_buf) & rte_be_to_cpu_16(0xff00);
+		sum += *((const uint8_t *)u16_buf);
 
 	return sum;
 }


### PR DESCRIPTION
Hi,
Recently, I found my commit f5319632 can make a potential problem on big-endian machines.
There is no issue on little-endian machines.
It was my fault at that time. Now I want to revert the change to fix it.