### PR TITLE
Improve update_astf_state() performance

### DIFF
--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -178,12 +178,14 @@ public:
     std::vector<CSTTCp *>    get_sttcp_list();
 
     std::vector<std::string> m_states_names;
+    std::vector<uint32_t>    m_states_cnt;
 
     bool is_another_profile_transmitting(cp_profile_id_t profile_id);
     bool is_safe_update_stats();
 
 protected:
     std::unordered_map<std::string, TrexAstfPerProfile *> m_profile_list;
+    std::unordered_map<uint32_t, cp_profile_id_t> m_profile_id_map;
 
 private:
     uint32_t m_dp_profile_last_id;


### PR DESCRIPTION
This PR is for improvement of DP event handling time.

There are 2 main functions to be improved:
1. update_astf_stat() checks all profiles state one by one. --> changed to use profile count for each state.
2. get_profile_id() does a sequential search to all profiles. --> changed to use id map.

According to my measurement, with 4000 profiles, it took about 30ms for processing 100 messages.
Now, it will take about 3ms.

Please check my changes and give your feedback.
