### PR TITLE
fix STL stream vm program size overflow issue by massive value_list

### DIFF
--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -108,7 +108,7 @@ private:
     /* Fast Field VM section */
     uint8_t *            m_vm_flow_var; /* pointer to the vm flow var */
     uint8_t *            m_vm_program;  /* pointer to the program */
-    uint16_t             m_vm_program_size; /* up to 64K op codes */
+    uint32_t             m_vm_program_size; /* op codes can exceed 64K by massive value_list */
     uint16_t             m_cache_size;   /*RO*/ /* the size of the mbuf array */
     uint8_t              m_batch_size;   /*RO*/ /* the batch size */
     uint8_t              m_port_id;

--- a/src/stx/stl/trex_stl_stream_vm.cpp
+++ b/src/stx/stl/trex_stl_stream_vm.cpp
@@ -1474,7 +1474,7 @@ void StreamDPVmInstructions::clear(){
 }
 
 
-void StreamDPVmInstructions::add_command(void *buffer,uint16_t size){
+void StreamDPVmInstructions::add_command(void *buffer,uint32_t size){
     uint8_t *p= (uint8_t *)buffer;
     std::vector<uint8_t> tmp;
     // push buffer byte by byte in tmp

--- a/src/stx/stl/trex_stl_stream_vm.h
+++ b/src/stx/stl/trex_stl_stream_vm.h
@@ -390,7 +390,7 @@ public:
         }
     }
 
-    inline uint16_t get_sizeof_list() {
+    inline uint32_t get_sizeof_list() {
         return sizeof(uint8_t) * m_list_size;
     }
 
@@ -453,7 +453,7 @@ public:
         }
     }
 
-    inline uint16_t get_sizeof_list() {
+    inline uint32_t get_sizeof_list() {
         return sizeof(uint16_t) * m_list_size;
     }
 
@@ -517,7 +517,7 @@ public:
         }
     }
 
-    inline uint16_t get_sizeof_list() {
+    inline uint32_t get_sizeof_list() {
         return sizeof(uint32_t) * m_list_size;
     }
 
@@ -587,7 +587,7 @@ public:
         }
     }
 
-    inline uint16_t get_sizeof_list() {
+    inline uint32_t get_sizeof_list() {
         return sizeof(uint64_t) * m_list_size;
     }
 
@@ -951,7 +951,7 @@ public:
 
 public:
     void clear();
-    void add_command(void *buffer,uint16_t size);
+    void add_command(void *buffer,uint32_t size);
     void build_instruction_list();
     uint8_t * get_program();
     uint32_t get_program_size();
@@ -1950,7 +1950,7 @@ public:
     StreamVmDp( uint8_t * bss,
                 uint16_t bss_size,
                 uint8_t * prog,
-                uint16_t prog_size,
+                uint32_t prog_size,
                 uint16_t max_pkt_offset,
                 uint16_t prefix_size,
                 bool a_is_pkt_size_var,
@@ -2031,7 +2031,7 @@ public:
         return (m_program_ptr);
     }
 
-    uint16_t  get_program_size(){
+    uint32_t  get_program_size(){
         return (m_program_size);
     }
 
@@ -2062,7 +2062,7 @@ private:
     uint8_t *  m_bss_ptr; /* pointer to the data section */
     uint8_t *  m_program_ptr; /* pointer to the program */
     uint16_t   m_bss_size;
-    uint16_t   m_program_size; /* program size*/
+    uint32_t   m_program_size; /* program size*/
     uint16_t   m_max_pkt_offset_change;
     uint16_t   m_prefix_size;
     bool       m_is_pkt_size_var;


### PR DESCRIPTION
Hi,
This change will solve the issue when the STL flow_var value_list is massively used.
When the total size of the value_list is over 64K, the unexpected results will occur.
So, I removed the limitation of 64K opcodes size by this change.

Please check my code changes and give your feedback.