### PR TITLE
Register the sync method of ASTFClient to the client API

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -262,23 +262,6 @@ class ASTFClient(TRexClient):
             port.state = port_state
         return port_state
 
-    def sync(self):
-        self.epoch = None
-        params = {'profile_id': "sync"}
-        rc = self._transmit('sync', params)
-
-        if not rc:
-            raise TRexError(rc.err())
-
-        self.state = rc.data()['state']
-        self.apply_port_states()
-        if self.is_dynamic:
-            self.astf_profile_state = rc.data()['state_profile']
-        else:
-            self.astf_profile_state[DEFAULT_PROFILE_ID] = self.state
-        self.epoch = rc.data()['epoch']
-
-
     def wait_for_steady(self, profile_id=None):
         timer = PassiveTimer()
         while True:
@@ -457,6 +440,26 @@ class ASTFClient(TRexClient):
             self.ports[int(port_id)]._set_handler(port_rc)
 
         self._post_acquire_common(ports)
+
+
+    @client_api('command', True)
+    def sync(self):
+        self.epoch = None
+        params = {'profile_id': "sync"}
+        rc = self._transmit('sync', params)
+
+        if not rc:
+            raise TRexError(rc.err())
+
+        self.state = rc.data()['state']
+        self.apply_port_states()
+        if self.is_dynamic:
+            self.astf_profile_state = rc.data()['state_profile']
+        else:
+            self.astf_profile_state[DEFAULT_PROFILE_ID] = self.state
+        self.epoch = rc.data()['epoch']
+
+        return self.astf_profile_state
 
 
     @client_api('command', True)


### PR DESCRIPTION
As a user, I want to get the astf_profile_state of ASTFClient periodically by use a client API, the class method of ASTFClient which is sync(), it is used to update the astf_profile_state but it doesn't have a return value and it's not a client API.
So, I modified the sync() method to the client API with the return value which is astf_profile_state.
 Could you please review and comment?