### PR TITLE
fixing import path in some example script

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/examples/stl/core_pinning_tutorial.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/stl/core_pinning_tutorial.py
@@ -1,3 +1,4 @@
+import stl_path
 from trex_stl_lib.api import *
 
 class STLS1(object):

--- a/scripts/automation/trex_control_plane/interactive/trex/examples/stl/null_stream.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/stl/null_stream.py
@@ -1,3 +1,4 @@
+import stl_path
 from trex_stl_lib.api import *
 
 class STLS1(object):

--- a/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_bi_dir_flows.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_bi_dir_flows.py
@@ -1,3 +1,4 @@
+import stl_path
 from trex.stl.api import *
 
 import time

--- a/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_dhcp_example.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_dhcp_example.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 from __future__ import print_function
 
+import stl_path
 from trex.stl.api import *
 from trex.common.services.trex_service_icmp import ServiceICMP
 from trex.common.services.trex_service_dhcp import ServiceDHCP


### PR DESCRIPTION
Some STL example scripts have broken import path and raise ImportError on execution. I have applied the tweak used by other examples and now they can be executed.