### PR TITLE
fix crash in rx_handle_packet and remove default profile in DP

### DIFF
--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -717,8 +717,6 @@ bool CTcpPerThreadCtx::Create(uint32_t size,
         return(false);
     }
 
-    create_profile_ctx(0);  // create default profile
-
     return(true);
 }
 

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -1038,6 +1038,7 @@ public:
     /* profile management */
 private:
     std::unordered_map<profile_id_t, CPerProfileCtx*> m_profiles;
+    std::unordered_map<profile_id_t, CPerProfileCtx*> m_active_profiles;
 
 public:
     bool is_profile_ctx(profile_id_t profile_id) { return m_profiles.find(profile_id) != m_profiles.end(); }
@@ -1047,13 +1048,14 @@ public:
 #ifdef TREX_SIM
         if (profile_id == 0 && !is_profile_ctx(0)) {
             create_profile_ctx(0);  // default profile need to be static in simulator.
+            append_active_profile(0);
         }
 #endif
         return m_profiles.at(profile_id);
     }
     CPerProfileCtx* get_first_profile_ctx() {
-        assert(m_profiles.size() != 0);
-        return m_profiles.begin()->second;
+        assert(m_active_profiles.size() != 0);
+        return m_active_profiles.begin()->second;
     }
     void create_profile_ctx(profile_id_t profile_id) {
         CPerProfileCtx* pctx;
@@ -1074,6 +1076,18 @@ public:
         if (is_profile_ctx(profile_id)) {
             delete m_profiles[profile_id];
             m_profiles.erase(profile_id);
+        }
+    }
+
+    void append_active_profile(profile_id_t profile_id) {
+        if (is_profile_ctx(profile_id)) {
+            m_active_profiles[profile_id] = m_profiles.at(profile_id);
+        }
+    }
+
+    void remove_active_profile(profile_id_t profile_id) {
+        if (is_profile_ctx(profile_id)) {
+            m_active_profiles.erase(profile_id);
         }
     }
 

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -563,6 +563,9 @@ void CFlowGenListPerThread::load_tcp_profile(profile_id_t profile_id, bool is_fi
     m_c_tcp->set_template_rw(rw, profile_id);
     m_s_tcp->set_template_rw(rw, profile_id);
 
+    m_c_tcp->append_active_profile(profile_id);
+    m_s_tcp->append_active_profile(profile_id);
+
     if (is_first) {
         m_c_tcp->update_tuneables(rw->get_c_tuneables());
         m_s_tcp->update_tuneables(rw->get_s_tuneables());
@@ -580,6 +583,9 @@ void CFlowGenListPerThread::load_tcp_profile(profile_id_t profile_id, bool is_fi
 
 void CFlowGenListPerThread::unload_tcp_profile(profile_id_t profile_id, bool is_last) {
     m_s_tcp->remove_server_ports(profile_id);
+
+    m_c_tcp->remove_active_profile(profile_id);
+    m_s_tcp->remove_active_profile(profile_id);
 
     if ( CAstfDB::has_instance(profile_id) ) {
         CAstfDB::instance(profile_id)->clear_db_ro_rw(nullptr, m_thread_id);


### PR DESCRIPTION
Crash was observed as the following backtrace, becasue server accessed a null pointer in the idle state of default profile in DP side.
So I have added a handling routine for active profiles in DP side to prevent crash.

Major changes are below.
1. removed the default profile in DP side.
 - Now it is possible to remove the default profile in DP side because 'Secure ASTF statistics update for multiple profiles'(https://github.com/cisco-system-traffic-generator/trex-core/commit/365973b365479d9c69573518af6f946a36177ab5) commit already covers a crash issue caused by the previous racing condition.
2. Handling the list of active profiles to avoid crash.
 - append an active profile into the list when load_tcp_profile.
 - remove an active profile from the list when unload_tcp_profile.
 - FALLBACK_PROFILE_CTX(ctx) will find the first profile context in the active profile list instead of the previousu profile list.

```
#0  std::vector<CTcpDataAssocTransHelp, std::allocator<CTcpDataAssocTransHelp> >::size (this=<optimized out>) at stl_vector.h:656
#1  CTcpDataAssocTranslation::get_server_info (params=<synthetic pointer>..., this=0x78)
     at ../../../../trex-core/src/astf/astf_db.cpp:105
#2  CAstfDbRO::get_server_info_by_port (this=this@entry=0x0, port=port@entry=67, stream=stream@entry=false) at ../../../../trex-core/src/astf/astf_db.cpp:1548
#3  0x00000000004f77ba in CFlowTable::rx_handle_packet_udp_no_flow (this=this@entry=0x2eddd38, ctx=ctx@entry=0x2eddc40, mbuf=mbuf@entry=0x1b6ce2e80, lpflow=lpflow@entry=0x0, parser=..., tuple=..., ftuple=..., hash=3430765316)
     at ../../../../trex-core/src/44bsd/flow_table.cpp:512
```


