### PR TITLE
Support VXLAN skip for latency

### DIFF
--- a/scripts/automation/regression/stateless_tests/stl_rx_test.py
+++ b/scripts/automation/regression/stateless_tests/stl_rx_test.py
@@ -997,14 +997,6 @@ class STLRX_Test(CStlGeneral_Test):
             raise TRexError('Did not raise exception')
 
         try:
-            self.setup_vxlan_streams(True, [pkt0, True])
-            c.start(ports = self.tx_port)
-        except TRexError as e:
-            assert 'not supported for latency' in str(e), 'Bad message in exception: %s' % e
-        else:
-            raise TRexError('Did not raise exception')
-
-        try:
             bad_pkt = Ether()/IP()/TCP()/('x' * 50)
             self.setup_vxlan_streams(False, [bad_pkt, True])
             c.start(ports = self.tx_port)

--- a/src/dpdk_trex_port_attr.cpp
+++ b/src/dpdk_trex_port_attr.cpp
@@ -242,6 +242,7 @@ int DpdkTRexPortAttr::set_vxlan_fs(vxlan_fs_ports_t &vxlan_fs_ports) {
                 return ret;
             }
             m_vxlan_fs_ports.erase(it);
+            CGlobalInfo::m_options.m_ip_cfg[m_port_id].set_vxlan_fs(false);
         }
 
         for (auto &vxlan_fs_port : vxlan_fs_ports) { // add new ports
@@ -251,6 +252,7 @@ int DpdkTRexPortAttr::set_vxlan_fs(vxlan_fs_ports_t &vxlan_fs_ports) {
                 return ret;
             }
             m_vxlan_fs_ports.insert(vxlan_fs_port);
+            CGlobalInfo::m_options.m_ip_cfg[m_port_id].set_vxlan_fs(true);
         }
     }
 

--- a/src/flow_stat_parser.cpp
+++ b/src/flow_stat_parser.cpp
@@ -167,6 +167,20 @@ uint16_t CFlowStatParser::get_vxlan_payload_offset(uint8_t *pkt, uint16_t len) {
     return len - payload_len + VXLAN_LEN;
 }
 
+uint16_t CFlowStatParser::get_vxlan_rx_payload_offset(uint8_t *pkt, uint16_t len) {
+    uint16_t payload_len;
+    if ( get_payload_len(pkt, len, payload_len) < 0 ) {
+        return 0;
+    }
+    if ( m_l4_proto != IPPROTO_UDP ) {
+        return 0;
+    }
+    if ( payload_len < VXLAN_LEN + ETH_HDR_LEN ) {
+        return 0;
+    }
+    return len - payload_len + VXLAN_LEN;
+}
+
 // arg is uint32_t in below two functions because we want same function to work for IPv4 and IPv6
 int CFlowStatParser::get_ip_id(uint32_t &ip_id) {
     if (m_ipv4) {

--- a/src/flow_stat_parser.h
+++ b/src/flow_stat_parser.h
@@ -65,6 +65,7 @@ class CFlowStatParser {
     std::string get_error_str(CFlowStatParser_err_t err);
     virtual CFlowStatParser_err_t parse(uint8_t *pkt, uint16_t len);
     virtual uint16_t get_vxlan_payload_offset(uint8_t *pkt, uint16_t len);
+    virtual uint16_t get_vxlan_rx_payload_offset(uint8_t *pkt, uint16_t len);
     virtual int get_ip_id(uint32_t &ip_id);
     virtual void set_ip_id(uint32_t ip_id);
     virtual void set_tos_to_cpu();

--- a/src/stx/common/trex_latency_counters.cpp
+++ b/src/stx/common/trex_latency_counters.cpp
@@ -141,6 +141,10 @@ RXLatency::handle_pkt(const rte_mbuf_t *m) {
     uint8_t tmp_buf[sizeof(struct flow_stat_payload_header)];
     CFlowStatParser parser(CFlowStatParser::FLOW_STAT_PARSER_MODE_SW);
     int ret = parser.parse(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
+    if ( CGlobalInfo::m_options.m_ip_cfg[0].get_vxlan_fs() ) {
+        uint16_t vxlan_skip = parser.get_vxlan_payload_offset(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
+        ret = parser.parse(rte_pktmbuf_mtod_offset(m, uint8_t *, vxlan_skip), m->pkt_len - vxlan_skip);
+    }
 
     if (m_rcv_all ||  (ret == 0)) {
         uint32_t ip_id = 0;

--- a/src/stx/common/trex_latency_counters.cpp
+++ b/src/stx/common/trex_latency_counters.cpp
@@ -142,8 +142,10 @@ RXLatency::handle_pkt(const rte_mbuf_t *m) {
     CFlowStatParser parser(CFlowStatParser::FLOW_STAT_PARSER_MODE_SW);
     int ret = parser.parse(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
     if ( CGlobalInfo::m_options.m_ip_cfg[0].get_vxlan_fs() ) {
-        uint16_t vxlan_skip = parser.get_vxlan_payload_offset(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
-        ret = parser.parse(rte_pktmbuf_mtod_offset(m, uint8_t *, vxlan_skip), m->pkt_len - vxlan_skip);
+        uint16_t vxlan_skip = parser.get_vxlan_rx_payload_offset(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
+        if (vxlan_skip > 0) {
+            ret = parser.parse(rte_pktmbuf_mtod(m, uint8_t *) + vxlan_skip, m->pkt_len - vxlan_skip);
+        }
     }
 
     if (m_rcv_all ||  (ret == 0)) {

--- a/src/stx/stl/trex_stl_fs.cpp
+++ b/src/stx/stl/trex_stl_fs.cpp
@@ -639,9 +639,6 @@ int CFlowStatRuleMgr::add_stream_internal(TrexStream * stream, bool do_action) {
         }
         break;
     case TrexPlatformApi::IF_STAT_PAYLOAD:
-        if ( stream->m_rx_check.m_vxlan_skip ) {
-            throw TrexFStatEx("VXLAN skip is not supported for latency stream", TrexException::T_FLOW_STAT_BAD_RULE_TYPE_FOR_MODE);
-        }
         uint16_t payload_len;
         // compile_stream throws exception if something goes wrong
         compile_stream(stream, m_parser_pl);

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -461,16 +461,19 @@ class CPerPortIPCfg {
     uint32_t get_mask() {return m_mask;}
     uint32_t get_def_gw() {return m_def_gw;}
     uint32_t get_vlan() {return m_vlan;}
+    bool get_vxlan_fs() {return m_vxlan_fs;}
     void set_ip(uint32_t val) {m_ip = val;}
     void set_mask(uint32_t val) {m_mask = val;}
     void set_def_gw(uint32_t val) {m_def_gw = val;}
     void set_vlan(uint16_t val) {m_vlan = val;}
+    void set_vxlan_fs(bool val) {m_vxlan_fs = val;}
 
  private:
     uint32_t m_def_gw;
     uint32_t m_ip;
     uint32_t m_mask;
     uint16_t m_vlan;
+    bool m_vxlan_fs = false;
 };
 
 


### PR DESCRIPTION
* Adds support for skipping the VXLAN header for latency streams.
  * Sets a flag, `m_vxlan_fs` when a port is configured for VXLAN
  * When received packets are handled, the flag is used to determine if the outer header should be skipped
* If the port is configured for VXLAN, but the received packets don't have the header, the parser will end up returning `FSTAT_PARSER_E_UNKNOWN_HDR` (6) and packets will not be processed