### PR TITLE
remove ASTF DP profile ctx safely

### DIFF
--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -903,6 +903,8 @@ public:
     on_stopped_cb_t     m_on_stopped_cb;
     void              * m_cb_data;
 
+    void              * m_tx_node;  /* to make CGenNodeTXFIF stop safe */
+
 private:
     bool                m_stopped;
     bool                m_nc_flow_close;

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -224,13 +224,13 @@ void CFlowGenListPerThread::generate_flow(bool &done, CPerProfileCtx * pctx){
 
     done=false;
 
-    if ( m_c_tcp->is_open_flow_enabled()==false ){
-        m_c_tcp->m_ft.inc_err_c_new_flow_throttled_cnt();
+    if (!pctx || !pctx->is_active()) { // transmit stopped
+        done=true;
         return;
     }
 
-    if (!pctx->is_active()) { // transmit stopped
-        done=true;
+    if ( m_c_tcp->is_open_flow_enabled()==false ){
+        m_c_tcp->m_ft.inc_err_c_new_flow_throttled_cnt();
         return;
     }
 


### PR DESCRIPTION
Hi,
I found that ASTF DP profile CPerProfileCtx entry had remained in some cases.
So, I added code to remove it when the related ASTF DB is cleared.

And I fixed an issue that CGenNodeTXFIF can reference already removed CPerProfileCtx.

@hhaim, please check my code and give your feedback.