### PR TITLE
limit flow generation by the number of active flows per template

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1169,13 +1169,17 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
         template_ro.m_stream = get_emul_stream(c_temp["program_index"].asInt());
         temp_rw->Create(g_gen, index, thread_id, &template_ro, dual_port_id);
 
+        bool is_cont = false;
+        if (c_temp["cont"] != Json::nullValue ) {
+            is_cont = c_temp["cont"].asBool(); // set continuous flows
+        }
         if (c_temp["limit"] != Json::nullValue ){
             uint32_t cnt= utl_split_int(c_temp["limit"].asUInt(),
                                         thread_id, 
                                         max_threads);
 
             /* there is a limit */
-            temp_rw->set_limit(cnt);
+            temp_rw->set_limit(cnt, is_cont);
         }
 
         CTcpTuneables *s_tuneable;

--- a/src/astf/astf_template_db.h
+++ b/src/astf/astf_template_db.h
@@ -68,13 +68,24 @@ public:
     uint16_t get_dest_port(){
         return(m_dest_port);
     }
-    void set_limit(uint32_t limit){
+    void set_limit(uint32_t limit, bool is_cont){
         m_limit=limit+1; /* need to add 1*/
+        m_is_cont=is_cont;
     }
 
     void dec_limit() {
         if (m_limit>1) { /* stop at 1 */
             --m_limit;
+        }
+    }
+    void try_dec_limit() {
+        if (m_is_cont) {
+            dec_limit();
+        }
+    }
+    void try_inc_limit() {
+        if (m_is_cont && m_limit>0) {
+            ++m_limit;
         }
     }
     bool check_limit(){
@@ -104,7 +115,8 @@ public:
     astf_thread_id_t              m_thread_id;
     CTcpTuneables               * m_c_tune;
     CTcpTuneables               * m_s_tune;
-    uint32_t                      m_limit;
+    uint32_t                      m_limit;      /* limit the generated flows */
+    bool                          m_is_cont;    /* continue flow generation to the limit */
     bool                         m_is_udp;
 } ;
 

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -82,6 +82,8 @@ int CTcpIOCb::on_flow_close(CTcpPerThreadCtx *ctx,
 
     CAstfPerTemplateRW * cur = flow->m_pctx->m_template_rw->get_template_by_id(c_template_id);
 
+    cur->try_inc_limit(); /* allow new flow when flows are limited */
+
     CTupleGeneratorSmart * lpgen= cur->m_tuple_gen.get_gen();
     if ( lpgen->IsFreePortRequired(c_pool_idx) ){
         lpgen->FreePort(c_pool_idx,c_idx,flow->m_template.m_src_port);
@@ -349,6 +351,7 @@ void CFlowGenListPerThread::generate_flow(bool &done, CPerProfileCtx * pctx){
     m_stats.m_total_open_flows += 1;
 
     if (!m_c_tcp->m_ft.insert_new_flow(c_flow,c_tuple)){
+        cur->try_dec_limit();   // flow close will increase value by try_inc_limit()
         /* need to free the tuple */
         m_c_tcp->m_ft.handle_close(m_c_tcp,c_flow,false);
         return;


### PR DESCRIPTION
Hi, this PR is related to #402.

Now, each template can limit the number of active flows.
The number of active flows will be affected by the network situation. The long RTT may increase active flows when the flow program has a long lifetime. This feature can limit the active flows in that situation.

Please check my changes and give your opinion.