### PR TITLE
net/mlx5: do not select legacy MPW implicitly

### DIFF
--- a/src/dpdk/drivers/net/mlx5/mlx5_rxtx.c
+++ b/src/dpdk/drivers/net/mlx5/mlx5_rxtx.c
@@ -5521,6 +5521,9 @@ mlx5_select_tx_function(struct rte_eth_dev *dev)
 			/* Does not meet requested offloads at all. */
 			continue;
 		}
+		if ((olx ^ tmp) & MLX5_TXOFF_CONFIG_MPW)
+			/* Do not enable MPW if not configured. */
+			continue;
 		if ((olx ^ tmp) & MLX5_TXOFF_CONFIG_EMPW)
 			/* Do not enable eMPW if not configured. */
 			continue;


### PR DESCRIPTION
The Legacy MPW (multi-packet write) should not be engaged implicitly.
We should exclude this function form a Tx burst routine selection process
unless it is requested specifically by setting the txq_mpw_en devarg.
Exclude this function from the selection process the same way it is done
for the Enhanced MPW in the mlx5_select_tx_function() routine.

Signed-off-by: Alexander Kozyrev <akozyrev@mellanox.com>