### PR TITLE
update L7_map template reference when the profile removed

### DIFF
--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -324,6 +324,8 @@ void CTcpFlow::Create(CPerProfileCtx *pctx, uint16_t tg_id){
     m_timer.reset();
     m_timer.m_type = 0; 
 
+    m_payload_info = nullptr;
+
     /* TCP_OPTIM  */
     tcpcb *tp=&m_tcp;
     memset((char *) tp, 0,sizeof(struct tcpcb));
@@ -382,7 +384,7 @@ CPerProfileCtx* CTcpFlow::create_on_flow_profile() {
     }
 }
 
-void CTcpFlow::start_identifying_template(CPerProfileCtx* pctx) {
+void CTcpFlow::start_identifying_template(CPerProfileCtx* pctx, CServerIpPayloadInfo* payload_info) {
     assert(pctx->is_on_flow());
 
     // to collect TCP statistics
@@ -398,6 +400,12 @@ void CTcpFlow::start_identifying_template(CPerProfileCtx* pctx) {
     m_app.set_l7_check(true);
     m_tcp.m_reass_disabled = true;
     m_template_info = nullptr;
+
+    // to update reference template quickly
+    m_payload_info = payload_info;
+    if (m_payload_info) {
+        m_payload_info->insert_template_flow(this);
+    }
 }
 
 
@@ -436,6 +444,11 @@ bool CTcpFlow::check_template_assoc_by_l7_data(uint8_t* l7_data, uint16_t l7_len
 void CTcpFlow::update_new_template_assoc_info() {
     if(!m_pctx->is_on_flow() || !m_template_info) {
         return;
+    }
+
+    if (m_payload_info) {
+        m_payload_info->remove_template_flow(this);
+        m_payload_info = nullptr;
     }
 
     CPerProfileCtx* pctx = m_template_info->get_profile_ctx();
@@ -549,6 +562,10 @@ void CTcpFlow::Delete(){
     struct tcpcb *tp=&m_tcp;
     tcp_reass_clean(m_pctx,tp);
     m_pctx->m_ctx->timer_w_stop(this);
+    if (m_payload_info) {
+        m_payload_info->remove_template_flow(this);
+        m_payload_info = nullptr;
+    }
 }
 
 
@@ -917,6 +934,7 @@ CServerIpPayloadInfo::CServerIpPayloadInfo(uint32_t start, uint32_t end, CServer
     auto payload_params = temp.get_server_info()->get_payload_params();
     assert(payload_params.size() % 3 == 0);
 
+    m_template_ref = nullptr;
     if (payload_params.size()) {
         payload_value_t pval = 0;
         for (int i = 0; i < payload_params.size();) {
@@ -968,18 +986,54 @@ bool CServerIpPayloadInfo::is_server_compatible(CTcpServerInfo* in_server) {
 
 
 CServerTemplateInfo* CServerIpPayloadInfo::get_reference_template_info() {
+    if (likely(m_template_ref)) {
+        return m_template_ref;
+    }
     for (auto it = m_payload_map.begin(); it != m_payload_map.end(); it++) {
         auto pctx = it->second.get_profile_ctx();
         // use first active entry for the reference
-        if (pctx->is_active() || !pctx->get_nc()) {
-            // the reference can be distinguished by existing payload params.
-            return &it->second;
+        if (pctx->is_active()) {
+            m_template_ref = &it->second;
+            break;
+        }
+        if (!pctx->get_nc()) {
+            m_template_ref = &it->second;
         }
     }
-    return nullptr;
+    return m_template_ref;  // the reference will be distinguished by existing payload params.
+}
+
+void CServerIpPayloadInfo::update_template_flows(CPerProfileCtx* pctx) {
+    auto temp_ref = get_reference_template_info();
+    auto new_pctx = temp_ref ? temp_ref->get_profile_ctx(): nullptr;
+    for (auto it = m_template_flows.begin(); it != m_template_flows.end();) {
+        auto flow = *it;
+        assert(!flow->is_activated());
+        // update removed profile/template reference
+        if (flow->m_pctx->m_profile_id == pctx->m_profile_id) {
+            if (new_pctx) {
+                flow->m_pctx->m_profile_id = new_pctx->m_profile_id;
+                flow->m_pctx->m_template_rw = new_pctx->m_template_rw;
+            }
+            else {
+                // trigger flow termination
+                flow->m_pctx->deactivate();
+                flow->m_pctx->set_nc(true);
+
+                // remove identifying template information
+                flow->m_payload_info = nullptr;
+                it = m_template_flows.erase(it);
+                continue;
+            }
+        }
+        ++it;
+    }
 }
 
 bool CServerIpPayloadInfo::remove_template_info(CPerProfileCtx* pctx) {
+    if (m_template_ref && m_template_ref->get_profile_ctx() == pctx) {
+        m_template_ref = nullptr;
+    }
     for (auto it = m_payload_map.begin(); it != m_payload_map.end();) {
         if (it->second.get_profile_ctx() == pctx) {
             it = m_payload_map.erase(it);
@@ -988,6 +1042,7 @@ bool CServerIpPayloadInfo::remove_template_info(CPerProfileCtx* pctx) {
             it++;
         }
     }
+    update_template_flows(pctx);
     return m_payload_map.empty();
 }
 
@@ -1025,9 +1080,33 @@ CServerTemplateInfo* CServerPortInfo::get_template_info(uint32_t ip, uint8_t* da
     return temp;
 }
 
+CServerIpPayloadInfo* CServerPortInfo::get_ip_payload_info(uint32_t ip) {
+    if (!m_ip_map_payload.empty()) {
+        auto it = m_ip_map_payload.lower_bound(ip);
+        if (it != m_ip_map_payload.end() && it->second.is_ip_in(ip)) {
+            return &it->second;
+        }
+    }
+    return nullptr;
+}
+
+void CServerPortInfo::update_payload_template_reference(CServerTemplateInfo* temp) {
+    auto server = temp->get_server_info();
+    auto ip_start = server->get_ip_start();
+    auto ip_end = server->get_ip_end();
+
+    for (auto it = m_ip_map_payload.lower_bound(ip_start); it != m_ip_map_payload.end(); it++) {
+        if (!it->second.is_ip_overlap(ip_start, ip_end)) {
+            break;
+        }
+        it->second.set_reference_template_info(temp);
+    }
+}
+
 bool CServerPortInfo::insert_template_payload(CTcpServerInfo* server, CPerProfileCtx* pctx, std::string& msg) {
     auto ip_start = server->get_ip_start();
     auto ip_end = server->get_ip_end();
+    auto is_stream = server->get_prog()->is_stream();
     CServerTemplateInfo temp{ server, pctx };
     CServerIpPayloadInfo in_payload{ ip_start, ip_end, temp };
 
@@ -1038,7 +1117,7 @@ bool CServerPortInfo::insert_template_payload(CTcpServerInfo* server, CPerProfil
         if (!it->second.is_ip_overlap(ip_start, ip_end)) {
             break;
         }
-        if (!in_payload.is_server_compatible(it->second.get_template_info()->get_server_info())) {
+        if (is_stream && !in_payload.is_server_compatible(it->second.get_template_info()->get_server_info())) {
             ss << "server tuneables(\"glob_info\") is not compatible with non payload tuneables";
             msg = ss.str();
             return false;
@@ -1055,7 +1134,7 @@ bool CServerPortInfo::insert_template_payload(CTcpServerInfo* server, CPerProfil
                 msg = ss.str();
                 return false;
             }
-            else if (!payload.is_server_compatible(server)) {
+            else if (is_stream && !payload.is_server_compatible(server)) {
                 ss << "server tuneables(\"glob_info\") should be compatible with payload tuneables";
                 msg = ss.str();
                 return false;
@@ -1088,14 +1167,15 @@ bool CServerPortInfo::insert_template_info(CTcpServerInfo* server, CPerProfileCt
     }
     auto ip_start = server->get_ip_start();
     auto ip_end = server->get_ip_end();
+    auto is_stream = server->get_prog()->is_stream();
 
     std::stringstream ss;
     /* server should be compatible with m_ip_map_payload entries */
     for (auto it = m_ip_map_payload.lower_bound(ip_start); it != m_ip_map_payload.end(); it++) {
-        if (it->second.is_ip_overlap(ip_start, ip_end)) {
+        if (!it->second.is_ip_overlap(ip_start, ip_end)) {
             break;
         }
-        if (it->second.is_server_compatible(server)) {
+        if (is_stream && !it->second.is_server_compatible(server)) {
             ss << "non payload server tuneables(\"glob_info\") is not compatible with existing payload tuneables";
             msg = ss.str();
             return false;
@@ -1122,18 +1202,12 @@ bool CServerPortInfo::insert_template_info(CTcpServerInfo* server, CPerProfileCt
             m_template_cache = m_ip_map[ip_end].get_template_info();
         }
     }
+    // set m_ip_map's template info to the reference of m_ip_map_payload
+    update_payload_template_reference(m_ip_map[ip_end].get_template_info());
     return true;
 }
 
 void CServerPortInfo::remove_template_info_by_profile(CPerProfileCtx* pctx) {
-    for (auto it = m_ip_map_payload.begin(); it != m_ip_map_payload.end();) {
-        if (it->second.remove_template_info(pctx)) {
-            it = m_ip_map_payload.erase(it);
-        }
-        else {
-            ++it;
-        }
-    }
     for (auto it = m_ip_map.begin(); it != m_ip_map.end();) {
         if (it->second.get_template_info()->get_profile_ctx() == pctx) {
             if (it->second.get_template_info() == m_template_cache) {
@@ -1142,9 +1216,19 @@ void CServerPortInfo::remove_template_info_by_profile(CPerProfileCtx* pctx) {
             it = m_ip_map.erase(it);
         }
         else {
+            update_payload_template_reference(it->second.get_template_info());
             ++it;
         }
     }
+    for (auto it = m_ip_map_payload.begin(); it != m_ip_map_payload.end();) {
+        if (it->second.remove_template_info(pctx)) {
+            it = m_ip_map_payload.erase(it);
+        }
+        else {
+            ++it;
+        }
+    }
+
     if (!m_template_cache && m_ip_map_payload.empty() && (m_ip_map.size() == 1)) {
         auto it = m_ip_map.begin();
         if (it->second.ip_start() == 0 && it->second.ip_end() == UINT32_MAX) {
@@ -1253,6 +1337,22 @@ CServerTemplateInfo * CTcpPerThreadCtx::get_template_info(uint16_t port, bool st
 
     if (m_server_ports.find(params) != m_server_ports.end()) {
         return m_server_ports[params].get_template_info(ip, data, len);
+    }
+    return nullptr;
+}
+
+CServerTemplateInfo * CTcpPerThreadCtx::get_template_info(uint16_t port, bool stream, uint32_t ip, CServerIpPayloadInfo** payload_info_p) {
+    uint32_t params = PortParams(port, stream);
+
+    if (m_server_ports.find(params) != m_server_ports.end()) {
+        auto payload_info = m_server_ports[params].get_ip_payload_info(ip);
+        if (payload_info) {
+            if (payload_info_p) {
+                *payload_info_p = payload_info;
+            }
+            return payload_info->get_reference_template_info();
+        }
+        return m_server_ports[params].get_template_info(ip);
     }
     return nullptr;
 }

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -740,6 +740,7 @@ public:
 /*****************************************************/
 
 class CServerTemplateInfo;
+class CServerIpPayloadInfo;
 
 class CTcpFlow : public CFlowBase {
 
@@ -782,7 +783,7 @@ public:
     void set_s_tcp_info(const CAstfDbRO * ro_db, CTcpTuneables *tune);
 
     CPerProfileCtx* create_on_flow_profile();
-    void start_identifying_template(CPerProfileCtx *pctx);
+    void start_identifying_template(CPerProfileCtx *pctx, CServerIpPayloadInfo* payload_info);
     bool new_template_identified();
     bool is_activated();
 
@@ -795,6 +796,7 @@ public:
     uint8_t           m_tick;
 
     CServerTemplateInfo*    m_template_info; /* to save the identified template */
+    CServerIpPayloadInfo*   m_payload_info; /* to manage template during identifying */
 };
 
 /* general timer object used by ASTF, 
@@ -1016,6 +1018,9 @@ class CServerIpPayloadInfo : CServerIpInfo {
     payload_rule_t m_payload_rule;
     std::unordered_map<payload_value_t,CServerTemplateInfo> m_payload_map;
 
+    CServerTemplateInfo* m_template_ref;    // IP only template >> latest payload template
+    std::set<CTcpFlow*> m_template_flows;   // flows to update reference template info
+
 public:
     CServerIpPayloadInfo() {}
     CServerIpPayloadInfo(uint32_t start, uint32_t end, CServerTemplateInfo& temp);
@@ -1054,11 +1059,13 @@ public:
     CServerTemplateInfo* get_template_info(uint8_t* data) {
         return data ? get_template_info(get_payload_value(data)): nullptr;
     }
+    void set_reference_template_info(CServerTemplateInfo* temp) { m_template_ref = temp; }
     CServerTemplateInfo* get_reference_template_info();
 
     bool insert_template_info(payload_value_t pval, CTcpServerInfo* server, CPerProfileCtx* pctx) {
         if (!get_template_info(pval)) {
             m_payload_map.insert(std::make_pair(pval, CServerTemplateInfo(server, pctx)));
+            m_template_ref = &m_payload_map[pval];  // updated by recently added one
             return true;
         }
         return false;
@@ -1074,6 +1081,17 @@ public:
     }
 
     bool remove_template_info(CPerProfileCtx* pctx);
+
+    void insert_template_flow(CTcpFlow* flow) {
+        m_template_flows.insert(flow);
+    }
+    void remove_template_flow(CTcpFlow* flow) {
+        auto it = m_template_flows.find(flow);
+        if (it != m_template_flows.end()) {
+            m_template_flows.erase(it);
+        }
+    }
+    void update_template_flows(CPerProfileCtx* pctx);
 
     std::string to_string() {
         std::stringstream ss;
@@ -1107,6 +1125,7 @@ class CServerPortInfo {
     std::map<uint32_t,CServerIpPayloadInfo> m_ip_map_payload;
     CServerTemplateInfo *m_template_cache;    // all ip range's template cache for the fast lookup.
 
+    void update_payload_template_reference(CServerTemplateInfo* temp);
     bool insert_template_payload(CTcpServerInfo* info, CPerProfileCtx* pctx, std::string& msg);
     CServerTemplateInfo* get_template_info_by_ip(uint32_t ip);
     CServerTemplateInfo* get_template_info_by_payload(uint32_t ip, uint8_t* data, uint16_t len);
@@ -1116,7 +1135,12 @@ public:
     bool insert_template_info(CTcpServerInfo* info, CPerProfileCtx* pctx, std::string& msg);
     void remove_template_info_by_profile(CPerProfileCtx* pctx);
 
+    CServerIpPayloadInfo* get_ip_payload_info(uint32_t ip);
+
     CServerTemplateInfo* get_template_info(uint32_t ip, uint8_t* data, uint16_t len);
+    CServerTemplateInfo* get_template_info(uint32_t ip) {
+        return m_template_cache ? m_template_cache : get_template_info_by_ip(ip);
+    }
     CServerTemplateInfo* get_template_info() { return m_template_cache; }
 
     void print_server_port();
@@ -1259,6 +1283,7 @@ public:
     void remove_server_ports(profile_id_t profile_id);
     CServerTemplateInfo * get_template_info_by_port(uint16_t port, bool stream);
     CServerTemplateInfo * get_template_info(uint16_t port, bool stream, uint32_t ip, uint8_t* data=nullptr, uint16_t len=0);
+    CServerTemplateInfo * get_template_info(uint16_t port, bool stream, uint32_t ip, CServerIpPayloadInfo** payload_info_p);
     CTcpServerInfo * get_server_info(uint16_t port, bool stream, uint32_t ip, uint8_t* data=nullptr, uint16_t len=0);
     void print_server_ports();
 


### PR DESCRIPTION
Hi,
ASTF TCP L7_map used template creates an interim profile ctx which refers to one of the possible profile's resources. It caused a crash after the reference profile removed.
So, I improved the way to select the referenced profile with updating when insertion and removal of server port information happens. When the profile removed, all the flow's interim profile will be updated to proper another one.

@hhaim, please check my changes and give your feedback.