### PR TITLE
stx: use reference instead of using exception by value.

### DIFF
--- a/src/stx/common/trex_stack_linux_based.cpp
+++ b/src/stx/common/trex_stack_linux_based.cpp
@@ -996,10 +996,10 @@ CLinuxIfNode::CLinuxIfNode(const string &ns_name, const string &mac_str, const s
         set_src_mac(mac_str, mac_buf);
         bind_pair();
         set_bpf_filter(get_default_bpf());
-    } catch (TrexException e) {
+    } catch (TrexException &e) {
         debug({"Got exception at Linux node ctor!", e.what()});
         delete_net();
-        throw &e;
+        throw e;
     }
 }
 
@@ -1040,10 +1040,10 @@ CSharedNSIfNode::CSharedNSIfNode(const string &ns_name, const string &if_name, c
         set_src_mac(mac_str, mac_buf);
         bind_pair();
         set_bpf_filter(get_default_bpf());
-    } catch (TrexException e) {
+    } catch (TrexException &e) {
         debug({"Got exception at Linux node ctor!", e.what()});
         delete_veth();
-        throw &e;
+        throw e;
     }
 }
 
@@ -1125,7 +1125,7 @@ bool run_in_ns(const string &cmd, const string &err, const string &ns, bool thro
     // using "cmd" for multiple commands
     try {
         popen_with_output(("ip netns exec "  + ns + " bash -c " + "\"" + cmd + "\"").c_str(), "cannot run " + cmd + " in ns " + ns, true, out);
-    } catch ( TrexException e ) {
+    } catch ( TrexException &e ) {
         if ( throw_ex ) {
             throw e;
         } else {


### PR DESCRIPTION
This changeset fixes the following error message from gcc 9.2.0:
```
| [147/332] Compiling ../src/stx/common/trex_rx_port_mngr.cpp
| ../../src/stx/common/trex_stack_linux_based.cpp: In constructor 'CLinuxIfNode::CLinuxIfNode(const string&, const string&, const string&, const string&, CMcastFilter&)':
| ../../src/stx/common/trex_stack_linux_based.cpp:999:28: error: catching polymorphic type 'class TrexException' by value [-Werror=catch-value=]
|   999 |     } catch (TrexException e) {
|       |                            ^
| ../../src/stx/common/trex_stack_linux_based.cpp: In constructor 'CSharedNSIfNode::CSharedNSIfNode(const string&, const string&, const string&, const string&, const stri
ng&, CMcastFilter&, bool)':
| ../../src/stx/common/trex_stack_linux_based.cpp:1043:28: error: catching polymorphic type 'class TrexException' by value [-Werror=catch-value=]
|  1043 |     } catch (TrexException e) {
|       |                            ^
| ../../src/stx/common/trex_stack_linux_based.cpp: In function 'bool run_in_ns(const string&, const string&, const string&, bool, std::string&)':
| ../../src/stx/common/trex_stack_linux_based.cpp:1128:29: error: catching polymorphic type 'class TrexException' by value [-Werror=catch-value=]
|  1128 |     } catch ( TrexException e ) {
|       |                             ^
| cc1plus: all warnings being treated as errors
|
| Build failed
|  -> task in 'bp-sim-64-debug' failed with exit status 1 (run with -v to display more information)
```