### PR TITLE
fix crash when duplicated port used in templates

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -1615,6 +1615,13 @@ class ASTFProfile(object):
                     if template.tg_name:
                             template.fields['tg_id'] = len(self.tg_name_to_id) + 1
                             self.tg_name_to_id[template.tg_name] = len(self.tg_name_to_id) + 1
+            server_ports = []
+            for template in self.templates:
+                port = template.fields['server_template'].fields['assoc'].port
+                if port in server_ports:
+                    raise ASTFError("Two server template with port {}".format(port))
+                else:
+                    server_ports.append(port)
 
         if cap_list is not None:
             mode = None

--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -770,6 +770,10 @@ void CTcpPerThreadCtx::append_server_ports(profile_id_t profile_id) {
     CAstfDbRO * template_db = pctx->m_template_ro;
     std::vector<uint16_t> server_ports;
 
+    if (!template_db) {
+        return;
+    }
+
     server_ports.clear();
     template_db->enumerate_server_ports(server_ports, true);
     for (auto port: server_ports) {
@@ -792,6 +796,10 @@ void CTcpPerThreadCtx::remove_server_ports(profile_id_t profile_id) {
     CPerProfileCtx * pctx = get_profile_ctx(profile_id);
     CAstfDbRO * template_db = pctx->m_template_ro;
     std::vector<uint16_t> server_ports;
+
+    if (!template_db) {
+        return;
+    }
 
     server_ports.clear();
     template_db->enumerate_server_ports(server_ports, true);


### PR DESCRIPTION
This PR is related to #305 the third issue(Issue#3. TRex server crash when same port used in the multiple template group in ASTF mode).
It comes from a lack of defense code when multiple profile support implemented.
I added a verification code for this issue in the client side also.
Please check my changes and give your feedback.
