### PR TITLE
Cant not clear ASTF Traffic Statistics sometimes

### DIFF
--- a/src/stt_cp.cpp
+++ b/src/stt_cp.cpp
@@ -484,11 +484,11 @@ void CSTTCp::Delete(bool last_time){
     
 }
 
-void CSTTCp::clear_counters(void) {
+void CSTTCp::clear_counters(bool epoch_increment) {
     for (auto &sts : m_sts) {
         sts.clear_counters();
     }
-    m_epoch++;
+    if (epoch_increment) m_epoch++;
 }
 
 void CSTTCp::Resize(uint16_t new_num_of_tg_ids) {

--- a/src/stt_cp.h
+++ b/src/stt_cp.h
@@ -99,7 +99,7 @@ public:
     void Update();
     void DumpTable();
     bool dump_json(std::string &json);
-    void clear_counters();
+    void clear_counters(bool epoch_increment=true);
     void Resize(uint16_t new_num_of_tg_ids);
     void DumpTGNames(Json::Value &result);
     void UpdateTGNames(const std::vector<std::string>& tg_names);

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -353,12 +353,6 @@ void TrexAstf::stop_transmit(cp_profile_id_t profile_id) {
 void TrexAstf::profile_clear(cp_profile_id_t profile_id){
     TrexAstfPerProfile* pid = get_profile(profile_id);
     pid->profile_check_whitelist_states({STATE_IDLE, STATE_LOADED});
-
-    if (profile_id == DEFAULT_ASTF_PROFILE_ID) {
-        pid->profile_init();
-        return;
-    }
-
     pid->profile_change_state(STATE_DELETE);
 
     TrexCpToDpMsgBase *msg = new TrexAstfDeleteDB(pid->get_dp_profile_id());
@@ -560,8 +554,16 @@ void TrexAstfProfile::add_profile(cp_profile_id_t profile_id) {
 }
 
 bool TrexAstfProfile::delete_profile(cp_profile_id_t profile_id) {
-    if (is_valid_profile(profile_id)) {
-        auto profile = m_profile_list[profile_id];
+    if (!is_valid_profile(profile_id)) {
+        return false;
+    }
+
+    auto profile = m_profile_list[profile_id];
+    profile->clear_counters(false);
+    if (profile_id == DEFAULT_ASTF_PROFILE_ID) {
+        profile->profile_change_state(STATE_IDLE);
+        profile->profile_init();
+    } else {
         m_profile_id_map.erase(profile->get_dp_profile_id());
 
         auto state = profile->get_profile_state();
@@ -570,10 +572,10 @@ bool TrexAstfProfile::delete_profile(cp_profile_id_t profile_id) {
 
         delete m_profile_list.find(profile_id)->second;
         m_profile_list.erase(profile_id);
-        return true;
+
     }
 
-    return false;
+    return true;
 }
 
 bool TrexAstfProfile::is_valid_profile(cp_profile_id_t profile_id) {

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -128,6 +128,11 @@ public:
     void    set_duration(double duration) { m_duration = duration; }
     void    set_factor(double mult) { m_factor = mult; }
 
+    /*
+     * clear statistics counter
+     */
+    void    clear_counters(bool epoch_increment=true) { m_stt_cp->clear_counters(epoch_increment); }
+
 private:
     state_e         m_profile_state;
     std::string     m_profile_buffer;


### PR DESCRIPTION
I fixed for not cleared statistics of deleted profiles in ASTF mode
You can see TRex console log which statistics are not cleared although no profile in ASTF mode.

`
Profile States

         ID          |        State         
---------------------+---------------------
         _           |      STATE_IDLE      


trex>stats -a
Traffic stats summary.

                        |      client       |      server       |                         
------------------------+-------------------+-------------------+------------------------
         m_active_flows |                 0 |                 0 | active open flows       
            m_est_flows |                 0 |                 0 | active established flows 
           m_tx_bw_l7_r |             0 bps |             0 bps | tx L7 bw acked          
     m_tx_bw_l7_total_r |             0 bps |             0 bps | tx L7 bw total          
           m_rx_bw_l7_r |             0 bps |             0 bps | rx L7 bw acked          
             m_tx_pps_r |             0 pps |             0 pps | tx pps                  
             m_rx_pps_r |             0 pps |             0 pps | rx pps                  
             m_avg_size |               0 B |               0 B | average pkt size        
             m_tx_ratio |             100 % |          109.29 % | Tx acked/sent ratio     
                      - |                   |                   |                         
                    TCP |                   |                   |                         
                      - |                   |                   |                         
       tcps_connattempt |               225 |                 0 | connections initiated   
           tcps_accepts |                 0 |               493 | connections accepted    
          tcps_connects |               128 |               128 | connections established 
            tcps_closed |               225 |               493 | conn. closed (includes drops) 
         tcps_segstimed |               481 |               877 | segs where we tried to get rtt 
        tcps_rttupdated |               384 |               512 | times we succeeded      
            tcps_delack |               128 |                 0 | delayed acks sent       
          tcps_sndtotal |              1005 |              3565 | total packets sent      
           tcps_sndpack |               128 |              2944 | data packets sent       
           tcps_sndbyte |             56025 |           4108032 | data bytes sent by application 
        tcps_sndbyte_ok |             31872 |           4108032 | data bytes sent by tcp  
           tcps_sndctrl |               493 |                 0 | control (SYN|FIN|RST) packets sent 
           tcps_sndacks |               384 |               621 | ack-only packets sent   
           tcps_rcvpack |              3072 |               256 | packets received in sequence 
           tcps_rcvbyte |           4108032 |             31872 | bytes received in sequence 
        tcps_rcvackpack |               256 |               512 | rcvd ack packets        
        tcps_rcvackbyte |             31872 |           4108032 | tx bytes acked by rcvd acks  
     tcps_rcvackbyte_of |               128 |               256 | tx bytes acked by rcvd acks - overflow acked 
           tcps_preddat |              2816 |                 0 | times hdr predict ok for data pkts  
             tcps_drops |                 0 |               365 | connections dropped     
         tcps_conndrops |                83 |                 0 | embryonic connections dropped 
    tcps_rexmttimeo_syn |               268 |                 0 | retransmit SYN timeouts 
         tcps_keeptimeo |                83 |                 0 | keepalive timeouts      
         tcps_keepdrops |                83 |                 0 | connections dropped in keepalive 
         tcps_testdrops |                17 |                 3 | connections dropped by user at timeout (no-close flag --nc) 
                      - |                   |                   |                         
                    UDP |                   |                   |                         
                      - |                   |                   |                         
                      - |                   |                   |                         
             Flow Table |                   |                   |                         
                      - |                   |                   |                         
                err_cwf |               602 |                 0 | client pkt without flow 
         redirect_rx_ok |                 8 |                 8 | redirect to rx OK       

trex>
`