### PR TITLE
Increase number of set_var()

### DIFF
--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -537,7 +537,7 @@ private:
 class CEmulApp  {
 public:
     enum {
-        apVAR_NUM_SIZE =2
+        apVAR_NUM_SIZE = 5
     };
 
     /* flags */
@@ -579,7 +579,7 @@ public:
         m_cmd_rx_bytes_wm=0;
         m_vars[0]=0; /* unroll*/
         m_vars[1]=0;
-        assert(apVAR_NUM_SIZE==2);
+        assert(apVAR_NUM_SIZE==5);
     }
 
     virtual ~CEmulApp(){


### PR DESCRIPTION
apVAR_NUM_SIZE=2 is too small number to simulate various traffic scenarios.
This issue was already discussed in https://github.com/cisco-system-traffic-generator/trex-core/issues/433, so I increased apVAR_NUM_SIZE=5