### PR TITLE
Added mutex lock for CAstfDB instance access

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -39,9 +39,11 @@ inline std::string methodName(const std::string& prettyFunction)
 astf_db_map_t CAstfDB::m_instances;
 
 
-CAstfDB::CAstfDB(){
+void CAstfDB::Create(){
+    if (m_validator && m_topo_mngr) {
+        return;
+    }
     m_client_config_info=0;
-    m_validator=0;
     m_validator = new CAstfJsonValidator();
     if (!m_validator->Create("astf_schema.json")) {
         printf("Could not create ASTF validator using file astf_schema.json\n");
@@ -49,35 +51,51 @@ CAstfDB::CAstfDB(){
     }
     m_topo_mngr = new TopoMngr();
     m_factor = -1.0;
+    m_json_initiated = false;
 }
 
 
-CAstfDB::~CAstfDB(){
+void CAstfDB::Delete(){
     if ( m_validator ) {
         m_validator->Delete();
         delete m_validator;
+        m_validator = nullptr;
     }
     delete m_topo_mngr;
+    m_topo_mngr = nullptr;
     for (auto it : m_smart_gen) {
         delete it.second;
     }
     m_smart_gen.clear();
 }
 
+CAstfDB::~CAstfDB(){
+    this->Delete();
+}
 
-CAstfDB* CAstfDB::instance(profile_id_t profile_id) {
-    if ( m_instances.find(profile_id) == m_instances.end() ) {
-        CAstfDB *new_inst = new CAstfDB();
-        new_inst->m_json_initiated = false;
-        m_instances[profile_id] = new_inst;
-        return new_inst;
+CAstfDB* CAstfDB::get_instance(profile_id_t profile_id) {
+    if (m_instances.find(profile_id) == m_instances.end()) {
+        m_instances[profile_id] = new CAstfDB();
     }
     return m_instances[profile_id];
+}
+CAstfDB* CAstfDB::instance(profile_id_t profile_id) {
+    return m_instances[profile_id];
+}
+
+CAstfDB* CAstfDB::instance() {
+    if (!has_instance()) {
+        CAstfDB* new_inst = get_instance(0);
+        new_inst->Create();
+        return new_inst;
+    }
+    return instance(0);
 }
 
 void CAstfDB::free_instance(profile_id_t profile_id) {
     if ( m_instances.find(profile_id) != m_instances.end() ){
-        delete m_instances[profile_id];
+        auto inst = m_instances[profile_id];
+        delete inst;
         m_instances.erase(profile_id);
     }
 }

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -411,7 +411,9 @@ class CAstfDB  : public CTRexDummyCommand  {
 
  public:
     // make the class singelton
-    static CAstfDB *instance(profile_id_t profile_id = 0);
+    static CAstfDB *get_instance(profile_id_t profile_id);
+    static CAstfDB *instance(profile_id_t profile_id);
+    static CAstfDB *instance();
 
     static void free_instance(profile_id_t profile_id = 0);
 
@@ -424,8 +426,10 @@ class CAstfDB  : public CTRexDummyCommand  {
         return m_topo_mngr;
     }
 
-    CAstfDB();
     virtual ~CAstfDB();
+
+    void Create();
+    void Delete();
 
     /***************************/
 

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -2993,6 +2993,7 @@ class CEmulAppProgram;
 class CMbufBuffer;
 class CTcpCtxCb;
 class CSyncBarrier;
+class CAstfDB;
 
 class CFlowGenListPerThread {
 
@@ -3231,8 +3232,10 @@ public:
     double tcp_get_tw_tick_in_sec();
 
     void Create_tcp_ctx();
-    void load_tcp_profile(profile_id_t profile_id = 0, bool is_first = true);
-    void unload_tcp_profile(profile_id_t profile_id = 0, bool is_last = true);
+    void load_tcp_profile(profile_id_t profile_id, bool is_first, CAstfDB* astf_db);
+    void load_tcp_profile();
+    void unload_tcp_profile(profile_id_t profile_id, bool is_last, CAstfDB* astf_db);
+    void unload_tcp_profile();
     void remove_tcp_profile(profile_id_t profile_id);
     void Delete_tcp_ctx();
 

--- a/src/gtest/bp_astf_interactive_gtest.cpp
+++ b/src/gtest/bp_astf_interactive_gtest.cpp
@@ -175,12 +175,13 @@ TEST_F(gt_astf_inter, astf_positive_7) {
 
     profile_id_t profile_id_1 = 0x12345678;
 
-    lpastf = CAstfDB::instance(profile_id_1);
+    lpastf = CAstfDB::get_instance(profile_id_1);
+    lpastf->Create();
     success = lpastf->parse_file("automation/regression/data/astf_dns.json");
     EXPECT_EQ(success, true);
 
     try {
-        lpt->load_tcp_profile(profile_id_1); // DB 1 loaded
+        lpt->load_tcp_profile(profile_id_1, true, lpastf); // DB 1 loaded
         success = true;
     } catch (const TrexException &ex) {
         std::cerr << "ERROR in ASTF object creation: " << ex.what();
@@ -188,10 +189,10 @@ TEST_F(gt_astf_inter, astf_positive_7) {
     }
     EXPECT_EQ(success, true);
 
-    lpt->unload_tcp_profile(profile_id_1);
+    lpt->unload_tcp_profile(profile_id_1, true, lpastf);
 
     try {
-        lpt->load_tcp_profile(profile_id_1); // DB 1 loaded
+        lpt->load_tcp_profile(profile_id_1, true, lpastf); // DB 1 loaded
         success = true;
     } catch (const TrexException &ex) {
         std::cerr << "ERROR in ASTF object creation: " << ex.what();
@@ -201,16 +202,17 @@ TEST_F(gt_astf_inter, astf_positive_7) {
 
     profile_id_t profile_id_2 = 0xfedcba98;
 
-    lpastf = CAstfDB::instance(profile_id_2);
+    lpastf = CAstfDB::get_instance(profile_id_2);
+    lpastf->Create();
     success = lpastf->parse_file("automation/regression/data/astf_dns.json");
     EXPECT_EQ(success, true);
 
     try {
-        lpt->load_tcp_profile(profile_id_2); // DB 1 loaded again
+        lpt->load_tcp_profile(profile_id_2, false, lpastf); // DB 1 loaded again
         success = true;
     } catch (const TrexException &ex) {
         std::cerr << "ERROR (as expected) in ASTF object creation: " << ex.what();
-        lpt->unload_tcp_profile(profile_id_2);
+        lpt->unload_tcp_profile(profile_id_2, false, lpastf);
         success = false;
     }
     EXPECT_EQ(success, false);
@@ -220,7 +222,7 @@ TEST_F(gt_astf_inter, astf_positive_7) {
     EXPECT_EQ(success, true);
 
     try {
-        lpt->load_tcp_profile(profile_id_2); // DB 2 loaded
+        lpt->load_tcp_profile(profile_id_2, true, lpastf); // DB 2 loaded
         success = true;
     } catch (const TrexException &ex) {
         std::cerr << "ERROR in ASTF object creation: " << ex.what();
@@ -230,11 +232,11 @@ TEST_F(gt_astf_inter, astf_positive_7) {
 
     /* TODO: run simulation of traffic here with --nc */
 
-    lpt->unload_tcp_profile(profile_id_1);
-    lpt->unload_tcp_profile(profile_id_2);
+    lpt->unload_tcp_profile(profile_id_1, false, CAstfDB::instance(profile_id_1));
+    lpt->unload_tcp_profile(profile_id_2, true, CAstfDB::instance(profile_id_2));
 
-    lpastf->free_instance(profile_id_1);
-    lpastf->free_instance(profile_id_2);
+    CAstfDB::free_instance(profile_id_1);
+    CAstfDB::free_instance(profile_id_2);
     fl.clean_p_thread_info();
     fl.Delete();
 }

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -395,7 +395,9 @@ void TrexAstf::profile_clear(cp_profile_id_t profile_id){
     if (pid->get_profile_state() == STATE_LOADED) {
         pid->profile_change_state(STATE_DELETE);
 
-        TrexCpToDpMsgBase *msg = new TrexAstfDeleteDB(pid->get_dp_profile_id());
+        auto dp_profile_id = pid->get_dp_profile_id();
+        auto astf_db = CAstfDB::instance(dp_profile_id);
+        TrexCpToDpMsgBase *msg = new TrexAstfDeleteDB(dp_profile_id, astf_db);
         send_message_to_dp(0, msg);
     }
     else { // STATE_IDLE
@@ -909,14 +911,16 @@ void TrexAstfPerProfile::parse() {
 
     profile_change_state(STATE_PARSE);
 
-    TrexCpToDpMsgBase *msg = new TrexAstfLoadDB(m_dp_profile_id, prof, topo);
+    auto astf_db = CAstfDB::get_instance(m_dp_profile_id);
+    TrexCpToDpMsgBase *msg = new TrexAstfLoadDB(m_dp_profile_id, prof, topo, astf_db);
     m_astf_obj->send_message_to_dp(0, msg);
 }
 
 void TrexAstfPerProfile::build() {
     profile_change_state(STATE_BUILD);
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpCreateTcp(m_dp_profile_id, m_factor);
+    auto astf_db = CAstfDB::instance(m_dp_profile_id);
+    TrexCpToDpMsgBase *msg = new TrexAstfDpCreateTcp(m_dp_profile_id, m_factor, astf_db);
     m_astf_obj->send_message_to_all_dp(msg);
 }
 
@@ -950,7 +954,8 @@ void TrexAstfPerProfile::cleanup() {
 
     m_astf_obj->handle_stop_latency();
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpDeleteTcp(m_dp_profile_id, false);
+    auto astf_db = CAstfDB::instance(m_dp_profile_id);
+    TrexCpToDpMsgBase *msg = new TrexAstfDpDeleteTcp(m_dp_profile_id, false, astf_db);
     m_astf_obj->send_message_to_all_dp(msg);
 }
 
@@ -979,6 +984,7 @@ void TrexAstfPerProfile::all_dp_cores_finished() {
             profile_change_state(STATE_LOADED);
             break;
         case STATE_DELETE:
+            CAstfDB::free_instance(m_dp_profile_id);
             publish_astf_profile_clear();
             {
                 auto astf = m_astf_obj;

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -26,6 +26,8 @@ limitations under the License.
 #include <algorithm>
 #include "trex_dp_core.h"
 
+class CAstfDB;
+
 struct profile_param {
     profile_id_t    m_profile_id;
     double          m_duration;
@@ -52,10 +54,10 @@ public:
     void start_transmit(profile_id_t profile_id, double duration, bool nc);
     void stop_transmit(profile_id_t profile_id, uint32_t stop_id);
     void update_rate(profile_id_t profile_id, double ratio);
-    void create_tcp_batch(profile_id_t profile_id, double factor);
-    void delete_tcp_batch(profile_id_t profile_id, bool do_remove);
-    void parse_astf_json(profile_id_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
-    void remove_astf_json(profile_id_t profile_id);
+    void create_tcp_batch(profile_id_t profile_id, double factor, CAstfDB* astf_db);
+    void delete_tcp_batch(profile_id_t profile_id, bool do_remove, CAstfDB* astf_db);
+    void parse_astf_json(profile_id_t profile_id, std::string *profile_buffer, std::string *topo_buffer, CAstfDB* astf_db);
+    void remove_astf_json(profile_id_t profile_id, CAstfDB* astf_db);
 
     void scheduler(bool activate);
 

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -111,49 +111,52 @@ TrexCpToDpMsgBase* TrexAstfDpUpdate::clone() {
 /*************************
   create tcp batch
  ************************/
-TrexAstfDpCreateTcp::TrexAstfDpCreateTcp(profile_id_t profile_id, double factor) {
+TrexAstfDpCreateTcp::TrexAstfDpCreateTcp(profile_id_t profile_id, double factor, CAstfDB* astf_db) {
     m_profile_id = profile_id;
     m_factor = factor;
+    m_astf_db = astf_db;
 }
 
 bool TrexAstfDpCreateTcp::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->create_tcp_batch(m_profile_id, m_factor);
+    astf_core(dp_core)->create_tcp_batch(m_profile_id, m_factor, m_astf_db);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpCreateTcp::clone() {
-    return new TrexAstfDpCreateTcp(m_profile_id, m_factor);
+    return new TrexAstfDpCreateTcp(m_profile_id, m_factor, m_astf_db);
 }
 
 /*************************
   delete tcp batch
  ************************/
-TrexAstfDpDeleteTcp::TrexAstfDpDeleteTcp(profile_id_t profile_id, bool do_remove) {
+TrexAstfDpDeleteTcp::TrexAstfDpDeleteTcp(profile_id_t profile_id, bool do_remove, CAstfDB* astf_db) {
     m_profile_id = profile_id;
     m_do_remove = do_remove;
+    m_astf_db = astf_db;
 }
 
 bool TrexAstfDpDeleteTcp::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->delete_tcp_batch(m_profile_id, m_do_remove);
+    astf_core(dp_core)->delete_tcp_batch(m_profile_id, m_do_remove, m_astf_db);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpDeleteTcp::clone() {
-    return new TrexAstfDpDeleteTcp(m_profile_id, m_do_remove);
+    return new TrexAstfDpDeleteTcp(m_profile_id, m_do_remove, m_astf_db);
 }
 
 
 /*************************
   parse ASTF JSON from string
  ************************/
-TrexAstfLoadDB::TrexAstfLoadDB(profile_id_t profile_id, string *profile_buffer, string *topo_buffer) {
+TrexAstfLoadDB::TrexAstfLoadDB(profile_id_t profile_id, string *profile_buffer, string *topo_buffer, CAstfDB* astf_db) {
     m_profile_id     = profile_id;
     m_profile_buffer = profile_buffer;
     m_topo_buffer    = topo_buffer;
+    m_astf_db        = astf_db;
 }
 
 bool TrexAstfLoadDB::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->parse_astf_json(m_profile_id, m_profile_buffer, m_topo_buffer);
+    astf_core(dp_core)->parse_astf_json(m_profile_id, m_profile_buffer, m_topo_buffer, m_astf_db);
     return true;
 }
 
@@ -165,12 +168,13 @@ TrexCpToDpMsgBase* TrexAstfLoadDB::clone() {
 /*************************
   remove ASTF JSON and DB
  ************************/
-TrexAstfDeleteDB::TrexAstfDeleteDB(profile_id_t profile_id) {
+TrexAstfDeleteDB::TrexAstfDeleteDB(profile_id_t profile_id, CAstfDB* astf_db) {
     m_profile_id     = profile_id;
+    m_astf_db        = astf_db;
 }
 
 bool TrexAstfDeleteDB::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->remove_astf_json(m_profile_id);
+    astf_core(dp_core)->remove_astf_json(m_profile_id, m_astf_db);
     return true;
 }
 

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -25,29 +25,30 @@ limitations under the License.
 #include "trex_messaging.h"
 #include "trex_defs.h"
 
+class CAstfDB;
 
 // create tcp batch per DP core
 class TrexAstfDpCreateTcp : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpCreateTcp(profile_id_t profile_id, double factor);
-    TrexAstfDpCreateTcp() : TrexAstfDpCreateTcp(0, -1) {}
+    TrexAstfDpCreateTcp(profile_id_t profile_id, double factor, CAstfDB* astf_db);
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
     profile_id_t m_profile_id;
     double m_factor;
+    CAstfDB* m_astf_db;
 };
 
 // delete tcp batch per DP core
 class TrexAstfDpDeleteTcp : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpDeleteTcp(profile_id_t profile_id, bool do_remove);
-    TrexAstfDpDeleteTcp() : TrexAstfDpDeleteTcp(0, false) {}
+    TrexAstfDpDeleteTcp(profile_id_t profile_id, bool do_remove, CAstfDB* astf_db);
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
     profile_id_t m_profile_id;
     bool m_do_remove;   // to remove profile context explicitly
+    CAstfDB* m_astf_db;
 };
 
 /**
@@ -57,7 +58,6 @@ private:
 class TrexAstfDpStart : public TrexCpToDpMsgBase {
 public:
     TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc);
-    TrexAstfDpStart() : TrexAstfDpStart(0, -1, false) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
@@ -74,7 +74,6 @@ class TrexAstfDpStop : public TrexCpToDpMsgBase {
 public:
     TrexAstfDpStop(profile_id_t profile_id, uint32_t stop_id);
     TrexAstfDpStop(profile_id_t profile_id) : TrexAstfDpStop(profile_id, 0) {}
-    TrexAstfDpStop() : TrexAstfDpStop(0, 0) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
     virtual void on_node_remove();
@@ -105,7 +104,6 @@ private:
 class TrexAstfDpUpdate : public TrexCpToDpMsgBase {
 public:
     TrexAstfDpUpdate(profile_id_t profile_id, double old_new_ratio);
-    TrexAstfDpUpdate(double old_new_ratio) : TrexAstfDpUpdate(0, old_new_ratio) {}
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
@@ -119,14 +117,14 @@ private:
  */
 class TrexAstfLoadDB : public TrexCpToDpMsgBase {
 public:
-    TrexAstfLoadDB(profile_id_t profile_id, std::string *profile_buffer, std::string *topo_buffer);
-    TrexAstfLoadDB(std::string *profile_buffer, std::string *topo_buffer) : TrexAstfLoadDB(0, profile_buffer, topo_buffer) {}
+    TrexAstfLoadDB(profile_id_t profile_id, std::string *profile_buffer, std::string *topo_buffer, CAstfDB* astf_db);
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
     profile_id_t m_profile_id;
     std::string *m_profile_buffer;
     std::string *m_topo_buffer;
+    CAstfDB* m_astf_db;
 };
 
 /**
@@ -135,11 +133,12 @@ private:
  */
 class TrexAstfDeleteDB : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDeleteDB(profile_id_t profile_id);
+    TrexAstfDeleteDB(profile_id_t profile_id, CAstfDB* astf_db);
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
     profile_id_t m_profile_id;
+    CAstfDB* m_astf_db;
 };
 
 /**


### PR DESCRIPTION
Hi,
I've experienced that CAstfDB::m_instances access is not safe between ASTF CP and DP.
In some cases, m_instances.find() failed although the element exist in it.
So, I simply added a mutex lock to access the CAstfDB::m_instance container exclusively.

@hhaim, Please check my changes and give your feedback.