### PR TITLE
Fixed send by size causes crash in multicore

### DIFF
--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -934,7 +934,10 @@ int utl_mbuf_buffer_create_and_copy(uint8_t socket,
         uint32_t alloc_size = bsd_umin(blk_size,size);
         auto copy_size = bsd_umin(d_size, alloc_size);
         rte_mbuf_t* m;
-        if (copy_size || !mbuf_fill) {
+        if (mbuf_fill && (alloc_size == blk_size)) {
+            m = mbuf_fill;
+            rte_mbuf_refcnt_update(m, 1);
+        } else {
             m = tcp_pktmbuf_alloc(socket,alloc_size);
             assert(m);
             char *p = (char *)rte_pktmbuf_append(m, alloc_size);
@@ -943,8 +946,7 @@ int utl_mbuf_buffer_create_and_copy(uint8_t socket,
                 d += copy_size;
                 p += copy_size;
                 d_size -= copy_size;
-            } else {
-                rte_mbuf_set_as_core_local(m);
+            } else if (!mbuf_fill) {
                 mbuf_fill = m; // filled data reference mbuf
             }
             for (auto i = 0; i < (alloc_size-copy_size); i++ ) {
@@ -952,15 +954,6 @@ int utl_mbuf_buffer_create_and_copy(uint8_t socket,
                 cnt++;
                 p++;
             }
-        } else if (alloc_size == blk_size) {
-            m = mbuf_fill;
-            rte_mbuf_refcnt_update(m, 1);
-        } else {
-            m = tcp_pktmbuf_alloc_small(socket);
-            assert(m);
-            rte_mbuf_set_as_core_local(m);
-            rte_pktmbuf_attach(m, mbuf_fill);
-            rte_pktmbuf_trim(m, blk_size-alloc_size);
         }
         CMbufObject obj;
         obj.m_type =MO_CONST;


### PR DESCRIPTION
Hi, this PR is to fix the crash in multicore usage.

Although the program buffers are created and removed in one core, it can be referenced in multiple cores at `tcp_build_dpkt_`.
```
            if (unlikely(!rb.need_indirect_mbuf(dlen))){
                /* last one */
                rte_pktmbuf_refcnt_update(mn,1);
                lastm->next =mn;
                bsize = rb.get_mbuf_size();
            }else{
```
Since `rte_mbuf_set_as_core_local(m)` should be used for single-core access, it should be removed from the program buffers.

@hhaim, please check my change and give your opinion.