### PR TITLE
fix DP to CP burst msg lost issue

### DIFF
--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -4157,6 +4157,8 @@ void   CFlowGenListPerThread::no_memory_error(){
 
 
 bool CFlowGenListPerThread::check_msgs_from_rx() {
+    m_ring_to_rx->Reschedule();
+
     if ( likely ( m_ring_from_rx->isEmpty() ) ) {
         return false;
     }

--- a/src/pal/linux/CRing.h
+++ b/src/pal/linux/CRing.h
@@ -89,6 +89,14 @@ public:
     int Dequeue(T * & obj){
         return (CRingSp::Dequeue(*((void **)&obj)));
     }
+
+    bool Reschedule() {
+        return true;
+    }
+
+    void SecureEnqueue(T *obj, bool use_resched=false) {
+        CRingSp::Enqueue((void*)obj);
+    }
 };
 
 

--- a/src/pal/linux_dpdk/CRing.h
+++ b/src/pal/linux_dpdk/CRing.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <string>
 #include <rte_config.h>
 #include <rte_ring.h>
+#include <queue>
 
 class CRingSp {
 public:
@@ -75,12 +76,47 @@ class CTRingSp : public CRingSp {
 public:
     int Enqueue(T *obj){
         assert(obj);
+        if (!Reschedule()) {
+            return -1;
+        }
         return ( CRingSp::Enqueue((void*)obj) );
     }
 
     int Dequeue(T * & obj){
         return (CRingSp::Dequeue(*((void **)&obj)));
     }
+
+    void Delete(void){
+        while (!m_resched_q.empty()) {
+            T* obj = m_resched_q.front();
+            delete obj;
+            m_resched_q.pop();
+        }
+        CRingSp::Delete();
+    }
+
+    bool Reschedule() {
+        while(!m_resched_q.empty() && !isFull()) {
+            T* obj = m_resched_q.front();
+            CRingSp::Enqueue((void*)obj);
+            m_resched_q.pop();
+        }
+        return m_resched_q.empty();
+    }
+
+    void SecureEnqueue(T *obj, bool use_resched=false) {
+        while (!Reschedule() || isFull()) {
+            if (use_resched) {
+                m_resched_q.push(obj);
+                return;
+            }
+        }
+        CRingSp::Enqueue((void*)obj);
+    }
+
+private:
+    // message rescheduling when rte_ring is full
+    std::queue<T *> m_resched_q;
 };
 
 

--- a/src/stateful_rx_core.cpp
+++ b/src/stateful_rx_core.cpp
@@ -887,6 +887,8 @@ void CLatencyManager::handle_rx_msgs(){
     uint8_t threads=CMsgIns::Ins()->get_num_threads();
     int ti;
     for (ti=0; ti<(int)threads; ti++) {
+        rx_dp->getRingCpToDp(ti)->Reschedule();
+
         CNodeRing * r = rx_dp->getRingDpToCp(ti);
         if ( !r->isEmpty() ){
             handle_rx_one_queue((uint8_t)ti,r);

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -459,9 +459,9 @@ void TrexAstf::handle_stop_latency() {
 void TrexAstf::send_message_to_dp(uint8_t core_id, TrexCpToDpMsgBase *msg, bool clone) {
     CNodeRing *ring = CMsgIns::Ins()->getCpDp()->getRingCpToDp(core_id);
     if ( clone ) {
-        ring->Enqueue((CGenNode *)msg->clone());
+        ring->SecureEnqueue((CGenNode *)msg->clone(), true);
     } else {
-        ring->Enqueue((CGenNode *)msg);
+        ring->SecureEnqueue((CGenNode *)msg, true);
     }
 }
 

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -473,12 +473,12 @@ bool TrexAstfDpCore::sync_barrier() {
 
 void TrexAstfDpCore::report_finished(profile_id_t profile_id) {
     TrexDpToCpMsgBase *msg = new TrexDpCoreStopped(m_flow_gen->m_thread_id, profile_id);
-    m_ring_to_cp->Enqueue((CGenNode *)msg);
+    m_ring_to_cp->SecureEnqueue((CGenNode *)msg, true);
 }
 
 void TrexAstfDpCore::report_error(profile_id_t profile_id, const string &error) {
     TrexDpToCpMsgBase *msg = new TrexDpCoreError(m_flow_gen->m_thread_id, profile_id, error);
-    m_ring_to_cp->Enqueue((CGenNode *)msg);
+    m_ring_to_cp->SecureEnqueue((CGenNode *)msg, true);
 }
 
 bool TrexAstfDpCore::rx_for_idle() {

--- a/src/stx/astf/trex_astf_rx_core.cpp
+++ b/src/stx/astf/trex_astf_rx_core.cpp
@@ -203,6 +203,8 @@ bool CRxAstfCore::work_tick(void) {
 uint32_t CRxAstfCore::handle_msg_packets(void) {
     uint32_t pkts = 0;
     for (uint8_t thread_id=0; thread_id<m_tx_cores; thread_id++) {
+        m_rx_dp->getRingCpToDp(thread_id)->Reschedule();
+
         CNodeRing *r = m_rx_dp->getRingDpToCp(thread_id);
         pkts += handle_rx_one_queue(thread_id, r);
     }

--- a/src/stx/common/trex_dp_core.cpp
+++ b/src/stx/common/trex_dp_core.cpp
@@ -46,7 +46,7 @@ TrexDpCore::barrier(uint8_t port_id, uint32_t profile_id, int event_id) {
                                                           port_id,
                                                           profile_id,
                                                           event_id);
-    ring->Enqueue((CGenNode *)event_msg);
+    ring->SecureEnqueue((CGenNode *)event_msg, true);
 }
 
 

--- a/src/stx/common/trex_dp_core.h
+++ b/src/stx/common/trex_dp_core.h
@@ -105,6 +105,8 @@ public:
         // doing this inline for performance reasons
 
         /* fast path */
+        m_ring_to_cp->Reschedule();
+
         if ( likely ( m_ring_from_cp->isEmpty() ) ) {
             return false;
         }

--- a/src/stx/common/trex_port.cpp
+++ b/src/stx/common/trex_port.cpp
@@ -305,7 +305,7 @@ TrexPort::send_message_to_dp(uint8_t core_id, TrexCpToDpMsgBase *msg) {
 
     /* send the message to the core */
     CNodeRing *ring = CMsgIns::Ins()->getCpDp()->getRingCpToDp(core_id);
-    ring->Enqueue((CGenNode *)msg);
+    ring->SecureEnqueue((CGenNode *)msg, true);
 }
 
 
@@ -314,7 +314,7 @@ TrexPort::send_message_to_rx(TrexCpToRxMsgBase *msg) {
 
     /* send the message to the core */
     CNodeRing *ring = CMsgIns::Ins()->getCpRx()->getRingCpToDp(0);
-    ring->Enqueue((CGenNode *)msg);
+    ring->SecureEnqueue((CGenNode *)msg);
 }
 
 

--- a/src/stx/common/trex_rx_core.cpp
+++ b/src/stx/common/trex_rx_core.cpp
@@ -43,6 +43,8 @@ CRxCore::~CRxCore(void) {
 uint32_t CRxCore::handle_msg_packets(void) {
     uint32_t pkts = 0;
     for (uint8_t thread_id=0; thread_id<m_tx_cores; thread_id++) {
+        m_rx_dp->getRingCpToDp(thread_id)->Reschedule();
+
         CNodeRing *r = m_rx_dp->getRingDpToCp(thread_id);
         pkts += handle_rx_one_queue(thread_id, r);
     }

--- a/src/stx/common/trex_stx.cpp
+++ b/src/stx/common/trex_stx.cpp
@@ -105,7 +105,7 @@ TrexSTX::send_msg_to_all_dp(TrexCpToDpMsgBase *msg) {
     
     for (int i = 0; i < max_threads; i++) {
         CNodeRing *ring = CMsgIns::Ins()->getCpDp()->getRingCpToDp((uint8_t)i);
-        ring->Enqueue((CGenNode*)msg->clone());
+        ring->SecureEnqueue((CGenNode*)msg->clone());
     }
     
     delete msg;
@@ -117,7 +117,7 @@ TrexSTX::send_msg_to_all_dp(TrexCpToDpMsgBase *msg) {
 void
 TrexSTX::send_msg_to_dp(uint8_t core_id, TrexCpToDpMsgBase *msg) {
     CNodeRing *ring = CMsgIns::Ins()->getCpDp()->getRingCpToDp(core_id);
-    ring->Enqueue((CGenNode*)msg->clone());
+    ring->SecureEnqueue((CGenNode*)msg->clone());
     delete msg;
 }
 
@@ -128,7 +128,7 @@ void
 TrexSTX::send_msg_to_rx(TrexCpToRxMsgBase *msg) const {
 
     CNodeRing *ring = CMsgIns::Ins()->getCpRx()->getRingCpToDp(0);
-    ring->Enqueue((CGenNode *)msg);
+    ring->SecureEnqueue((CGenNode *)msg);
 }
 
 
@@ -180,6 +180,9 @@ TrexSTX::check_for_dp_messages() {
 
     /* for all the cores - check for a new message */
     for (int i = 0; i < m_dp_core_count; i++) {
+        CNodeRing *ring_to_dp = CMsgIns::Ins()->getCpDp()->getRingCpToDp(i);
+        ring_to_dp->Reschedule();
+
         check_for_dp_message_from_core(i);
     }
 }

--- a/src/stx/stl/trex_stl_dp_core.cpp
+++ b/src/stx/stl/trex_stl_dp_core.cpp
@@ -1542,7 +1542,7 @@ TrexStatelessDpCore::push_pcap(uint8_t port_id,
                                                               0,
                                                               event_id,
                                                               false);
-        ring->Enqueue((CGenNode *)event_msg);
+        ring->SecureEnqueue((CGenNode *)event_msg, true);
         return;
     }
 
@@ -1592,7 +1592,7 @@ TrexStatelessDpCore::stop_traffic(uint8_t  port_id,
                                                           port_id,
                                                           profile_id,
                                                           event_id);
-    ring->Enqueue((CGenNode *)event_msg);
+    ring->SecureEnqueue((CGenNode *)event_msg, true);
 }
 
 

--- a/src/stx/stl/trex_stl_fs.cpp
+++ b/src/stx/stl/trex_stl_fs.cpp
@@ -1150,7 +1150,7 @@ void CFlowStatRuleMgr::send_start_stop_msg_to_rx(bool is_start) {
         reply.reset();
 
         msg = new TrexStatelessRxEnableLatency(reply);
-        m_ring_to_rx->Enqueue((CGenNode *)msg);
+        m_ring_to_rx->SecureEnqueue((CGenNode *)msg);
 
         /* hold until message was ack'ed - otherwise we might lose packets */
         reply.wait_for_reply();
@@ -1158,7 +1158,7 @@ void CFlowStatRuleMgr::send_start_stop_msg_to_rx(bool is_start) {
         
     } else {
         msg = new TrexStatelessRxDisableLatency();
-        m_ring_to_rx->Enqueue((CGenNode *)msg);
+        m_ring_to_rx->SecureEnqueue((CGenNode *)msg);
     }
 }
 


### PR DESCRIPTION
This PR is related to #338 (Some DP to CP burst messages might be lost).

I modified CNodeRing to append SecureEnqueue() and Reschedule() methods.
SecureEnqueue() will be blocked until rte_ring buffer is available by default.
It also supports rescheduling when rte_ring buffer is full. CP<->DP messages use it.
To support rescheduling, I added Reschedule() method which is called at CP and DP scheduler.

Please check my changes and give your feedback.
