### PR TITLE
enable latency statistics of custom ethertype packet stream

### DIFF
--- a/src/flow_stat_parser.cpp
+++ b/src/flow_stat_parser.cpp
@@ -295,8 +295,8 @@ int CFlowStatParser::get_payload_len(uint8_t *p, uint16_t len, uint16_t &payload
     uint8_t *p_l4 = NULL;
     TCPHeader *p_tcp = NULL;
     if (!m_ipv4 && !m_ipv6) {
-        payload_len = 0;
-        return -1;
+        payload_len = len - ETH_HDR_LEN;
+        return 0;
     }
 
     if (m_ipv4) {

--- a/src/stx/stl/trex_stl_fs.cpp
+++ b/src/stx/stl/trex_stl_fs.cpp
@@ -555,7 +555,7 @@ int CFlowStatRuleMgr::compile_stream(const TrexStream * stream, CFlowStatParser 
     CFlowStatParser_err_t ret = parser->parse(stream->m_pkt.binary, stream->m_pkt.len);
 
     // if we could not parse the packet, but no stat count needed, it is probably OK.
-    if ( ret != FSTAT_PARSER_E_OK && stream->need_flow_stats() ) {
+    if ( ret != FSTAT_PARSER_E_OK && stream->need_flow_stats() && get_dpdk_mode()->is_hardware_filter_needed() ) {
         throw TrexFStatEx(parser->get_error_str(ret), TrexException::T_FLOW_STAT_BAD_PKT_FORMAT);
     }
 


### PR DESCRIPTION
Hi,
I would like to get statistics per stream which packet has custom ethernet type.
According to my investigation, I can get it using by **--software** option and the **STLFlowLatencyStats** stream. But, there are some issues to make it work.

1. compile_stream is parsing the stream's packet and the result is failed --> can't add the stream
2. can't get the payload length from the custom ether type packet --> sanity check failed and can't add the stream
3. In MULTI_QUE mode, DP core is parsing the received packet and the result is failed --> RX counters in pg_id won't be updated.
4. When I entered the service mode, RX counters in pg_id are stopped. When I exited from the service mode, the counting resumes but counters during in service mode are missing.

This PR will be a simple solution for the above issues.
Please check the changes and give your feedback.