### PR TITLE
RXLatency - refactor - stage 1

### DIFF
--- a/src/stx/common/trex_latency_counters.cpp
+++ b/src/stx/common/trex_latency_counters.cpp
@@ -147,99 +147,13 @@ RXLatency::handle_pkt(const rte_mbuf_t *m) {
         int ret2 = parser.get_ip_id(ip_id);
         if (m_rcv_all || ( ret2 == 0)) {
             if (m_rcv_all || is_flow_stat_id(ip_id)) {
-                uint16_t hw_id;
                 if (is_flow_stat_payload_id(ip_id) || ((! is_flow_stat_id(ip_id)) && m_rcv_all)) {
-                    bool good_packet = true;
                     struct flow_stat_payload_header *fsp_head = (flow_stat_payload_header *)
                         utl_rte_pktmbuf_get_last_bytes(m, sizeof(struct flow_stat_payload_header), tmp_buf);
-                    hw_id = fsp_head->hw_id;
-                    CRFC2544Info *curr_rfc2544;
-                    if (unlikely(fsp_head->magic != FLOW_STAT_PAYLOAD_MAGIC) || hw_id >= MAX_FLOW_STATS_PAYLOAD) {
-                        good_packet = false;
-                        if (!m_rcv_all)
-                            m_err_cntrs->m_bad_header++;
-                    } else {
-                        curr_rfc2544 = &m_rfc2544[hw_id];
-
-                        if (fsp_head->flow_seq != curr_rfc2544->get_exp_flow_seq()) {
-                            // bad flow seq num
-                            // Might be the first packet of a new flow, packet from an old flow, or garbage.
-                            if (fsp_head->flow_seq == curr_rfc2544->get_prev_flow_seq()) {
-                                // packet from previous flow using this hw_id that arrived late
-                                good_packet = false;
-                                m_err_cntrs->m_old_flow++;
-                            } else {
-                                if (curr_rfc2544->no_flow_seq()) {
-                                    // first packet we see from this flow
-                                    good_packet = true;
-                                    curr_rfc2544->set_exp_flow_seq(fsp_head->flow_seq);
-                                } else {
-                                    // garbage packet
-                                    good_packet = false;
-                                    m_err_cntrs->m_bad_header++;
-                                }
-                            }
-                        }
-                    }
-
-                    if (good_packet) {
-                        uint32_t pkt_seq = fsp_head->seq;
-                        uint32_t exp_seq = curr_rfc2544->get_seq();
-                        if (unlikely(pkt_seq != exp_seq)) {
-                            if (pkt_seq < exp_seq) {
-                                if (exp_seq - pkt_seq > 100000) {
-                                    // packet loss while we had wrap around
-                                    curr_rfc2544->inc_seq_err(pkt_seq - exp_seq);
-                                    curr_rfc2544->inc_seq_err_too_big();
-                                    curr_rfc2544->set_seq(pkt_seq + 1);
-#ifdef LAT_DEBUG
-                                    printf("magic:%x flow_seq:%x hw_id:%x seq %x exp %x\n"
-                                           , fsp_head->magic, fsp_head->flow_seq, fsp_head->hw_id, pkt_seq
-                                           , exp_seq);
-                                    utl_DumpBuffer(stdout, rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len, 0);
-#endif
-                                } else {
-                                    if (pkt_seq == (exp_seq - 1)) {
-                                        curr_rfc2544->inc_dup();
-                                    } else {
-                                        curr_rfc2544->inc_ooo();
-                                        // We thought it was lost, but it was just out of order
-                                        curr_rfc2544->dec_seq_err();
-                                    }
-                                    curr_rfc2544->inc_seq_err_too_low();
-                                }
-                            } else {
-                                if (unlikely (pkt_seq - exp_seq > 100000)) {
-                                    // packet reorder while we had wrap around
-                                    if (pkt_seq == (exp_seq - 1)) {
-                                        curr_rfc2544->inc_dup();
-                                    } else {
-                                        curr_rfc2544->inc_ooo();
-                                        // We thought it was lost, but it was just out of order
-                                        curr_rfc2544->dec_seq_err();
-                                    }
-                                    curr_rfc2544->inc_seq_err_too_low();
-                                } else {
-                                // seq > curr_rfc2544->seq. Assuming lost packets
-                                    curr_rfc2544->inc_seq_err(pkt_seq - exp_seq);
-                                    curr_rfc2544->inc_seq_err_too_big();
-                                    curr_rfc2544->set_seq(pkt_seq + 1);
-#ifdef LAT_DEBUG
-                                    printf("2:seq %d exp %d\n", exp_seq, pkt_seq);
-#endif
-                                }
-                            }
-                        } else {
-                            curr_rfc2544->set_seq(pkt_seq + 1);
-                        }
-                        m_rx_pg_stat_payload[hw_id].add_pkts(1);
-                        m_rx_pg_stat_payload[hw_id].add_bytes(m->pkt_len + 4); // +4 for ethernet CRC
-                        uint64_t d = (os_get_hr_tick_64() - fsp_head->time_stamp );
-                        dsec_t ctime = ptime_convert_hr_dsec(d);
-                        curr_rfc2544->add_sample(ctime);
-                    }
+                    hr_time_t hr_time_now = os_get_hr_tick_64();
+                    update_stats_for_pkt(fsp_head, m->pkt_len, hr_time_now);
                 } else {
-                    hw_id = get_hw_id((uint16_t)ip_id);
+                    uint16_t hw_id = get_hw_id((uint16_t)ip_id);
                     if (hw_id < MAX_FLOW_STATS) {
                         m_rx_pg_stat[hw_id].add_pkts(1);
                         m_rx_pg_stat[hw_id].add_bytes(m->pkt_len + 4); // +4 for ethernet CRC
@@ -247,6 +161,91 @@ RXLatency::handle_pkt(const rte_mbuf_t *m) {
                 }
             }
         }
+    }
+}
+
+void
+RXLatency::update_stats_for_pkt(
+        flow_stat_payload_header *fsp_head,
+        uint32_t pkt_len,
+        hr_time_t hr_time_now) {
+    bool good_packet = true;
+    uint16_t hw_id = fsp_head->hw_id;
+    CRFC2544Info *curr_rfc2544;
+    if (unlikely(fsp_head->magic != FLOW_STAT_PAYLOAD_MAGIC) || hw_id >= MAX_FLOW_STATS_PAYLOAD) {
+        good_packet = false;
+        if (!m_rcv_all)
+            m_err_cntrs->m_bad_header++;
+    } else {
+        curr_rfc2544 = &m_rfc2544[hw_id];
+
+        if (fsp_head->flow_seq != curr_rfc2544->get_exp_flow_seq()) {
+            // bad flow seq num
+            // Might be the first packet of a new flow, packet from an old flow, or garbage.
+            if (fsp_head->flow_seq == curr_rfc2544->get_prev_flow_seq()) {
+                // packet from previous flow using this hw_id that arrived late
+                good_packet = false;
+                m_err_cntrs->m_old_flow++;
+            } else {
+                if (curr_rfc2544->no_flow_seq()) {
+                    // first packet we see from this flow
+                    good_packet = true;
+                    curr_rfc2544->set_exp_flow_seq(fsp_head->flow_seq);
+                } else {
+                    // garbage packet
+                    good_packet = false;
+                    m_err_cntrs->m_bad_header++;
+                }
+            }
+        }
+    }
+
+    if (good_packet) {
+        uint32_t pkt_seq = fsp_head->seq;
+        uint32_t exp_seq = curr_rfc2544->get_seq();
+        if (unlikely(pkt_seq != exp_seq)) {
+            if (pkt_seq < exp_seq) {
+                if (exp_seq - pkt_seq > 100000) {
+                    // packet loss while we had wrap around
+                    curr_rfc2544->inc_seq_err(pkt_seq - exp_seq);
+                    curr_rfc2544->inc_seq_err_too_big();
+                    curr_rfc2544->set_seq(pkt_seq + 1);
+                } else {
+                    if (pkt_seq == (exp_seq - 1)) {
+                        curr_rfc2544->inc_dup();
+                    } else {
+                        curr_rfc2544->inc_ooo();
+                        // We thought it was lost, but it was just out of order
+                        curr_rfc2544->dec_seq_err();
+                    }
+                    curr_rfc2544->inc_seq_err_too_low();
+                }
+            } else {
+                if (unlikely (pkt_seq - exp_seq > 100000)) {
+                    // packet reorder while we had wrap around
+                    if (pkt_seq == (exp_seq - 1)) {
+                        curr_rfc2544->inc_dup();
+                    } else {
+                        curr_rfc2544->inc_ooo();
+                        // We thought it was lost, but it was just out of order
+                        curr_rfc2544->dec_seq_err();
+                    }
+                    curr_rfc2544->inc_seq_err_too_low();
+                } else {
+                // seq > curr_rfc2544->seq. Assuming lost packets
+                    curr_rfc2544->inc_seq_err(pkt_seq - exp_seq);
+                    curr_rfc2544->inc_seq_err_too_big();
+                    curr_rfc2544->set_seq(pkt_seq + 1);
+                }
+            }
+        } else {
+            curr_rfc2544->set_seq(pkt_seq + 1);
+        }
+        m_rx_pg_stat_payload[hw_id].add_pkts(1);
+        m_rx_pg_stat_payload[hw_id].add_bytes(pkt_len + 4); // +4 for ethernet CRC
+        uint64_t d = (hr_time_now - fsp_head->time_stamp );
+        dsec_t ctime = ptime_convert_hr_dsec(d);
+        curr_rfc2544->add_sample(ctime);
     }
 }
 

--- a/src/stx/common/trex_latency_counters.h
+++ b/src/stx/common/trex_latency_counters.h
@@ -83,21 +83,24 @@ public:
     void create(CRFC2544Info *rfc2544, CRxCoreErrCntrs *err_cntrs);
 
     void handle_pkt(const rte_mbuf_t *m);
+    void update_stats_for_pkt(flow_stat_payload_header *fsp_head,
+                              uint32_t pkt_len,
+                              hr_time_t hr_time_now);
 
     Json::Value to_json() const;
-    
+
     void get_stats(rx_per_flow_t *rx_stats,
                    int min,
                    int max,
                    bool reset,
                    TrexPlatformApi::driver_stat_cap_e type);
-    
+
     void reset_stats();
     void reset_stats_partial(int min, int max, TrexPlatformApi::driver_stat_cap_e type);
 
     RXLatency operator+=(const RXLatency& in);
     friend std::ostream& operator<<(std::ostream& os, const RXLatency& in);
-    
+
 private:
     // below functions for both IP v4 and v6, so they need uint32_t id
     bool is_flow_stat_id(uint32_t id) {


### PR DESCRIPTION
Part of RXLatency::handle_pkt is moved to separate function:
RXLatency::update_stats_for_pkt. The new function does not depend
on rte_mbuf_t and time measurement. It makes it easier to unit
test stats calculation code. Another benefit is improved
readability of the code (original function was more than 100 lines
long). Some unit tests for duplicate calculation have been added.

Signed-off-by: Jacek Iżykowski <jacek.izykowski@codilime.com>