### PR TITLE
Cannot start new profile during latency profile running

### DIFF
--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -50,6 +50,7 @@ TrexAstf::TrexAstf(const TrexSTXCfg &cfg) : TrexSTX(cfg) {
     m_l_state = STATE_L_IDLE;
     m_latency_pps = 0;
     m_lat_with_traffic = false;
+    m_lat_profile_id = 0;
 
     TrexRpcCommandsTable &rpc_table = TrexRpcCommandsTable::get_instance();
 
@@ -309,6 +310,7 @@ void TrexAstf::start_transmit(cp_profile_id_t profile_id, const start_params_t &
         }
         m_latency_pps = args.latency_pps;
         m_lat_with_traffic = true;
+        m_lat_profile_id = pid->get_dp_profile_id();
     }
 
     pid->set_factor(args.mult);
@@ -419,7 +421,7 @@ void TrexAstf::get_latency_stats(Json::Value & obj) {
 }
 
 string TrexAstf::handle_start_latency(int32_t dp_profile_id) {
-    if ( m_lat_with_traffic ) {
+    if ( m_lat_profile_id == dp_profile_id && m_lat_with_traffic && m_l_state == STATE_L_IDLE ) {
         CAstfDB *db = CAstfDB::instance(dp_profile_id);
         lat_start_params_t args;
 
@@ -445,6 +447,7 @@ void TrexAstf::handle_stop_latency() {
     if (m_lat_with_traffic && m_l_state == STATE_L_WORK) {
         m_latency_pps = 0;
         m_lat_with_traffic = false;
+        m_lat_profile_id = 0;
         stop_transmit_latency();
     }
 }

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -379,6 +379,7 @@ protected:
     state_latency_e m_l_state;
     uint32_t        m_latency_pps;
     bool            m_lat_with_traffic;
+    int32_t         m_lat_profile_id;
 
     TrexOwner       m_owner;
     state_e         m_state;


### PR DESCRIPTION
If one profile started with latency enabled, then other new profile cannot be started during latency enabled profile running.

Reproduction:

trex>start -l 1 -f astf/udp1.py --pid udp
trex>start -f astf/http_simple.py --pid tcp

Last command failed: Latency state is not idle, should stop latency first