### PR TITLE
Use configured or discovered dest mac addresses

### DIFF
--- a/doc/trex_astf.asciidoc
+++ b/doc/trex_astf.asciidoc
@@ -2809,6 +2809,7 @@ link:cp_astf_docs/index.html[python index]
 |  tunable      | min-max|default| per-template |global| Description  
 |   ip.tos    | uint8 |0 |+|+| ipv4/ipv6 TOS/Class. limitation LSB can't be set as it is used by hardware filter on some NICs 
 |   ip.ttl    | uint8 |0 |+|+| ipv4/ipv6 TTL/TimeToLive. limitation can't be higher than 0x7f as it might used by some hardware filter on some NICs 
+|   ip.dont_use_inbound_mac | bool |0|+|+| server side will use configured src/dest MACs for the port or resolved gateway MAC instead of reflecting incoming MACs
 |   ipv6.src_msb    | string |0 |+|+| default IPv6.src MSB address. see Priority in ipv6 enable
 |   ipv6.dst_msb    | string |0 |+|+| default IPv6.dst MSB address. see Priority in ipv6 enable
 |   ipv6.enable     | bool   |0 |+|+| enable IPv6 for all templates. Priority is given for global (template come next) -- not as other tunable. It means that for mix of ipv4/ipv6 only per template should be used   

--- a/scripts/astf_schema.json
+++ b/scripts/astf_schema.json
@@ -574,6 +574,9 @@
                            },
                            "ttl" : {
                                "type": "integer"
+                           },
+                           "dont_use_inbound_mac" : {
+                                "type": "integer"
                            }
                         }
                     }

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_global_info.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_global_info.py
@@ -126,7 +126,8 @@ class ASTFGlobalInfo(ASTFGlobalInfoBase):
             ],
         "ip": [
             {"name": "tos", "type": [int]},
-            {"name": "ttl", "type": [int]}
+            {"name": "ttl", "type": [int]},
+            {"name": "dont_use_inbound_mac", "type": [int]}
         ],
     }
 
@@ -152,7 +153,8 @@ class ASTFGlobalInfoPerTemplate(ASTFGlobalInfoBase):
             ],
         "ip": [
             {"name": "tos", "type": [int]},
-            {"name": "ttl", "type": [int]}
+            {"name": "ttl", "type": [int]},
+            {"name": "dont_use_inbound_mac", "type": [int]}
         ],
 
        "ipv6": [

--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -244,7 +244,8 @@ public:
                                         CSimplePacketParser & parser,
                                         CFlowKeyTuple & tuple,
                                         CFlowKeyFullTuple & ftuple,
-                                        uint32_t  hash
+                                        uint32_t  hash,
+                                        tvpid_t port_id
                                         );
 
       void process_udp_packet(CTcpPerThreadCtx * ctx,
@@ -260,7 +261,8 @@ public:
                                         CSimplePacketParser & parser,
                                         CFlowKeyTuple & tuple,
                                         CFlowKeyFullTuple & ftuple,
-                                        uint32_t  hash
+                                        uint32_t  hash,
+                                        tvpid_t port_id
                                         );
 
       bool rx_handle_packet(CTcpPerThreadCtx * ctx,
@@ -325,7 +327,8 @@ public:
                       TCPHeader    * lpTcp,
                       uint8_t *   pkt,
                       IPv6Header *    ipv6,
-                      CFlowKeyFullTuple &ftuple);
+                      CFlowKeyFullTuple &ftuple,
+                      tvpid_t port_id);
 
 
     CTcpFlow * alloc_flow(CPerProfileCtx * pctx,

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -489,7 +489,7 @@ public:
         m_proto    = proto;
     }
 
-    void server_update_mac_from_packet(uint8_t *pkt);
+    void server_update_mac(uint8_t *pkt, CTcpPerThreadCtx * ctx, tvpid_t port_id);
 
     void learn_ipv6_headers_from_network(IPv6Header * net_ipv6);
 
@@ -1284,6 +1284,8 @@ public:
     uint16_t tcp_fast_tick_msec;
     uint16_t tcp_slow_fast_ratio;
     int tcp_ttl;            /* time to live for TCP segs */
+
+    uint8_t use_inbound_mac;    /* whether to use MACs from incoming pkts */
 
     //struct    inpcb tcb;      /* head of queue of active tcpcb's */
     uint32_t    tcp_now;        /* for RFC 1323 timestamps */

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -867,6 +867,10 @@ bool CAstfDB::read_tunables(CTcpTuneables *tune, Json::Value tune_json) {
             if (tune->m_ip_ttl>0x7f) {
                 tune->m_ip_ttl = 0x7f;
             }
+
+            if (read_tunable_uint8(tune,json,"dont_use_inbound_mac",CTcpTuneables::dont_use_inbound_mac,tune->m_dont_use_inbound_mac)){
+                tunable_min_max_u32("dont_use_inbound_mac",tune->m_dont_use_inbound_mac,0,1);
+            }
         }
 
         if (tune_json["tcp"] != Json::nullValue) {

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -81,6 +81,7 @@ class CTcpTuneables {
         ip_ttl          =  0x20000,
         ip_tos          =  0x40000,
         tcp_no_delay_counter = 0x80000,
+        dont_use_inbound_mac = 0x100000,
     };
     enum {
         no_delay_mask_nagle = 0x1,
@@ -111,6 +112,7 @@ class CTcpTuneables {
         m_scheduler_accurate=0;
         m_ip_ttl=0;
         m_ip_tos=0;
+        m_dont_use_inbound_mac=0;
 
         memset(m_ipv6_src,0,16);
         memset(m_ipv6_dst,0,16);
@@ -157,7 +159,7 @@ class CTcpTuneables {
     uint16_t m_scheduler_rampup; /* time in sec for rampup*/
     uint8_t  m_ip_ttl;
     uint8_t  m_ip_tos;
-    
+    uint8_t  m_dont_use_inbound_mac;
 
  private:
     uint32_t m_bitfield;


### PR DESCRIPTION
When the generator is used against a DUT that consists of a router (gateway) and a device that performs Direct Server Return, or any setup where traffic on a port is asymmetrical in terms of
layer2 counterpart, the source mac address of incoming packets should not be used as destination for outgoing packets of a flow. Instead the configured 'dest_mac' or discovered (ARP) mac address
of the configured 'default_gw' should be used.

Note1: I don't fully understand all trex modes and I wasn't sure that always using the configured/discovered mac would be appropriate. So I introduced this CGlobalInfo::m_options.is_mac_set() check (mainly to avoid a memcmp(empty_mac)) but, except in the case of client config, the configured/discovered mac will always be used for flow templates. If it's also appropriate for the case of client config, then the flag and check could be removed.

Note2: With this change, the mac is now copied from CGlobalInfo::m_options instead of from the incoming packet that triggers to creation of the new server-side flow. This may have a performance impact as this global config might not be as "hot" as the packet data. Though it will be used at each new flow, but this global data did not seem to be laid out with the same performance focus as some others... I did not have the opportunity to make any performance comparison as my use case only works with the change...