### PR TITLE
Fix a wrong calculation in ASTF get_total_counter_values

### DIFF
--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -497,8 +497,47 @@ trex_rpc_cmd_rc_e
 TrexRpcCmdAstfTotalCountersValues::_run(const Json::Value &params, Json::Value &result) {
     TrexAstf *stx = get_astf_object();
     vector<CSTTCp *> sttcp_list = stx->get_sttcp_list();
-    Json::Value temp;
+    vector<string> names;
+    uint32_t index, avg_size_id=0, tx_ratio_id=0, flow_table_id=0;
+    string tx_bw, tx_bw_tot, rx_bw, tx_pps, rx_pps, avg_size, tx_ratio;
+    double total_pps, total_tx_bw;
+    Json::Value entry, temp;
 
+    /* Get index by counters name */
+    if (!sttcp_list.empty() && sttcp_list[0]->m_init) {
+        sttcp_list[0]->m_dtbl.get_counters_names(&names);
+        for (int i = 0; i < names.size(); i++) {
+            if (names[i] == "m_tx_bw_l7_r") {
+                tx_bw = to_string(i);
+            } else if (names[i] == "m_tx_bw_l7_total_r") {
+                tx_bw_tot = to_string(i);
+            } else if (names[i] == "m_rx_bw_l7_r") {
+                rx_bw = to_string(i);
+            } else if (names[i] == "m_tx_pps_r") {
+                tx_pps = to_string(i);
+            } else if (names[i] == "m_rx_pps_r") {
+                rx_pps = to_string(i);
+            } else if (names[i] == "m_avg_size") {
+                avg_size_id = i;
+                avg_size = to_string(i);
+            } else if (names[i] == "m_tx_ratio") {
+                tx_ratio_id = i;
+                tx_ratio = to_string(i);
+            } else if (names[i] == "Flow Table") {
+                flow_table_id = i;
+            }
+        }
+    }
+
+    if (!flow_table_id || !avg_size_id || !tx_ratio_id) {
+        generate_execute_err(result, "Statistics are not initialized yet");
+    }
+
+    /* Step1. Accumulate counters of each profile except Flow Table.
+     * Step2. Calculate avg_size and tx_ratio using total counters.
+     *  - m_avg_size = (m_tx_bw_l7_r+m_rx_bw_l7_r)/(8.0*(m_tx_pps_r+m_rx_pps_r))
+     *  - m_tx_ratio = m_tx_bw_l7_r*100.0/m_tx_bw_l7_total_r
+     */
     for (auto lpstt : sttcp_list) {
         if (lpstt->m_init) {
             temp.clear();
@@ -509,24 +548,43 @@ TrexRpcCmdAstfTotalCountersValues::_run(const Json::Value &params, Json::Value &
                 if (!temp[i].isObject()) {
                     continue;
                 }
-                if (!result["result"].isMember(i)) {
-                    result["result"][i] = Json::objectValue;
+                if (!entry.isMember(i)) {
+                    entry[i] = Json::objectValue;
                 }
 
-                /* Member : counters id */
+                /* Member : counters index */
                 for (auto j : temp[i].getMemberNames()) {
-                    if (!result["result"][i].isMember(j)) {
-                        result["result"][i][j] = 0;
+                    if (!entry[i].isMember(j)) {
+                        entry[i][j] = 0;
                     }
-                    if (temp[i][j].isInt64()) {
-                        result["result"][i][j] = result["result"][i][j].asInt64() +
-                                                 temp[i][j].asInt64();
+
+                    index = atoi(j.c_str());
+                    if (index < flow_table_id && index != avg_size_id && index != tx_ratio_id) {
+                        /* externation, TCP and UDP counters */
+                        if (temp[i][j].isInt64()) {
+                            entry[i][j] = entry[i][j].asInt64() + temp[i][j].asInt64();
+                        } else {
+                            entry[i][j] = entry[i][j].asDouble() + temp[i][j].asDouble();
+                        }
                     } else {
-                        result["result"][i][j] = result["result"][i][j].asDouble() +
-                                                 temp[i][j].asDouble();
+                        /* Flow Table counters */
+                        entry[i][j] = temp[i][j];
                     }
                 }
+
+                total_pps = entry[i][tx_pps].asDouble() + entry[i][rx_pps].asDouble();
+                total_tx_bw = entry[i][tx_bw_tot].asDouble();
+                entry[i][avg_size] = 0.0;
+                entry[i][tx_ratio] = 0.0;
+                if (total_pps > 0.0) {
+                    entry[i][avg_size] = (entry[i][tx_bw].asDouble()+entry[i][rx_bw].asDouble()) /
+                                         (8.0*total_pps);
+                }
+                if (total_tx_bw > 0.0) {
+                    entry[i][tx_ratio] = entry[i][tx_bw].asDouble()*100.0 / total_tx_bw;
+                }
             }
+            result["result"] = entry;
         } else {
             generate_execute_err(result, "Statistics are not initialized yet");
         }

--- a/src/utils/utl_counter.cpp
+++ b/src/utils/utl_counter.cpp
@@ -283,5 +283,14 @@ void CTblGCounters::verify(){
     }
 }
 
+void CTblGCounters::get_counters_names(std::vector<std::string> *names){
+
+    CGTblClmCounters* lp=m_counters[0];
+    int i;
+    for (i=0; i<lp->get_size(); i++) {
+        CGSimpleBase* lpcnt=lp->get_cnt(i);
+        names->push_back(lpcnt->get_name());
+    }
+}
 
 

--- a/src/utils/utl_counter.h
+++ b/src/utils/utl_counter.h
@@ -397,6 +397,8 @@ public:
         m_epoch = epoch;
     }
 
+    void get_counters_names(std::vector<std::string> *names);
+
 private:
     void verify();
     bool can_skip_zero(int index);


### PR DESCRIPTION
m_avg_size and m_tx_ratio was miscalculated in 'get_total_counter_values' RPC command.
I verified it with 'tui' and 'stats -a' command in trex-console.

Step1. Accumulate counters of each profile except Flow Table.
Step2. Calculate avg_size and tx_ratio using total counters.
     - m_avg_size = (m_tx_bw_l7_r+m_rx_bw_l7_r)/(8.0*(m_tx_pps_r+m_rx_pps_r))
     - m_tx_ratio = m_tx_bw_l7_r*100.0/m_tx_bw_l7_total_r
