### PR TITLE
Update recv(bytes,clear=True) function issue in ASTFProgram

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -449,10 +449,10 @@ class ASTFProgram(object):
                     }
         ArgVerify.verify(self.__class__.__name__ + "." + sys._getframe().f_code.co_name, ver_args)
 
-        if clear:
-            self.total_rcv_bytes = 0
         self.total_rcv_bytes += pkts
         self.fields['commands'].append(ASTFCmdRecvMsg(self.total_rcv_bytes,clear))
+        if clear:
+            self.total_rcv_bytes = 0
 
 
     def send(self, buf):
@@ -507,10 +507,10 @@ class ASTFProgram(object):
                     }
         ArgVerify.verify(self.__class__.__name__ + "." + sys._getframe().f_code.co_name, ver_args)
 
-        if clear:
-            self.total_rcv_bytes = 0
         self.total_rcv_bytes += bytes
         self.fields['commands'].append(ASTFCmdRecv(self.total_rcv_bytes,clear))
+        if clear:
+            self.total_rcv_bytes = 0
 
     def delay(self, usec):
         """


### PR DESCRIPTION
Hi,
I found that previous `recv(bytes,clear=True) function issue in ASTFProgram` implementation may have different behavior compared to the document and server.
The client clears before recv(). But, the server clears after recv() done.
My change will make the client clear after recv() done also.
