### PR TITLE
Secure ASTF statistics update for multiple profiles

### DIFF
--- a/src/44bsd/sim_cs_tcp.cpp
+++ b/src/44bsd/sim_cs_tcp.cpp
@@ -776,6 +776,7 @@ void CClientServerTcp::dump_counters(){
     stt_cp.m_init=true;
     stt_cp.Add(TCP_CLIENT_SIDE,&m_c_ctx);
     stt_cp.Add(TCP_SERVER_SIDE,&m_s_ctx);
+    stt_cp.update_profile_ctx();
     stt_cp.Update();
     stt_cp.DumpTable();
     std::string json;

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -1036,8 +1036,8 @@ public:
 private:
     std::unordered_map<profile_id_t, CPerProfileCtx*> m_profiles;
 
-    bool is_profile_ctx(profile_id_t profile_id) { return m_profiles.find(profile_id) != m_profiles.end(); }
 public:
+    bool is_profile_ctx(profile_id_t profile_id) { return m_profiles.find(profile_id) != m_profiles.end(); }
 #define FALLBACK_PROFILE_CTX(ctx)   ((ctx)->get_first_profile_ctx())
 #define DEFAULT_PROFILE_CTX(ctx)    ((ctx)->get_profile_ctx(0))
     CPerProfileCtx* get_profile_ctx(profile_id_t profile_id) {

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4230,8 +4230,10 @@ void CGlobalTRex::update_stats(){
 
     bool all_init=true;
     vector<CSTTCp *> sttcp_list;
+    TrexAstf* stx = 0;
     if ( get_is_interactive() && get_is_tcp_mode() ) {
-        sttcp_list = get_astf_object()->get_sttcp_list();
+        stx = get_astf_object();
+        sttcp_list = stx->get_sttcp_list();
     }
     else if ( m_fl.m_stt_cp ) {
         sttcp_list.push_back(m_fl.m_stt_cp);
@@ -4258,6 +4260,9 @@ void CGlobalTRex::update_stats(){
         }
 
         if (lpstt->m_init){
+            if (lpstt->need_profile_ctx_update() && stx && stx->is_safe_update_stats()) {
+                lpstt->update_profile_ctx();
+            }
             lpstt->Update();
         }
     }

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4260,8 +4260,10 @@ void CGlobalTRex::update_stats(){
         }
 
         if (lpstt->m_init){
-            if (lpstt->need_profile_ctx_update() && stx && stx->is_safe_update_stats()) {
-                lpstt->update_profile_ctx();
+            if (lpstt->need_profile_ctx_update()) {
+                if (!stx || (stx && stx->is_safe_update_stats())) {
+                    lpstt->update_profile_ctx();
+                }
             }
             lpstt->Update();
         }

--- a/src/sim/trex_sim_astf.cpp
+++ b/src/sim/trex_sim_astf.cpp
@@ -184,6 +184,7 @@ static void dump_tcp_counters(CTcpPerThreadCtx  *      c_ctx,
     stt_cp.m_init=true;
     stt_cp.Add(TCP_CLIENT_SIDE,c_ctx);
     stt_cp.Add(TCP_SERVER_SIDE,s_ctx);
+    stt_cp.update_profile_ctx();
     stt_cp.Update();
     stt_cp.DumpTable();
     std::string json;

--- a/src/stt_cp.cpp
+++ b/src/stt_cp.cpp
@@ -386,6 +386,7 @@ void CSTTCp::Create(uint32_t stt_id, uint16_t num_of_tg_ids, bool first_time){
     m_num_of_tg_ids = num_of_tg_ids;
     if (first_time) {
         m_init = false;
+        m_update = true;
         m_profile_ctx_updated = false;
         m_epoch = 0;
         m_dtbl.set_epoch(m_epoch);
@@ -410,6 +411,8 @@ void CSTTCp::Create(uint32_t stt_id, uint16_t num_of_tg_ids, bool first_time){
 }
 
 void CSTTCp::Update(){
+    if (!m_update) return;
+
     // Updates the counters only for the sum.
     for (int i = 0; i < TCP_CS_NUM; i++) {
         m_sts[i].update_counters(true);
@@ -448,6 +451,8 @@ void CSTTCp::DumpTGStats(Json::Value &result, const std::vector<uint16_t>& tg_id
 }
 
 void CSTTCp::UpdateTGStats(const std::vector<uint16_t>& tg_ids) {
+    if (!m_update) return;
+
     for (int i = 0; i < TCP_CS_NUM; i++) {
         for (uint16_t tg_id : tg_ids) {
             m_sts_per_tg_id[i][tg_id]->update_counters(false, tg_id);
@@ -530,5 +535,6 @@ void CSTTCp::update_profile_ctx() {
     }
 
     m_profile_ctx_updated = true;
+    m_update = true;
 }
 

--- a/src/stt_cp.h
+++ b/src/stt_cp.h
@@ -115,6 +115,7 @@ public:
     CSTTCpPerTGIDPerDir                 m_sts[TCP_CS_NUM]; // This isn't really per TGID, it's the sum over all TGIDs per client/server
     CTblGCounters                       m_dtbl;
     bool                                m_init;
+    bool                                m_update;
     uint16_t                            m_num_of_tg_ids;
     std::vector<std::string>            m_tg_names;
 

--- a/src/stt_cp.h
+++ b/src/stt_cp.h
@@ -47,7 +47,7 @@ typedef uint8_t tcp_dir_t;
 
 class CSTTCpPerTGIDPerDir {
 public:
-    bool Create(uint32_t stt_id, uint32_t time_msec);
+    bool Create(uint32_t time_msec);
     void Delete();
     void update_counters(bool is_sum, uint16_t tg_id=0);
     void clear_counters();
@@ -86,8 +86,7 @@ public:
 
     std::vector<CTcpPerThreadCtx*>  m_tcp_ctx; /* vectors contexts*/
 
-private:
-    uint32_t m_stt_id;
+    std::vector<CPerProfileCtx*>  m_profile_ctx; /* profile context */
 };
 
 class CSTTCp {
@@ -106,6 +105,8 @@ public:
     void UpdateTGNames(const std::vector<std::string>& tg_names);
     void DumpTGStats(Json::Value &result, const std::vector<uint16_t>& tg_ids);
     void UpdateTGStats(const std::vector<uint16_t>& tg_ids);
+    void update_profile_ctx();
+    bool need_profile_ctx_update() { return !m_profile_ctx_updated; }
 
 public:
     uint64_t                            m_epoch;
@@ -116,9 +117,10 @@ public:
     bool                                m_init;
     uint16_t                            m_num_of_tg_ids;
     std::vector<std::string>            m_tg_names;
+
 private:
     uint32_t m_stt_id;
-
+    bool     m_profile_ctx_updated;
 };
 
 

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -627,7 +627,7 @@ bool TrexAstfProfile::is_another_profile_transmitting(cp_profile_id_t profile_id
 bool TrexAstfProfile::is_safe_update_stats() {
     for (auto id : get_profile_id_list()) {
         state_e state = get_profile(id)->get_profile_state();
-        if (state == STATE_BUILD || state == STATE_CLEANUP) {
+        if (state == STATE_BUILD || state == STATE_CLEANUP || state == STATE_DELETE) {
             return false;
         }
     }
@@ -711,6 +711,7 @@ void TrexAstfPerProfile::profile_change_state(state_e new_state) {
             m_active_cores = 0;
             break;
         case STATE_LOADED:
+            m_stt_cp->m_update = true;
             m_profile_stopping = false;
             m_active_cores = 0;
             break;
@@ -718,15 +719,21 @@ void TrexAstfPerProfile::profile_change_state(state_e new_state) {
             m_active_cores = 1;
             break;
         case STATE_BUILD:
+            m_stt_cp->m_update = false;
             m_active_cores = get_platform_api().get_dp_core_count();
             break;
         case STATE_TX:
+            if (m_astf_obj->is_safe_update_stats()) {
+                m_stt_cp->update_profile_ctx();
+            }
             m_active_cores = get_platform_api().get_dp_core_count();
             break;
         case STATE_CLEANUP:
+            m_stt_cp->m_update = false;
             m_active_cores = get_platform_api().get_dp_core_count();
             break;
         case STATE_DELETE:
+            m_stt_cp->m_update = false;
             m_active_cores = 1;
             break;
         case AMOUNT_OF_STATES:
@@ -792,9 +799,6 @@ void TrexAstfPerProfile::transmit() {
     /* Resize the statistics vector depending on the number of template groups */
     CSTTCp* lpstt = m_stt_cp;
     lpstt->Resize(CAstfDB::instance(m_dp_profile_id)->get_num_of_tg_ids());
-    if (m_astf_obj->is_safe_update_stats()) {
-        lpstt->update_profile_ctx();
-    }
 
     string err = m_astf_obj->handle_start_latency(m_dp_profile_id);
     if (err != "") {

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -180,7 +180,7 @@ public:
     std::vector<std::string> m_states_names;
 
     bool is_another_profile_transmitting(cp_profile_id_t profile_id);
-    bool is_another_profile_busy(cp_profile_id_t profile_id);
+    bool is_safe_update_stats();
 
 protected:
     std::unordered_map<std::string, TrexAstfPerProfile *> m_profile_list;

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -553,7 +553,7 @@ TrexRpcCmdAstfGetTGNames::_run(const Json::Value &params, Json::Value &result) {
     TrexAstfPerProfile *pid = stx->get_profile(profile_id);
     CSTTCp *lpstt = pid->get_stt_cp();
     if (lpstt && lpstt->m_init) {
-        if (!pid->is_profile_state_build()) {
+        if (lpstt->m_update) {
             lpstt->UpdateTGNames(CAstfDB::instance(pid->get_dp_profile_id())->get_tg_names());
         }
         uint64_t server_epoch = lpstt->m_epoch;
@@ -597,10 +597,7 @@ TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
             uint64_t server_epoch = lpstt->m_epoch;
             result["result"]["epoch"] = server_epoch;
             if (server_epoch == epoch) {
-                if (!pid->is_profile_state_build()) {
-                    if (lpstt->need_profile_ctx_update() && stx->is_safe_update_stats()) {
-                        lpstt->update_profile_ctx();
-                    }
+                if (lpstt->m_update) {
                     lpstt->UpdateTGStats(tgids_arr);
                 }
                 lpstt->DumpTGStats(result["result"], tgids_arr);

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -574,7 +574,8 @@ TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
     vector<uint16_t> tgids_arr;
     uint64_t epoch = parse_uint64(params, "epoch", result);
     const Json::Value &tgids = parse_array(params, "tg_ids", result);
-    TrexAstfPerProfile *pid = get_astf_object()->get_profile(profile_id);
+    TrexAstf *stx = get_astf_object();
+    TrexAstfPerProfile *pid = stx->get_profile(profile_id);
     CSTTCp *lpstt = pid->get_stt_cp();
     try {
         if (tgids.size() > MAX_TG_ALLOWED_AT_ONCE) {
@@ -597,6 +598,9 @@ TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
             result["result"]["epoch"] = server_epoch;
             if (server_epoch == epoch) {
                 if (!pid->is_profile_state_build()) {
+                    if (lpstt->need_profile_ctx_update() && stx->is_safe_update_stats()) {
+                        lpstt->update_profile_ctx();
+                    }
                     lpstt->UpdateTGStats(tgids_arr);
                 }
                 lpstt->DumpTGStats(result["result"], tgids_arr);


### PR DESCRIPTION
I implemented a secure statistical update routine considering profile state to avoid crash 

1. New member vector of CSTTCpPerTGIDPerDir instance to manage profile contexts.
- std::vector<CPerProfileCtx*>  m_profile_ctx;
- profile_ctx will be updated in CSTTCpPerTGIDPerDir one time, and then use it to read statistics safely.

2. New function for safe update
- bool TrexAstfProfile::is_safe_update_stats() --> check if astf profile is on STATE_BUILD or STATE_CLEANUP.
- void CSTTCp::update_profile_ctx()            --> update profile contexts to m_profile_ctx vector

3. read tct/udp statistics using profile_ctx
```
    for (int i = 0; i < m_profile_ctx.size(); i++) {                                                           
        CPerProfileCtx* pctx = m_profile_ctx[i];
        uint64_t *base_tcp;
        uint64_t *base_udp;
        if (is_sum) {
            base_tcp = (uint64_t *)&pctx->m_tcpstat.m_sts;
            base_udp = (uint64_t *)&pctx->m_udpstat.m_sts;
        } else {
            base_tcp = (uint64_t *)&pctx->m_tcpstat.m_sts_tg_id[tg_id];
            base_udp = (uint64_t *)&pctx->m_udpstat.m_sts_tg_id[tg_id];
```

4. Have done regression test on my setups.
