### PR TITLE
added a stateless test for raw packet stream statistics

### DIFF
--- a/scripts/automation/regression/stateless_tests/stl_rx_test.py
+++ b/scripts/automation/regression/stateless_tests/stl_rx_test.py
@@ -47,7 +47,7 @@ class STLRX_Test(CStlGeneral_Test):
         self.num_cores = system_info.get('dp_core_count', 'Unknown')
         self.is_multiqueue_mode = system_info.get('is_multiqueue_mode', False)
         self.is_vxlan_supported = system_info['ports'][0]['is_vxlan_supported']
-        self.is_virtual = system_info['ports'][0]['is_virtual']
+        self.advanced_per_stream_stats = system_info.get('advanced_per_stream_stats', False)
         mbufs = self.c.get_util_stats()['mbuf_stats']
         # currently in MLX drivers, we use 9k mbufs for RX, so we can't use all of them for TX.
         if self.drv_name == 'net_mlx5':
@@ -441,7 +441,7 @@ class STLRX_Test(CStlGeneral_Test):
 
     @try_few_times_on_vm
     def test_raw_pkt_stream(self):
-        if not self.is_virtual or not self.is_multiqueue_mode:
+        if not self.advanced_per_stream_stats or not self.is_multiqueue_mode:
             self.skip('Skip this for unsupported modes')
 
         total_pkts = self.total_pkts

--- a/scripts/automation/regression/stateless_tests/stl_rx_test.py
+++ b/scripts/automation/regression/stateless_tests/stl_rx_test.py
@@ -47,6 +47,7 @@ class STLRX_Test(CStlGeneral_Test):
         self.num_cores = system_info.get('dp_core_count', 'Unknown')
         self.is_multiqueue_mode = system_info.get('is_multiqueue_mode', False)
         self.is_vxlan_supported = system_info['ports'][0]['is_vxlan_supported']
+        self.is_virtual = system_info['ports'][0]['is_virtual']
         mbufs = self.c.get_util_stats()['mbuf_stats']
         # currently in MLX drivers, we use 9k mbufs for RX, so we can't use all of them for TX.
         if self.drv_name == 'net_mlx5':
@@ -424,6 +425,29 @@ class STLRX_Test(CStlGeneral_Test):
         self.c.reset()
         s1 = STLStream(name = 'rx',
                        packet = self.pkt,
+                       flow_stats = STLFlowLatencyStats(pg_id = 5),
+                       mode = STLTXSingleBurst(total_pkts = total_pkts,
+                                               percentage = self.rate_lat
+                       ))
+
+        # add both streams to ports
+        self.c.add_streams([s1], ports = [self.tx_port])
+
+        print("\ninjecting {0} packets on port {1}\n".format(total_pkts, self.tx_port))
+
+        exp = {'pg_id': 5, 'total_pkts': total_pkts, 'pkt_len': s1.get_pkt_len()}
+
+        self.__rx_iteration( [exp] )
+
+    @try_few_times_on_vm
+    def test_raw_pkt_stream(self):
+        if not self.is_virtual or not self.is_multiqueue_mode:
+            self.skip('Skip this for unsupported modes')
+
+        total_pkts = self.total_pkts
+        self.c.reset()
+        s1 = STLStream(name = 'rx',
+                       packet = STLPktBuilder(pkt = Ether(type=0xCCCC)/('x'*50)),
                        flow_stats = STLFlowLatencyStats(pg_id = 5),
                        mode = STLTXSingleBurst(total_pkts = total_pkts,
                                                percentage = self.rate_lat

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -406,6 +406,7 @@ TrexRpcCmdGetSysInfo::_run(const Json::Value &params, Json::Value &result) {
     section["dp_core_count_per_port"] = api.get_dp_core_count() / (api.get_port_count() / 2);
     section["core_type"] = get_cpu_model();
     section["is_multiqueue_mode"] = get_dpdk_mode()->dp_rx_queues() ? true : false;
+    section["advanced_per_stream_stats"] = !get_dpdk_mode()->is_hardware_filter_needed();
 
     /* ports */
     const stx_port_map_t &stx_port_map = get_stx()->get_port_map();


### PR DESCRIPTION
This PR is related to #293 "enable latency statistics of custom ethertype packet stream".

I added a condition to run this test like this:
```
        if not self.is_virtual or not self.is_multiqueue_mode:
            self.skip('Skip this for unsupported modes')
```

I think that ```is_multiqueue_mode``` is not enough because it may be true on some real NIC.
So, I added a condition ```is_virtual``` from port 0.