### PR TITLE
Updates and errors corrected for Napatech adapters.

### DIFF
--- a/scripts/automation/regression/setups/trex42/benchmark.yaml
+++ b/scripts/automation/regression/setups/trex42/benchmark.yaml
@@ -1,0 +1,278 @@
+###############################################################
+####           TRex benchmark configuration file           ####
+###############################################################
+
+############### STF ################
+
+
+test_short_flow:
+    multiplier          : 20000
+    cores               : 7
+    bw_per_core         : 1000
+
+test_short_flow_high_active:
+    multiplier          : 20000
+    cores               : 7
+    bw_per_core         : 1000
+    active_flows        : 4000000
+
+test_short_flow_high_active2:
+    multiplier          : 10000
+    cores               : 7
+    bw_per_core         : 1000
+    active_flows        : 4000000
+
+
+test_jumbo:
+    multiplier          : 100
+    cores               : 10
+    bw_per_core         : 962.464
+
+
+test_routing_imix:
+    multiplier          : 80
+    cores               : 10
+    bw_per_core         : 48.130
+
+
+test_routing_imix_64:
+    multiplier          : 4000
+    cores               : 10
+    bw_per_core         : 12.699
+
+
+test_static_routing_imix_asymmetric:
+    multiplier          : 100
+    cores               : 10
+    bw_per_core         : 50.561
+
+
+test_ipv6_simple:
+    multiplier          : 50
+    cores               : 5
+    bw_per_core         : 19.5
+
+
+test_rx_check_http: &rx_http
+    multiplier          : 180000
+    cores               : 10
+    rx_sample_rate      : 128
+    bw_per_core         : 49.464
+    error_tolerance     : 5
+
+test_rx_check_http_ipv6:
+    <<                  : *rx_http
+    bw_per_core         : 49.237
+
+test_rx_check_sfr: &rx_sfr
+    multiplier          : 70
+    cores               : 10
+    rx_sample_rate      : 128
+    bw_per_core         : 20.871
+    error_tolerance     : 5
+
+test_rx_check_sfr_ipv6:
+    <<                  : *rx_sfr
+    bw_per_core         : 19.198
+
+
+############### ASTF ################
+
+test_tcp_http : &tcp_http
+    multiplier          : 20000
+    cores               : 1
+    bw_per_core         : 25
+    bypass_result       : 1
+
+test_ipv6_tcp_http :
+    <<                  : *tcp_http
+    bw_per_core         : 20
+
+test_tcp_sfr :
+    multiplier          : 20
+    cores               : 1
+    bw_per_core         : 20
+
+
+############### STL ################
+
+
+test_CPU_benchmark:
+    profiles:
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 64}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 64, stream_count: 10}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 64, stream_count: 100}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 64, stream_count: 1000}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 128}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 256}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 512}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 1500}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 4000}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 9000}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 9000, stream_count: 10}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_for_benchmarks.py
+        kwargs          : {packet_len: 9000, stream_count: 100}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+# not enough memory + queue full if memory increase
+#      - name            : stl/udp_for_benchmarks.py
+#        kwargs          : {packet_len: 9000, stream_count: 1000}
+#        cpu_util        : 1
+#        bw_per_core     : 1
+
+      - name            : stl/imix.py
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_1pkt_tuple_gen.py
+        kwargs          : {packet_len: 64}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_1pkt_tuple_gen.py
+        kwargs          : {packet_len: 128}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_1pkt_tuple_gen.py
+        kwargs          : {packet_len: 256}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_1pkt_tuple_gen.py
+        kwargs          : {packet_len: 512}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_1pkt_tuple_gen.py
+        kwargs          : {packet_len: 1500}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_1pkt_tuple_gen.py
+        kwargs          : {packet_len: 4000}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_1pkt_tuple_gen.py
+        kwargs          : {packet_len: 9000}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/pcap.py
+        kwargs          : {ipg_usec: 2, loop_count: 0}
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/udp_rand_len_9k.py
+        cpu_util        : 1
+        bw_per_core     : 1
+
+      - name            : stl/hlt/hlt_udp_rand_len_9k.py
+        cpu_util        : 1
+        bw_per_core     : 1
+
+
+test_performance_syn_attack_multi_cpus:
+    cfg:
+        core_count             : 10
+        mult                   : "25%"
+        mpps_per_core_golden   : # avg 7.6
+                                  min: 6.6
+                                  max: 8.6
+
+
+test_performance_syn_attack_single_cpu:
+     cfg:
+        mult                    : "2.5%"
+        mpps_per_core_golden    : # avg 8
+                                  min: 7
+                                  max: 9
+
+
+test_performance_vm_multi_cpus:
+    cfg:
+        core_count             : 10
+        mult                   : "25%"
+        mpps_per_core_golden   : # avg 9
+                                  min: 8
+                                  max: 10
+
+
+test_performance_vm_multi_cpus_cached:
+    cfg:
+        core_count             : 10
+        mult                   : "50%"
+        mpps_per_core_golden   : # avg 16
+                                  min: 13
+                                  max: 17
+
+
+test_performance_vm_single_cpu:
+    cfg:
+        mult                    : "2.5%"
+        mpps_per_core_golden    : # avg 9.7
+                                   min: 8.7
+                                   max: 10.7
+
+
+test_performance_vm_single_cpu_cached:
+    cfg:
+        mult                    : "5%"
+        mpps_per_core_golden    : # avg 16.4, sometimes 13...
+                                   min: 12.4
+                                   max: 17.4
+
+
+
+test_all_profiles :
+        mult          : "5%"
+        skip          : ['udp_rand_len_9k.py', 'udp_inc_len_9k.py']
+
+
+

--- a/scripts/automation/regression/setups/trex42/benchmark.yaml
+++ b/scripts/automation/regression/setups/trex42/benchmark.yaml
@@ -6,80 +6,78 @@
 
 
 test_short_flow:
-    multiplier          : 20000
-    cores               : 7
+    multiplier          : 2000
+    cores               : 4
     bw_per_core         : 1000
 
 test_short_flow_high_active:
-    multiplier          : 20000
-    cores               : 7
+    multiplier          : 2000
+    cores               : 4
     bw_per_core         : 1000
-    active_flows        : 4000000
+    active_flows        : 400000
 
 test_short_flow_high_active2:
-    multiplier          : 10000
-    cores               : 7
+    multiplier          : 2000
+    cores               : 4
     bw_per_core         : 1000
-    active_flows        : 4000000
+    active_flows        : 400000
 
 
 test_jumbo:
-    multiplier          : 100
-    cores               : 10
-    bw_per_core         : 962.464
+    multiplier          : 1
+    cores               : 1
+    bw_per_core         : 443.970
 
 
 test_routing_imix:
-    multiplier          : 80
-    cores               : 10
-    bw_per_core         : 48.130
+    multiplier          : 4
+    cores               : 1
+    bw_per_core         : 26.509
 
 
 test_routing_imix_64:
-    multiplier          : 4000
-    cores               : 10
-    bw_per_core         : 12.699
+    multiplier          : 60
+    cores               : 1
+    bw_per_core         : 6.391
 
 
 test_static_routing_imix_asymmetric:
-    multiplier          : 100
-    cores               : 10
-    bw_per_core         : 50.561
+    multiplier          : 3.2
+    cores               : 1
+    bw_per_core         : 28.229
 
 
 test_ipv6_simple:
-    multiplier          : 50
-    cores               : 5
-    bw_per_core         : 19.5
+    multiplier          : 6
+    cores               : 1
+    bw_per_core         : 19.185
 
 
 test_rx_check_http: &rx_http
-    multiplier          : 180000
-    cores               : 10
-    rx_sample_rate      : 128
-    bw_per_core         : 49.464
-    error_tolerance     : 5
+    multiplier          : 8800
+    cores               : 1
+    rx_sample_rate      : 16
+    bw_per_core         : 31.389
 
 test_rx_check_http_ipv6:
     <<                  : *rx_http
-    bw_per_core         : 49.237
+    bw_per_core         : 37.114
 
 test_rx_check_sfr: &rx_sfr
-    multiplier          : 70
-    cores               : 10
-    rx_sample_rate      : 128
-    bw_per_core         : 20.871
-    error_tolerance     : 5
+    multiplier          : 3.2
+    cores               : 1
+    rx_sample_rate      : 16
+    bw_per_core         : 16.063
 
 test_rx_check_sfr_ipv6:
     <<                  : *rx_sfr
-    bw_per_core         : 19.198
+    bw_per_core         : 19.663
 
 
 ############### ASTF ################
 
 test_tcp_http : &tcp_http
-    multiplier          : 20000
+    multiplier          : 200
     cores               : 1
     bw_per_core         : 25
     bypass_result       : 1
@@ -89,7 +87,7 @@ test_ipv6_tcp_http :
     bw_per_core         : 20
 
 test_tcp_sfr :
-    multiplier          : 20
+    multiplier          : 2
     cores               : 1
     bw_per_core         : 20
 
@@ -220,8 +218,8 @@ test_CPU_benchmark:
 
 test_performance_syn_attack_multi_cpus:
     cfg:
-        core_count             : 10
-        mult                   : "25%"
+        core_count             : 4
+        mult                   : "40%"
         mpps_per_core_golden   : # avg 7.6
                                   min: 6.6
                                   max: 8.6
@@ -229,7 +227,7 @@ test_performance_syn_attack_multi_cpus:
 
 test_performance_syn_attack_single_cpu:
      cfg:
-        mult                    : "2.5%"
+        mult                    : "40%"
         mpps_per_core_golden    : # avg 8
                                   min: 7
                                   max: 9
@@ -237,8 +235,8 @@ test_performance_syn_attack_single_cpu:
 
 test_performance_vm_multi_cpus:
     cfg:
-        core_count             : 10
-        mult                   : "25%"
+        core_count             : 4
+        mult                   : "40%"
         mpps_per_core_golden   : # avg 9
                                   min: 8
                                   max: 10
@@ -246,8 +244,8 @@ test_performance_vm_multi_cpus:
 
 test_performance_vm_multi_cpus_cached:
     cfg:
-        core_count             : 10
-        mult                   : "50%"
+        core_count             : 4
+        mult                   : "40%"
         mpps_per_core_golden   : # avg 16
                                   min: 13
                                   max: 17
@@ -255,7 +253,8 @@ test_performance_vm_multi_cpus_cached:
 
 test_performance_vm_single_cpu:
     cfg:
-        mult                    : "2.5%"
+        core_count              : 4
+        mult                    : "40%"
         mpps_per_core_golden    : # avg 9.7
                                    min: 8.7
                                    max: 10.7
@@ -263,7 +262,8 @@ test_performance_vm_single_cpu:
 
 test_performance_vm_single_cpu_cached:
     cfg:
-        mult                    : "5%"
+        core_count              : 4
+        mult                    : "40%"
         mpps_per_core_golden    : # avg 16.4, sometimes 13...
                                    min: 12.4
                                    max: 17.4

--- a/scripts/automation/regression/setups/trex42/config.yaml
+++ b/scripts/automation/regression/setups/trex42/config.yaml
@@ -8,5 +8,5 @@ trex:
   hostname       : SuperBK
   cores          : 4
   astf_cores     : 1
-  modes          : ['loopback', 'dummy']
+  modes          : ['loopback']
 

--- a/scripts/automation/regression/setups/trex42/config.yaml
+++ b/scripts/automation/regression/setups/trex42/config.yaml
@@ -1,0 +1,12 @@
+################################################################
+####         TRex nightly test configuration file          ####
+################################################################
+
+# Napatech setup
+
+trex:
+  hostname       : SuperBK
+  cores          : 4
+  astf_cores     : 1
+  modes          : ['loopback', 'dummy']
+

--- a/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.c
+++ b/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.c
@@ -148,7 +148,6 @@ static struct {
   struct pmd_internals *pInternals;
 } _PmdInternals[RTE_MAX_ETHPORTS];
 
-
 /**
  * Log nt errors (Napatech adapter errors)
  *

--- a/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.h
+++ b/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.h
@@ -256,9 +256,6 @@ struct externalBufferInfo_s {
 };
 #endif
 
-
-#define NB_SUPPORTED_FPGAS 16
-
 int DoNtpl(const char *ntplStr, uint32_t *pNtplID, struct pmd_internals *internals, struct rte_flow_error *error);
 
 extern int ntacc_logtype;


### PR DESCRIPTION
Some corrections and updates for Napatech adapters.

1. All Napatech 4Generation adapters are now supported.
    Before the supported adapters was limited to adapters with certain FPGA versions.
    Now it just have to be a 4Generation adapter.

2. Handling of 25G enum added. 
    Compiling TRex with a newer Napatech drivers would fail due to a 25G enums was not handled.

3. Bug in handling jumbo frames corrected. 
    The mbuf->data_len was not updated in the first segment in a jumbo frame

Regression test trex42 has bee run with no errors:

233 tests run in 1940.2 seconds.
41 skipped (192 tests passed)

                 ..::''''::..
               .;''        ``;.
              ::    ::  ::    ::
             ::     ::  ::     ::
             ::     ::  ::     ::
             :: .:' ::  :: `:. ::
             ::  :          :  ::
              :: `:.      .:' ::
               `;..``::::''..;'
                 ``::,,,,::''

               ___  ___   __________
              / _ \/ _ | / __/ __/ /
             / ___/ __ |_\ \_\ \/_/
            /_/  /_/ |_/___/___(_)



python test succeeded

Note: This is my first pull request, so please advise me if I am doing something wrong.
Best regards 
Bent Kuhre


