### PR TITLE
Fix building with GCC 9

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -55,7 +55,8 @@ gcc_flags = ['-Wall',
              '-Werror',
              '-Wno-literal-suffix',
              '-Wno-sign-compare',
-             '-Wno-strict-aliasing']
+             '-Wno-strict-aliasing',
+             '-Wno-address-of-packed-member']
 
 
 


### PR DESCRIPTION
GCC 9 added the no-address-of-packed-member check to Wall, which causes
the build to fail under GCC. Clang already had that check, and the
warning is explicitly disabled for the clang build, so we disable it
for GCC as well.

Signed-off-by: Zvi Effron <zeffron@hmc.edu>