### PR TITLE
improve watchdog timeout handling

### DIFF
--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -2792,7 +2792,7 @@ bool CFlowGenListPerThread::Create(uint32_t           thread_id,
 
     unsigned flow_nodes = CGlobalInfo::m_memory_cfg.get_each_core_dp_flows() ;
     if (get_is_tcp_mode()) {
-        flow_nodes = 1024; /* No need for many nodes, it handles in different ways */
+        flow_nodes = 8192; /* No need for many nodes, it handles in different ways */
     }
 
     bool use_hugepages = CGlobalInfo::m_options.m_is_vdev ? false : true;

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4897,8 +4897,10 @@ COLD_FUNC int CGlobalTRex::run_in_master() {
         m_monitor.disable(30); //assume we will wake up
 
         cp_lock.unlock();
-        delay(FASTPATH_DELAY_MS);
-        slow_path_counter += FASTPATH_DELAY_MS;
+        if (! m_stx->has_dp_messages()) {
+            delay(FASTPATH_DELAY_MS);
+            slow_path_counter += FASTPATH_DELAY_MS;
+        }
         cp_lock.lock();
 
         m_monitor.enable();

--- a/src/rpc-server/trex_rpc_req_resp_server.cpp
+++ b/src/rpc-server/trex_rpc_req_resp_server.cpp
@@ -249,8 +249,14 @@ void TrexRpcServerReqRes::process_request_raw(const std::string &request, std::s
     for (auto command : commands) {
         Json::Value single_response;
 
+#ifndef TREX_SIM
+        m_monitor.disable();    // to avoid watchdog during lock waiting
+#endif
         /* the command itself should be protected */
         std::unique_lock<std::recursive_mutex> lock(*m_lock);
+#ifndef TREX_SIM
+        m_monitor.enable();
+#endif
         command->execute(single_response);
         lock.unlock();
 

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -338,6 +338,9 @@ void TrexAstfDpCore::parse_astf_json(profile_id_t profile_id, string *profile_bu
 }
 
 void TrexAstfDpCore::remove_astf_json(profile_id_t profile_id) {
+    TrexWatchDog::IOFunction dummy;
+    (void)dummy;
+
     CAstfDB::free_instance(profile_id);
     report_finished(profile_id);
 }

--- a/src/stx/common/trex_stx.h
+++ b/src/stx/common/trex_stx.h
@@ -211,6 +211,7 @@ public:
      * 
      */
     void check_for_dp_messages();
+    bool has_dp_messages();
 
     /**
      *  get ticket for async ops


### PR DESCRIPTION
This PR is related to #327.

1. the number of ASTF flow_nodes is updated to 8192(8 times than before).
2. RPC server thread will not receive wrong watchdog timeout any more caused by CP master thread.
3. CP master thread will process up to 100 DP messages at once to avoid watchdog timeout.

Please check my changes and give your feedback.
