### PR TITLE
fix possible ASTF crash issue derived from #455

### DIFF
--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -89,6 +89,7 @@ void TrexAstfDpCore::set_profile_stopping(profile_id_t profile_id) {
     CGenNodeTXFIF* tx_node = (CGenNodeTXFIF*)pctx->m_tx_node;
     if (tx_node) {
         tx_node->m_pctx = nullptr;  // trigger stopping generate_flow() safely.
+        pctx->m_tx_node = nullptr;  // prevent from unexpected reference.
     }
 }
 


### PR DESCRIPTION
Hi @hhaim, this PR is to fix my faulty code derived from #455.

ASTF DP allows the multiple triggering to stop a profile. The stop_profile_ctx() can call set_profile_stopping() multiple times.
If there is a long lifetime flow in the profile and the duration without `nc` option is short, the profile can live after the duration for a while. Meanwhile, a user requests to stop the profile. It may cause a crash if the CGenNodeTXFIF is allocated for another node like CGenNodeCommand.

I'm sorry for my carelessness in the coding.
