### PR TITLE
fix astf start --pid failed

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -238,7 +238,10 @@ class ASTFClient(TRexClient):
         # Check if profile_id is a valid profile name
         for profile_id in profile_list:
             if profile_id not in list(self.astf_profile_state.keys()):
-                raise TRexError("ASTF profile_id %s does not exist." % profile_id)
+                if start == True:
+                    self.astf_profile_state[profile_id] = self.STATE_IDLE
+                else:
+                    raise TRexError("ASTF profile_id %s does not exist." % profile_id)
 
             if start == True:
                 if self.is_dynamic and self.astf_profile_state.get(profile_id) not in ok_states:


### PR DESCRIPTION
Hi,
Just before, I've found my last commit(b75c39c) causes a new issue.
In the **trex-console**, ```start``` command with ```--pid``` option will be failed.
```
trex>start -f astf/http_simple.py --pid http

start - ASTF profile_id http does not exist.
```
This PR will fix this issue.
I'm sorry for my carelessness in my previous commit.