### PR TITLE
Added stack name info to get_system_info

### DIFF
--- a/doc/trex_rpc_server_spec.asciidoc
+++ b/doc/trex_rpc_server_spec.asciidoc
@@ -46,7 +46,10 @@ include::trex_ga.asciidoc[]
 - add capture port support
 | 1.8    | Hanoch Haim (hhaim)
 |
-- add astf commands 
+- add astf commands
+| 1.9    | Egor Blagov (eblagov)
+|
+- add stack name in `get_system_info`
 
 |=================
 
@@ -410,6 +413,7 @@ Example:
 | description         | string   | description of port
 | driver              | string   | driver type
 | numa                | int      | NUMA of port
+| stack               | string   | stack name
 | pci_addr            | string   | PCI address of port
 | hw_macaddr          | string   | HW MAC of port (masked by src_macaddr)
 | src_macaddr         | string   | src MAC of port

--- a/src/gtest/rpc_test.cpp
+++ b/src/gtest/rpc_test.cpp
@@ -377,6 +377,7 @@ TEST_F(RpcTest, get_system_info) {
 
     for (int i = 0; i < ports.size(); i++) {
         EXPECT_TRUE(ports[i]["index"] == i);
+        EXPECT_TRUE(ports[i]["stack"].isString());
         EXPECT_TRUE(ports[i]["driver"].isString());
         EXPECT_TRUE(ports[i]["speed"].isString());
     }

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -435,6 +435,7 @@ TrexRpcCmdGetSysInfo::_run(const Json::Value &params, Json::Value &result) {
         port_json["pci_addr"]     = port_info.pci_addr;
         port_json["numa"]         = port_info.numa_node;
         port_json["hw_mac"]       = utl_macaddr_to_str(port_info.hw_macaddr);
+        port_json["stack"]        = port.second->get_stack_name();
 
         port_json["description"]  = api.getPortAttrObj(i)->get_description();
         


### PR DESCRIPTION
Signed-off-by: Egor Blagov <e.m.blagov@gmail.com>

- Added capability to get info about current stack from API

NOTE: Though stack is a global option for now, as I saw each port has it's own method to get stack name, hence I've added it under system info's port object
NOTE2: I didn't find a way how to start rpc_test.cpp tests (gtests), but edited it.
