### PR TITLE
Increase the number of maximum interfaces

### DIFF
--- a/scripts/dpdk_setup_ports.py
+++ b/scripts/dpdk_setup_ports.py
@@ -539,8 +539,8 @@ Other network devices
 
         if_list= if_list_remove_sub_if(self.m_cfg_dict[0]['interfaces']);
         l=len(if_list);
-        if l > 24:
-            raise DpdkSetup("Configuration file %s should include interfaces field with maximum 24 elements, got: %s." % (fcfg,l))
+        if l > 32:
+            raise DpdkSetup("Configuration file %s should include interfaces field with maximum 32 elements, got: %s." % (fcfg,l))
         if l % 2:
             raise DpdkSetup("Configuration file %s should include even number of interfaces, got: %s" % (fcfg,l))
         if 'port_limit' in cfg_dict:

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -116,7 +116,7 @@ static inline int get_is_rx_thread_enabled() {
     return ((CGlobalInfo::m_options.is_rx_enabled() || get_is_interactive()) ?1:0);
 }
 
-#define MAX_DPDK_ARGS 50
+#define MAX_DPDK_ARGS (30 + TREX_MAX_PORTS * 2)
 static CPlatformYamlInfo global_platform_cfg_info;
 static int g_dpdk_args_num ;
 static char * g_dpdk_args[MAX_DPDK_ARGS];

--- a/src/trex_defs.h
+++ b/src/trex_defs.h
@@ -25,7 +25,7 @@ limitations under the License.
 #include <functional>
 #include <json/json.h>
 
-#define TREX_MAX_PORTS 24
+#define TREX_MAX_PORTS 32
 
 #define MAX_SOCKETS_SUPPORTED   (4)
 #define MAX_THREADS_SUPPORTED   (120)


### PR DESCRIPTION
We need to run TREX on a setup with more than 24 interfaces. This change increases the maximum number of allowed interfaces to 32.