### PR TITLE
make recursive CEmulApp::process_cmd() iterative

### DIFF
--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -325,8 +325,19 @@ void CEmulApp::check_rx_pkt_condition(){
 
 */
 void CEmulApp::process_cmd(CEmulAppCmd * cmd){
+    CEmulAppCmd temp_cmd;
+    int process_cnt = 0;
+
     while(cmd) {
-       cmd = process_cmd_one(cmd);
+        // add implicit delay to avoid watchdog
+        if (++process_cnt > 1000) {
+            --m_cmd_index;  // rewind index for next()
+
+            temp_cmd.m_cmd = tcDELAY;
+            temp_cmd.u.m_delay_cmd.m_ticks = 1;
+            cmd = &temp_cmd;
+        }
+        cmd = process_cmd_one(cmd);
     }
 }
 

--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -811,6 +811,8 @@ private:
 
     void check_rx_pkt_condition();
 
+    inline CEmulAppCmd* next_cmd();
+    CEmulAppCmd* process_cmd_one(CEmulAppCmd * cmd);
     void process_cmd(CEmulAppCmd * cmd);
 
     void run_cmd_delay_rand(htw_ticks_t min_ticks,


### PR DESCRIPTION
This PR is related to #305 the second issue((Issue#2. TRex server crash when the user used big set_var in ASTF UDP mode).
According to my examination, the reason for the crash is a stack overflow.
Since CEmulApp::process_cmd() and CEmulApp::next() were recursively called by the programmed loop, stack memory was exhausted by a large value of the loop.
So, I changed the recursive routine to iterative.

I hope my change will remove the massive stack usage caused by huge recursive calls.
