### PR TITLE
set stdout line buffered when --iom is 0

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -6366,8 +6366,13 @@ int main_test(int argc , char * argv[]){
     if (!po->preview.get_is_termio_disabled()) {
         utl_termio_init();
     }
-    
-    
+
+    /* set line buffered mode only if --iom 0 */
+    if (CGlobalInfo::m_options.m_io_mode == 0) {
+        setvbuf(stdout, NULL, _IOLBF, 0);
+    }
+
+
     /* enable core dump if requested */
     if (po->preview.getCoreDumpEnable()) {
         utl_set_coredump_size(-1);


### PR DESCRIPTION
This PR is related to issue #318 (truncated messages in the server console log.

As you suggested, I set stdout line-buffered mode only when --iom 0 is specified.

Please check my changes and give your feedback.
