### PR TITLE
fix_checksum_ipv4 and fix_checksum_hw allowed without flow variables …

### DIFF
--- a/src/gtest/trex_stateless_gtest.cpp
+++ b/src/gtest/trex_stateless_gtest.cpp
@@ -1600,6 +1600,24 @@ TEST_F(basic_vm, vm7) {
 
 ////////////////////////////////////////////////////////
 
+TEST_F(basic_vm, vm_no_flow_var) {
+
+    bool fail=false;
+    /* should not be failed */
+
+    try {
+        StreamVm vm;
+        vm.add_instruction( new StreamVmInstructionFixChecksumIpv4(14) );
+        vm.compile(128);
+        uint32_t program_size=vm.get_dp_instruction_buffer()->get_program_size();
+        printf(" program_size : %lu \n",(ulong)program_size);
+     } catch (const TrexException &ex) {
+        fail=true;
+    }
+
+     EXPECT_EQ(false, fail);
+}
+
 TEST_F(basic_vm, vm_mask_err) {
 
     bool fail=false;
@@ -1607,7 +1625,7 @@ TEST_F(basic_vm, vm_mask_err) {
 
     try {
         StreamVm vm;
-        vm.add_instruction( new StreamVmInstructionFixChecksumIpv4(14) );
+        vm.add_instruction( new StreamVmInstructionWriteMaskToPkt("var1", 36,2,0x00ff,0,0,1) );
         vm.compile(128);
         uint32_t program_size=vm.get_dp_instruction_buffer()->get_program_size();
         printf(" program_size : %lu \n",(ulong)program_size);

--- a/src/stx/stl/trex_stl_stream_vm.cpp
+++ b/src/stx/stl/trex_stl_stream_vm.cpp
@@ -707,6 +707,7 @@ void StreamVm::build_program(){
     /* build the commands into a buffer */
     m_instructions.clear();
     int var_cnt=0;
+    int var_ref_cnt=0;
     clean_max_field_cnt();
     uint32_t ins_id=0;
     uint32_t skip=0;
@@ -1113,6 +1114,8 @@ void StreamVm::build_program(){
         if (ins_type == StreamVmInstruction::itPKT_WR) {
             StreamVmInstructionWriteToPkt *lpPkt =(StreamVmInstructionWriteToPkt *)inst;
 
+            var_ref_cnt++;
+
             VmFlowVarRec var;
             if ( var_lookup(lpPkt->m_flow_var_name ,var) == false){
 
@@ -1180,6 +1183,8 @@ void StreamVm::build_program(){
 
         if (ins_type == StreamVmInstruction::itPKT_WR_MASK) {
             StreamVmInstructionWriteMaskToPkt *lpPkt =(StreamVmInstructionWriteMaskToPkt *)inst;
+
+            var_ref_cnt++;
 
             VmFlowVarRec var;
 
@@ -1278,6 +1283,8 @@ void StreamVm::build_program(){
         if (ins_type == StreamVmInstruction::itPKT_SIZE_CHANGE ) {
             StreamVmInstructionChangePktSize *lpPkt =(StreamVmInstructionChangePktSize *)inst;
 
+            var_ref_cnt++;
+
             VmFlowVarRec var;
             if ( var_lookup(lpPkt->m_flow_var_name ,var) == false){
 
@@ -1306,7 +1313,7 @@ void StreamVm::build_program(){
     m_instructions.build_instruction_list();
 
 
-    if ( var_cnt ==0 ){
+    if ( var_ref_cnt > 0 && var_cnt ==0 ){
         std::stringstream ss;
         ss << "It is not valid to have a VM program without a variable  or tuple generator ";
         err(ss.str());


### PR DESCRIPTION
Hi, this PR is prepared for issue #478.
This change makes fix_checksum_ipv4 and fix_checksum_hw available even though there is no flow variable in StreamVm.

@hhaim please check my changes and give your feedback.