### PR TITLE
Avoid raising an exception if returned latency is -1

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_stats.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_stats.py
@@ -257,7 +257,8 @@ class CPgIdStats(object):
                         if port in self.ref['flow_stats'][pg_id][field]:
                             try:
                                 rel_val = val - self.ref['flow_stats'][pg_id][field][port]
-                                assert rel_val >= 0, 'Negative pg_id stat value: %s (%s %s %s)' % (rel_val, pg_id, field, port)
+                                # -1 likely means all the latency packets were dropped
+                                assert rel_val >= -1, 'Negative pg_id stat value: %s (%s %s %s)' % (rel_val, pg_id, field, port)
                                 pg_id_val[field][port] = rel_val
                             except TypeError: # might be StatNotAvailable
                                 pass


### PR DESCRIPTION
In case of heavy packet drops, it is possible that no latency packets return, which 
will cause the returned latency value to be -1.
In this case, it is not desirable to have an exception in the python library and instead returns
-1 latency. 