### PR TITLE
ASTF multi: fix calculating client port by using profile id

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -39,7 +39,7 @@ inline std::string methodName(const std::string& prettyFunction)
 astf_db_map_t CAstfDB::m_instances;
 
 
-CAstfDB::CAstfDB(){
+CAstfDB::CAstfDB(profile_id_t profile_id){
     m_client_config_info=0;
     m_validator=0;
     m_validator = new CAstfJsonValidator();
@@ -49,6 +49,7 @@ CAstfDB::CAstfDB(){
     }
     m_topo_mngr = new TopoMngr();
     m_factor = -1.0;
+    m_profile_id = profile_id;
 }
 
 
@@ -67,7 +68,7 @@ CAstfDB::~CAstfDB(){
 
 CAstfDB* CAstfDB::instance(profile_id_t profile_id) {
     if ( m_instances.find(profile_id) == m_instances.end() ) {
-        CAstfDB *new_inst = new CAstfDB();
+        CAstfDB *new_inst = new CAstfDB(profile_id);
         new_inst->m_json_initiated = false;
         m_instances[profile_id] = new_inst;
         return new_inst;
@@ -1140,7 +1141,7 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
             gen_idx_trans.push_back(last_c_idx);
             last_c_idx++;
             ClientCfgDB  * cdb=get_client_cfg_db();
-            g_gen->add_client_pool(dist, portion.m_ip_start, portion.m_ip_end, active_flows_per_core, *cdb, 0, 0);
+            g_gen->add_client_pool(dist, portion.m_ip_start, portion.m_ip_end, active_flows_per_core, *cdb, 0, 0, m_profile_id);
         } else {
             gen_idx_trans.push_back(last_s_idx);
             last_s_idx++;

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -393,7 +393,7 @@ class CAstfDB  : public CTRexDummyCommand  {
         return m_topo_mngr;
     }
 
-    CAstfDB();
+    CAstfDB(profile_id_t profile_id = 0);
     virtual ~CAstfDB();
 
     /***************************/
@@ -594,6 +594,8 @@ private:
     double m_factor; /* initial multiplier factor */
 
     std::unordered_map<uint16_t,CTupleGeneratorSmart*> m_smart_gen;
+
+    profile_id_t m_profile_id;
 public:
     bool is_smart_gen(uint16_t thread_id) {
         return (m_smart_gen.find(thread_id) != m_smart_gen.end());

--- a/src/tuple_gen.h
+++ b/src/tuple_gen.h
@@ -38,6 +38,7 @@ limitations under the License.
 #include <bitset>
 #include <yaml-cpp/yaml.h>
 #include "trex_client_config.h"
+#include "trex_defs.h"
 
 #include <random>
 
@@ -636,12 +637,13 @@ class CIpPool {
 class CClientPool : public CIpPool {
 public:
 
-    CClientPool(){
+    CClientPool(profile_id_t profile_id=0){
         m_thread_id=0;
         m_rss_thread_id=0;
         m_rss_thread_max=0;
         m_reta_mask=0;
         m_rss_astf_mode=false;
+        m_profile_id=profile_id;
 
     }
 
@@ -671,7 +673,8 @@ public:
                 double          active_flows,
                 ClientCfgDB     &client_info,
                 uint16_t        tcp_aging,
-                uint16_t        udp_aging); 
+                uint16_t        udp_aging,
+                uint32_t        base_client_id=0);
 
 
     void set_thread_id(uint16_t thread_id){
@@ -694,6 +697,8 @@ public:
     uint16_t m_rss_thread_max;
     uint8_t  m_reta_mask;
     bool     m_rss_astf_mode;
+    profile_id_t m_profile_id;
+    uint32_t     m_base_client_id;
 
 private:
     void allocate_simple_clients(uint32_t  min_ip,
@@ -890,7 +895,8 @@ public:
                          double        active_flows,
                          ClientCfgDB   &client_info,
                          uint16_t      tcp_aging,
-                         uint16_t      udp_aging);
+                         uint16_t      udp_aging,
+                         profile_id_t  profile_id=0);
 
     bool add_server_pool(IP_DIST_t  server_dist,
                          uint32_t   min_server,


### PR DESCRIPTION
When client create profile with same IP address, ASTF connection does not established because of the source port conflict in client side.  This issue is caused because client source port is generated by randomly, but, random sequence is same per profile.  And, in case of single profile include multiple ip_gen object start with same client IP address, this issue can happen by same reason.
I modified port calculation function use  porfile id and base_client_id to fix this issue, and I think this commit can almost reduce port conflicts.