### PR TITLE
Fixing #340 - set_keepalive_msg() failing

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -451,7 +451,7 @@ class ASTFProgram(object):
                     }
         ArgVerify.verify(self.__class__.__name__ + "." + sys._getframe().f_code.co_name, ver_args)
 
-        self.fields['commands'].append(ASTFCmdRecvMsg(self.total_rcv_bytes))
+        self.fields['commands'].append(ASTFCmdKeepaliveMsg(msec))
 
 
     def recv_msg(self, pkts,clear=False):

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -439,7 +439,7 @@ class ASTFProgram(object):
 
     def set_keepalive_msg (self,msec):
         """
-        set_keepalive_msg (sec), set the keepalive timer for UDP flows 
+        set_keepalive_msg (msec), set the keepalive timer for UDP flows 
 
         :parameters:
                   msec  : uint32_t


### PR DESCRIPTION
Fixing #340 - set_keepalive_msg() failing - see https://github.com/cisco-system-traffic-generator/trex-core/issues/340 

Thanks,
Darren