### PR TITLE
fix server down issue when dynamic profile add/remove randomly

### DIFF
--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -899,7 +899,6 @@ public:
         if (m_flow_cnt == 0 && !is_active()) {
             if (m_on_stopped_cb) {
                 m_on_stopped_cb(m_cb_data, m_profile_id);
-                m_on_stopped_cb = nullptr;
             }
         }
     }

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -347,7 +347,6 @@ void TrexAstf::start_transmit(cp_profile_id_t profile_id, const start_params_t &
     pid->set_nc_flow_close(args.nc);
 
     m_opts->m_astf_client_mask = args.client_mask;
-    m_opts->preview.setNoCleanFlowClose(args.nc);
     m_opts->preview.set_ipv6_mode_enable(args.ipv6);
 
     if ( pid->profile_needs_parsing() || topo_needs_parsing() ) {
@@ -366,8 +365,6 @@ void TrexAstf::stop_transmit(cp_profile_id_t profile_id) {
     }
 
     pid->set_profile_stopping(true);
-    // TODO: apply nc_flow_close per each profile after changing DP code
-    m_opts->preview.setNoCleanFlowClose(true);
 
     TrexCpToDpMsgBase *msg = new TrexAstfDpStop(pid->get_dp_profile_id());
     send_message_to_all_dp(msg, true);

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -734,6 +734,7 @@ void TrexAstfPerProfile::profile_change_state(state_e new_state) {
             m_active_cores = get_platform_api().get_dp_core_count();
             break;
         case STATE_CLEANUP:
+            m_stt_cp->Update();
             m_stt_cp->m_update = false;
             m_active_cores = get_platform_api().get_dp_core_count();
             break;

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -852,7 +852,7 @@ void TrexAstfPerProfile::transmit() {
 
     profile_change_state(STATE_TX);
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpStart(m_dp_profile_id, m_duration);
+    TrexCpToDpMsgBase *msg = new TrexAstfDpStart(m_dp_profile_id, m_duration, m_nc_flow_close);
 
     m_astf_obj->send_message_to_all_dp(msg, true);
 }

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -374,6 +374,7 @@ public:
     std::string* get_topo_buffer() { return &m_topo_buffer; }
     void         set_topo_parsed(bool topo) { m_topo_parsed = topo; }
 
+    void stop_dp_scheduler();
     bool is_dp_core_state(int state, bool any = false);
 
 protected:
@@ -399,6 +400,7 @@ protected:
     uint64_t        m_epoch;
 
 public:
+    bool                m_stopping_dp;
     std::vector<int>    m_dp_states;
     std::vector<TrexCpToDpMsgBase*> m_suspended_msgs;
 };

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -33,6 +33,7 @@ class TrexAstfPort;
 class CSyncBarrier;
 class CRxAstfCore;
 class TrexAstf;
+class TrexCpToDpMsgBase;
 
 typedef std::unordered_map<uint8_t, TrexAstfPort*> astf_port_map_t;
 typedef std::string cp_profile_id_t;
@@ -223,6 +224,8 @@ public:
 
     void dp_core_finished(int thread_id, uint32_t dp_profile_id);
 
+    void dp_core_state(int thread_id, int state);
+
     /**
      * async data sent for ASTF
      * 
@@ -365,11 +368,13 @@ public:
 
     void set_barrier(double timeout_sec);
     void send_message_to_dp(uint8_t core_id, TrexCpToDpMsgBase *msg, bool clone = false);
-    void send_message_to_all_dp(TrexCpToDpMsgBase *msg);
+    void send_message_to_all_dp(TrexCpToDpMsgBase *msg, bool suspend = false);
     bool is_trans_state();
 
     std::string* get_topo_buffer() { return &m_topo_buffer; }
     void         set_topo_parsed(bool topo) { m_topo_parsed = topo; }
+
+    bool is_dp_core_state(int state, bool any = false);
 
 protected:
     void change_state(state_e new_state);
@@ -392,6 +397,10 @@ protected:
     std::string     m_topo_hash;
     bool            m_topo_parsed;
     uint64_t        m_epoch;
+
+public:
+    std::vector<int>    m_dp_states;
+    std::vector<TrexCpToDpMsgBase*> m_suspended_msgs;
 };
 
 static inline TrexAstf * get_astf_object() {

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -83,6 +83,9 @@ void TrexAstfDpCore::on_profile_stop_event(profile_id_t profile_id) {
             (m_flow_gen->m_s_tcp->profile_flow_cnt(profile_id) == 0)) {
             set_profile_state(profile_id, pSTATE_LOADED);
             report_finished(profile_id);
+
+            m_flow_gen->m_c_tcp->set_profile_cb(profile_id, this, nullptr);
+            m_flow_gen->m_s_tcp->set_profile_cb(profile_id, this, nullptr);
         }
     }
 }

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -61,6 +61,7 @@ protected:
     void report_finished(profile_id_t profile_id = 0);
     void report_error(profile_id_t profile_id, const std::string &error);
     bool sync_barrier();
+    void report_dp_state();
     CFlowGenListPerThread *m_flow_gen;
 
     virtual void start_scheduler() override;

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -29,6 +29,7 @@ limitations under the License.
 struct profile_param {
     profile_id_t    m_profile_id;
     double          m_duration;
+    bool            m_nc_flow_close;
 };
 
 class TrexAstfDpCore : public TrexDpCore {
@@ -48,7 +49,7 @@ public:
      */
     virtual bool is_port_active(uint8_t port_id);
 
-    void start_transmit(profile_id_t profile_id, double duration);
+    void start_transmit(profile_id_t profile_id, double duration, bool nc);
     void stop_transmit(profile_id_t profile_id, uint32_t stop_id);
     void update_rate(profile_id_t profile_id, double ratio);
     void create_tcp_batch(profile_id_t profile_id, double factor);
@@ -71,7 +72,7 @@ protected:
     void set_profile_stop_id(profile_id_t profile_id, uint32_t stop_id);
 
     void get_scheduler_options(profile_id_t profile_id, bool& disable_client, double& d_time_flow, double& d_phase);
-    void start_profile_ctx(profile_id_t profile_id, double duration);
+    void start_profile_ctx(profile_id_t profile_id, double duration, bool nc);
     void stop_profile_ctx(profile_id_t profile_id, uint32_t stop_id);
 
     std::vector<struct profile_param> m_sched_param;
@@ -120,6 +121,9 @@ protected:
     void set_profile_stopping(profile_id_t profile_id);
     int active_profile_cnt() { return m_active_profile_cnt; }
     int profile_cnt() { return m_profile_states.size(); }
+
+    void set_profile_nc(profile_id_t profile_id, bool nc);
+    bool get_profile_nc(profile_id_t profile_id);
 
     uint32_t profile_stop_id() {
         if (++m_profile_stop_id == 0) {

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -57,6 +57,8 @@ public:
     void parse_astf_json(profile_id_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
     void remove_astf_json(profile_id_t profile_id);
 
+    void scheduler(bool activate);
+
 protected:
     virtual bool rx_for_idle();
     void report_finished(profile_id_t profile_id = 0);

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -76,6 +76,22 @@ TrexCpToDpMsgBase* TrexAstfDpStop::clone() {
 }
 
 /*************************
+  control DP scheduler
+ ************************/
+TrexAstfDpScheduler::TrexAstfDpScheduler(bool activate) {
+    m_activate = activate;
+}
+
+bool TrexAstfDpScheduler::handle(TrexDpCore *dp_core) {
+    astf_core(dp_core)->scheduler(m_activate);
+    return true;
+}
+
+TrexCpToDpMsgBase* TrexAstfDpScheduler::clone() {
+    return new TrexAstfDpScheduler(m_activate);
+}
+
+/*************************
   update traffic message
  ************************/
 TrexAstfDpUpdate::TrexAstfDpUpdate(profile_id_t profile_id, double old_new_ratio) {

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -34,19 +34,20 @@ TrexAstfDpCore* astf_core(TrexDpCore *dp_core) {
 /*************************
   start traffic message
  ************************/
-TrexAstfDpStart::TrexAstfDpStart(profile_id_t profile_id, double duration) {
+TrexAstfDpStart::TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc) {
     m_profile_id = profile_id;
     m_duration = duration;
+    m_nc_flow_close = nc;
 }
 
 
 bool TrexAstfDpStart::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->start_transmit(m_profile_id, m_duration);
+    astf_core(dp_core)->start_transmit(m_profile_id, m_duration, m_nc_flow_close);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpStart::clone() {
-    return new TrexAstfDpStart(m_profile_id, m_duration);
+    return new TrexAstfDpStart(m_profile_id, m_duration, m_nc_flow_close);
 }
 
 /*************************

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -86,6 +86,19 @@ private:
 };
 
 /**
+ * a message to stop DP scheduler
+ *
+ */
+class TrexAstfDpScheduler : public TrexCpToDpMsgBase {
+public:
+    TrexAstfDpScheduler(bool activate);
+    virtual TrexCpToDpMsgBase* clone();
+    virtual bool handle(TrexDpCore *dp_core);
+private:
+    bool m_activate;    // DP scheduler activate(true) or deactivate(false)
+};
+
+/**
  * a message to update traffic rate
  *
  */

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -56,13 +56,14 @@ private:
  */
 class TrexAstfDpStart : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpStart(profile_id_t profile_id, double duration);
-    TrexAstfDpStart() : TrexAstfDpStart(0, -1) {}
+    TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc);
+    TrexAstfDpStart() : TrexAstfDpStart(0, -1, false) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
     profile_id_t m_profile_id;
     double m_duration;
+    bool m_nc_flow_close;
 };
 
 /**

--- a/src/stx/common/trex_messaging.cpp
+++ b/src/stx/common/trex_messaging.cpp
@@ -119,6 +119,12 @@ TrexDpCoreError::handle(void) {
     return true;
 }
 
+bool
+TrexDpCoreState::handle(void) {
+    get_stx()->dp_core_state(m_thread_id, m_state);
+    return true;
+}
+
 /************************* messages from CP to RX **********************/
 
 #if 0

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -315,6 +315,25 @@ private:
 
 };
 
+/**
+ * a message indicating that DP core state changed
+ */
+class TrexDpCoreState : public TrexDpToCpMsgBase {
+public:
+
+    TrexDpCoreState(int thread_id, int state) {
+        m_thread_id = thread_id;
+        m_state = state;
+    }
+
+    virtual bool handle(void);
+
+private:
+    int          m_thread_id;
+    int          m_state;
+
+};
+
 /************************* messages from CP to RX **********************/
 
 /**

--- a/src/stx/common/trex_stx.cpp
+++ b/src/stx/common/trex_stx.cpp
@@ -171,6 +171,10 @@ void
 TrexSTX::dp_core_error(int thread_id, uint32_t profile_id, const std::string &err) {
 }
 
+void
+TrexSTX::dp_core_state(int thread_id, int state) {
+}
+
 /**
  * check for messages that arrived from DP to CP
  *

--- a/src/stx/common/trex_stx.h
+++ b/src/stx/common/trex_stx.h
@@ -152,6 +152,11 @@ public:
      */
     virtual void dp_core_error(int thread_id, uint32_t profile_id, const std::string &err);
 
+    /**
+     * DP core state changed
+     */
+    virtual void dp_core_state(int thread_id, int state);
+
     virtual void set_capture_feature(const std::set<uint8_t>& rx_cores) {};
 
     virtual void unset_capture_feature() {};


### PR DESCRIPTION
This PR is related to #324.

Followings are implemented as discussed at #324:
- DP core now exits from its scheduler by TrexAstfDpScheduler CP to DP message explicitly.
CP now sends TrexAstfDpScheduler message to DP when it decided to make DP scheduler exited.
DP core reports its scheduler state by TrexDpCoreState DP to CP message when the state is changed.
CP will hold the following CP to DP messages until DP reports its state is IDLE.
- Per profile --nc option now works.
CP start_transmit() delivers the --nc option which is requested by the user to DP and it triggers the active flows to be closed.

Please check my code and give your feedback.
