### PR TITLE
fixed TRexTimeoutError issue in astf_client.py

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -11,7 +11,7 @@ from ..utils import parsing_opts, text_tables
 from ..common.trex_api_annotators import client_api, console_api
 from ..common.trex_client import TRexClient, NO_TCP_UDP_MASK
 from ..common.trex_events import Event
-from ..common.trex_exceptions import TRexError
+from ..common.trex_exceptions import TRexError, TRexTimeoutError
 from ..common.trex_types import *
 from ..common.trex_types import DEFAULT_PROFILE_ID, ALL_PROFILE_ID
 


### PR DESCRIPTION
When Timeout has occurred in wait_on_traffic,
Exception is NameError, not TRexTimeoutError