### PR TITLE
check_limit modified to cover generate_flow fail case

### DIFF
--- a/src/astf/astf_template_db.h
+++ b/src/astf/astf_template_db.h
@@ -72,15 +72,18 @@ public:
         m_limit=limit+1; /* need to add 1*/
     }
 
+    void dec_limit() {
+        if (m_limit>1) { /* stop at 1 */
+            --m_limit;
+        }
+    }
     bool check_limit(){
         if (m_limit==0){
             return(false);
         }
         if (m_limit>1) {
-            --m_limit;
             return(false);
         }else{
-            /* stop at 1 */
             return(true);
         }
     }

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -354,6 +354,8 @@ void CFlowGenListPerThread::generate_flow(bool &done, CPerProfileCtx * pctx){
         return;
     }
 
+    cur->dec_limit();
+
     CEmulApp * app_c;
 
     app_c = &c_flow->m_app;


### PR DESCRIPTION
Hi, I changed check_limit action to cover generate_flow fail case.
Currently, check_limit reduces the limit number immediately. But when generate_flow returns without a new flow, generate_flow will not retry the failed flow at next time.
So, it results less flows than the specified limit. This change make it up to the specified limit.
