### PR TITLE
Crash issues from wrong API usage in ASTF mode #305 - Issue1

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -14,7 +14,6 @@ from ..common.trex_types import listify
 import imp
 import collections
 
-
 class _ASTFCapPath(object):
     @classmethod
     def get_pcap_file_path(cls, pcap_file_name):
@@ -838,7 +837,7 @@ class ASTFIPGenDist(object):
 
         @property
         def direction(self):
-            return self.fields['dir']
+            return self.fields.get('dir')
 
         @direction.setter
         def direction(self, direction):
@@ -855,7 +854,7 @@ class ASTFIPGenDist(object):
         def to_json(self):
             return dict(self.fields)
 
-    def __init__(self, ip_range, distribution="seq",per_core_distribution=None):
+    def __init__(self, ip_range, distribution="seq", per_core_distribution=None):
 
         """
         Define a ASTFIPGenDist
@@ -885,12 +884,13 @@ class ASTFIPGenDist(object):
             if per_core_distribution not in per_core_distribution_vals:
                 raise ASTFError("per_core_distribution must be one of {0}".format(per_core_distribution_vals))
 
-
         new_inner = self.Inner(ip_range=ip_range, distribution=distribution,per_core_distribution=per_core_distribution)
+
         for i in range(0, len(self.in_list)):
             if new_inner == self.in_list[i]:
                 self.index = i
                 return
+
         self.in_list.append(new_inner)
         self.index = len(self.in_list) - 1
 
@@ -992,13 +992,18 @@ class ASTFIPGen(object):
                      {"name": "dist_client", 'arg': dist_client, "t": ASTFIPGenDist, "must": True},
                      {"name": "dist_server", 'arg': dist_server, "t": ASTFIPGenDist, "must": True},
                      ]}
+
         ArgVerify.verify(self.__class__.__name__, ver_args)
 
         self.fields = {}
         self.fields['dist_client'] = dist_client
+        if dist_client.direction and dist_client.direction is not "c":
+            raise ASTFError("dist_client.direction is already dir:{0}".format(dist_client.direction))
         dist_client.direction = "c"
         dist_client.ip_offset = glob.ip_offset
         self.fields['dist_server'] = dist_server
+        if dist_server.direction and dist_server.direction is not "s":
+            raise ASTFError("dist_server.direction is already dir:{0}".format(dist_server.direction))
         dist_server.direction = "s"
         dist_server.ip_offset = glob.ip_offset
 

--- a/src/astf/astf_json_validator.cpp
+++ b/src/astf/astf_json_validator.cpp
@@ -105,6 +105,14 @@ bool CAstfJsonValidator::validate_program(Json::Value  profile,
         int ip_gen_s=temp["client_template"]["ip_gen"]["dist_server"]["index"].asInt();
         max_temp  = std::max(max_temp,std::max(pinx_c,pinx_s));
         ip_gen_max = std::max(ip_gen_max,std::max(ip_gen_c,ip_gen_s));
+        /* check dist_client and dist_server direction in ip_gen_dist_list */
+        if (ip_gen_c == ip_gen_s) {
+            Json::Value dist_list = profile["ip_gen_dist_list"];
+            std::stringstream ss;
+            ss << "Validation failed : client direction is " << dist_list[ip_gen_c]["dir"] << ", server direction is " << dist_list[ip_gen_s]["dir"] <<std::endl;
+            err = ss.str();
+            return(false);
+        }
     }
 
     /* check #templates */


### PR DESCRIPTION
TRex server crash when user used same client/server IP in ASTF mode
Added defensive code to report error messages instead of crashing TRex server.