### PR TITLE
Add Fix Icmpv6 FE instruction

### DIFF
--- a/doc/trex_rpc_server_spec.asciidoc
+++ b/doc/trex_rpc_server_spec.asciidoc
@@ -50,6 +50,10 @@ include::trex_ga.asciidoc[]
 | 1.9    | Egor Blagov (eblagov)
 |
 - add stack name in `get_system_info`
+| 1.10   | Egor Blagov (eblagov)
+|
+- update VM instructions 
+
 
 |=================
 
@@ -1347,6 +1351,19 @@ Fix TCP/UDP and IPv4 headers using hardware assit engine
 | Field       | Type        | Description
 | type        | string      | ''fix_checksum_ipv4''
 | pkt_offset  | uint16      | offset of the field to fix 
+|=================
+
+===== fix_checksum_icmpv6
+
+Fix ICMPv6 layer checksum on top of IPv6 using software
+
+.Object type 'vm - fix_checksum_icmpv6'
+[options="header",cols="1,1,3"]
+|=================
+| Field       | Type        | Description
+| type        | string      | ''fix_checksum_icmpv6''
+| l2_len      | uint16      | len of L2 (e.g. 22 Ether + Dot1Q + Dot1Q)
+| l3_len      | uint16      | len of l3 header (e.g. 40 for IPv6)
 |=================
 
 ===== flow_var

--- a/scripts/automation/regression/functional_tests/stl_basic_tests.py
+++ b/scripts/automation/regression/functional_tests/stl_basic_tests.py
@@ -288,6 +288,7 @@ class CStlBasic_Test(functional_general_test.CGeneralFunctional_Test):
         exclude_list = [
             'imix_wlc.py',          # expects tunables
             'udp_1pkt_vxlan.py',    # uses custom Scapy layer
+            'icmpv6_fix_cs.py',     # cannot parse layer name from offset correctly (ICMPv6ND_NS classname and layer name do not match)
             ]
         exclude_dict = {}.fromkeys(exclude_list)
         output_file = os.path.join(self.generated_path, 'exported_to_code.py')

--- a/scripts/automation/trex_control_plane/doc_stl/api/field_engine.rst
+++ b/scripts/automation/trex_control_plane/doc_stl/api/field_engine.rst
@@ -148,6 +148,16 @@ STLVmFixIpv4
     :members: 
     :member-order: bysource
  
+ 
+
+STLVmFixIcmpv6
+------------------
+
+.. autoclass:: trex.stl.trex_stl_packet_builder_scapy.STLVmFixIcmpv6
+    :members: 
+    :member-order: bysource
+ 
+
 
 STLVmTrimPktSize
 ------------------

--- a/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_simple_nd.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_simple_nd.py
@@ -51,7 +51,7 @@ try:
     c.set_service_mode(port)
     
 
-    capture_id = c.start_capture(rx_ports = port)['id'] # here we should have rx
+    capture_id = c.start_capture(rx_ports = port)['id']
 
     # starting and waiting for traffic
     c.start(ports = port, force = True)

--- a/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_simple_nd.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/stl/stl_simple_nd.py
@@ -1,0 +1,98 @@
+import stl_path
+from trex.stl.api import *
+import time
+import ipaddress
+import sys
+
+
+def inc_ip(ip, add):
+    ip_arg = ip
+
+    if sys.version_info < (3,):
+        ip_arg = ip.decode()
+
+    return str(ipaddress.ip_address(ip_arg) + add)
+
+
+c = STLClient()
+passed = True
+
+port = 0
+source_ipv6_start = '2001:db8::1:100'
+target_ipv6 = '2001:db8::1:1'
+mcast_dst_ipv6 = 'ff02::1:ff01:1'
+mcast_dst_mac = '33:33:00:01:00:01'
+count = 10
+
+try:
+    # connect to server
+    c.connect()
+
+    # preparing the stream
+    pkt_base = Ether(dst=mcast_dst_mac)/IPv6(src=source_ipv6_start, dst=mcast_dst_ipv6, hlim=255)/ICMPv6ND_NS(tgt=target_ipv6)
+    pkt_base /= ICMPv6NDOptSrcLLAddr(lladdr=c.get_port(port).get_layer_cfg()['ether']['src'])
+    vm = [
+        STLVmFlowVar(name="src", min_value=1, max_value=count, size=1, op="inc"),
+        STLVmWrFlowVar(fv_name="src", pkt_offset= "IPv6.src", offset_fixup=15),
+        STLVmFixIcmpv6(l3_offset = "IPv6", l4_offset=ICMPv6ND_NS().name)
+    ]
+    pkt = STLPktBuilder(pkt = pkt_base, vm = vm)
+    stream = STLStream(packet = pkt, mode = STLTXSingleBurst(pps = 100, total_pkts = count))
+    
+
+    # prepare our ports
+    c.reset(ports = port)
+    c.set_port_attr(promiscuous=True)
+
+    # add stream to port
+    c.add_streams(stream, ports = port)
+
+    # starting the capture
+    c.set_service_mode(port)
+    
+
+    capture_id = c.start_capture(rx_ports = port)['id'] # here we should have rx
+
+    # starting and waiting for traffic
+    c.start(ports = port, force = True)
+    c.wait_on_traffic(ports = port)
+    time.sleep(5)
+
+    # getting the captured packets
+    packets = []
+    c.stop_capture(capture_id, output=packets)
+
+    # validating NA response presents within captured packets
+    expected_targets = [inc_ip(source_ipv6_start, 1 + i) for i in range(count)]
+
+    for p in packets:
+        scapy_pkt = Ether(p['binary'])
+        if ICMPv6ND_NA in scapy_pkt:
+            found_ip = scapy_pkt[IPv6].dst
+            print('Found NA for {}'.format(found_ip))
+            expected_targets.remove(found_ip)
+
+    for target in expected_targets:
+        print('Warning, NA for {} was not found'.format(target))
+
+
+    passed = not expected_targets
+
+except STLError as e:
+    passed = False
+    print(e)
+
+finally:
+    c.disconnect()
+
+if c.get_warnings():
+        print("\n\n*** test had warnings ****\n\n")
+        for w in c.get_warnings():
+            print(w)
+
+if passed and not c.get_warnings():
+    print("\nTest has passed :-)\n")
+else:
+    print("\nTest has failed :-(\n")
+
+

--- a/scripts/automation/trex_control_plane/interactive/trex/scapy_server/field_engine.json
+++ b/scripts/automation/trex_control_plane/interactive/trex/scapy_server/field_engine.json
@@ -31,6 +31,10 @@
     {
       "id": "STLVmFixChecksumHw",
       "parameters": ["l3_offset","l4_offset","l4_type"]
+    },
+    {
+      "id": "STLVmFixIcmpv6",
+      "parameters": ["l3_offset", "l4_offset"]
     }
   ],
 

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_streams.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_streams.py
@@ -625,7 +625,7 @@ class STLStream(object):
         if name in inst:
             ret = pkt.get_field_by_offset(inst[name])
             if ret:
-                if inst['type'] in ('fix_checksum_ipv4', 'fix_checksum_hw'): # do not include field name
+                if inst['type'] in ('fix_checksum_ipv4', 'fix_checksum_hw', 'fix_checksum_icmpv6'): # do not include field name
                     if ret[1] == 0: # layer index is redundant
                         inst[name] = "'%s'" % ret[0]
                     else: 
@@ -695,6 +695,12 @@ class STLStream(object):
                 self.__fix_offset_by_name(pkt, inst, 'l3_offset')
                 self.__fix_offset_by_name(pkt, inst, 'l4_offset')
                 vm_list.append("vm.fix_chksum_hw(l3_offset={l3_offset}, l4_offset={l4_offset}, l4_type={l4_type})".format(**inst))
+            elif inst['type'] == 'fix_checksum_icmpv6':
+                inst['l3_offset'] = inst['l2_len']
+                inst['l4_offset'] = inst['l2_len'] + inst['l3_len']
+                self.__fix_offset_by_name(pkt, inst, 'l3_offset')
+                self.__fix_offset_by_name(pkt, inst, 'l4_offset')
+                vm_list.append("vm.fix_chksum_icmpv6(l3_offset={l3_offset}, l4_offset={l4_offset})".format(**inst))
             elif inst['type'] == 'trim_pkt_size':
                 vm_list.append("vm.trim(fv_name='{name}')".format(**inst))
             elif inst['type'] == 'tuple_flow_var':

--- a/scripts/stl/icmpv6_fix_cs.py
+++ b/scripts/stl/icmpv6_fix_cs.py
@@ -1,0 +1,51 @@
+from trex_stl_lib.api import *
+
+class STLS1(object):
+
+    def __init__ (self):
+        self.max_pkt_size_l3  =9*1024;
+
+    def create_stream_icmpv6_nd_ns (self):
+        target_addr = "2001:0:4137:9350:8000:f12a:b9c8:2815"
+
+        # ICMPv6 NS packet
+        base_pkt = Ether()/IPv6(dst=target_addr, src="2001:4860:0:2001::68")/ICMPv6ND_NS(tgt=target_addr)
+
+        # vm
+        vm = STLScVmRaw( [ STLVmFlowVar(name="ip_dst", 
+                                        min_value="16.0.0.0", 
+                                        max_value="18.0.0.254", 
+                                        size=4, op="random"),
+
+                           STLVmWrFlowVar(fv_name="ip_dst", pkt_offset ="IPv6.dst", offset_fixup=12),
+                           STLVmWrFlowVar(fv_name="ip_dst",
+                                          # actual ICMPv6 NS layer name in scapy notation is
+                                          # 'ICMPv6 Neighbor Discovery - Neighbor Solicitation'
+                                          # which is too verbose
+                                          pkt_offset ="{}.tgt".format(base_pkt[2].name),
+                                          offset_fixup=12),
+
+                           # must be last 
+                           STLVmFixIcmpv6(l3_offset = "IPv6",
+                                          l4_offset = base_pkt[2].name)
+
+                          ]
+                       )
+
+        pkt = STLPktBuilder(pkt = base_pkt,
+                            vm = vm)
+
+        return STLStream(packet = pkt,
+                         random_seed = 0x1234,
+                         mode = STLTXCont())
+
+    def get_streams (self, direction = 0, **kwargs):
+        return [ self.create_stream_icmpv6_nd_ns()]
+
+
+# dynamic load - used for trex console or simulator
+def register():
+    return STLS1()
+
+
+

--- a/src/common/Network/Packet/IcmpHeader.h
+++ b/src/common/Network/Packet/IcmpHeader.h
@@ -64,6 +64,7 @@ public:
 
     inline  void setChecksum(uint16_t data);
     inline  uint16_t getChecksum();
+    inline  void setChecksumRaw(uint16_t data);
 
     inline void updateCheckSum(uint16_t len);
     inline bool isCheckSumOk(uint16_t len);

--- a/src/common/Network/Packet/IcmpHeader.inl
+++ b/src/common/Network/Packet/IcmpHeader.inl
@@ -64,6 +64,11 @@ inline uint16_t ICMPHeader::getChecksum()
     return PKT_NTOHS(myChecksum);
 }
 
+inline void ICMPHeader::setChecksumRaw(uint16_t argNewChecksum)
+{
+    myChecksum = argNewChecksum;
+}
+
 inline void ICMPHeader::updateCheckSum(uint16_t len)
 {
 	setChecksum(0);// must be here 

--- a/src/stx/stl/trex_stl_rpc_cmds.cpp
+++ b/src/stx/stl/trex_stl_rpc_cmds.cpp
@@ -76,6 +76,7 @@ void validate_stream(string profile_id, const std::unique_ptr<TrexStream> &strea
 void parse_vm(const Json::Value &vm, std::unique_ptr<TrexStream> &stream, Json::Value &result);
 void parse_vm_instr_checksum(const Json::Value &inst, std::unique_ptr<TrexStream> &stream, Json::Value &result);
 void parse_vm_instr_checksum_hw(const Json::Value &inst, std::unique_ptr<TrexStream> &stream, Json::Value &result);
+void parse_vm_instr_checksum_icmpv6(const Json::Value &inst, std::unique_ptr<TrexStream> &stream, Json::Value &result);
 
 void parse_vm_instr_flow_var(const Json::Value &inst, std::unique_ptr<TrexStream> &stream, Json::Value &result);
 void parse_vm_instr_flow_var_rand_limit(const Json::Value &inst, std::unique_ptr<TrexStream> &stream, Json::Value &result);
@@ -601,6 +602,14 @@ TrexRpcCmdAddStream::parse_vm_instr_checksum_hw(const Json::Value &inst, std::un
     stream->m_vm.add_instruction(new StreamVmInstructionFixHwChecksum(l2_len,l3_len,l4_type));
 }
 
+void
+TrexRpcCmdAddStream::parse_vm_instr_checksum_icmpv6(const Json::Value &inst, std::unique_ptr<TrexStream> &stream, Json::Value &result) {
+    uint16_t l2_len = parse_uint16(inst, "l2_len", result); 
+    uint16_t l3_len = parse_uint16(inst, "l3_len", result); 
+
+    stream->m_vm.add_instruction(new StreamVmInstructionFixChecksumIcmpv6(l2_len, l3_len));
+}
+
 void 
 TrexRpcCmdAddStream::parse_vm_instr_checksum(const Json::Value &inst, std::unique_ptr<TrexStream> &stream, Json::Value &result) {
 
@@ -926,7 +935,7 @@ TrexRpcCmdAddStream::parse_vm(const Json::Value &vm, std::unique_ptr<TrexStream>
     for (int i = 0; i < instructions.size(); i++) {
         const Json::Value & inst = parse_object(instructions, i, result);
 
-        auto vm_types = {"fix_checksum_hw", "fix_checksum_ipv4", "flow_var", "write_flow_var","tuple_flow_var","trim_pkt_size","write_mask_flow_var","flow_var_rand_limit"};
+        auto vm_types = {"fix_checksum_hw", "fix_checksum_ipv4", "fix_checksum_icmpv6", "flow_var", "write_flow_var","tuple_flow_var","trim_pkt_size","write_mask_flow_var","flow_var_rand_limit"};
         std::string vm_type = parse_choice(inst, "type", vm_types, result);
 
         // checksum instruction
@@ -936,6 +945,9 @@ TrexRpcCmdAddStream::parse_vm(const Json::Value &vm, std::unique_ptr<TrexStream>
         } else if (vm_type == "fix_checksum_hw") {
 
             parse_vm_instr_checksum_hw(inst, stream, result);
+
+        } else if (vm_type == "fix_checksum_icmpv6") {
+            parse_vm_instr_checksum_icmpv6(inst, stream, result);
 
         } else if (vm_type == "flow_var") {
             parse_vm_instr_flow_var(inst, stream, result);

--- a/src/stx/stl/trex_stl_stream_vm.h
+++ b/src/stx/stl/trex_stl_stream_vm.h
@@ -721,8 +721,7 @@ public:
 
 
 
-static inline HOT_FUNC uint16_t csum_reduce(uint32_t sum)
-{
+static inline HOT_FUNC uint16_t csum_reduce(uint32_t sum) {
      /* two folds are required */
     sum = (sum & 0xffff) + (sum >> 16);
     sum = (sum & 0xffff) + (sum >> 16);
@@ -747,13 +746,12 @@ static inline HOT_FUNC uint16_t fast_csum(const void *iph, unsigned int ihl) {
 }
 
 
-static inline HOT_FUNC uint16_t
-csum_ipv6_psd_raw(IPv6Header* ipv6) {
+static inline HOT_FUNC uint16_t csum_ipv6_psd_raw(IPv6Header* ipv6) {
     struct {
         uint8_t src_addr[16];
         uint8_t dst_addr[16];
-        uint32_t len;
-        uint32_t proto;
+        volatile uint32_t len;
+        volatile uint32_t proto;
     } __attribute__((packed)) ipv6_psdhdr;
 
     memcpy(&ipv6_psdhdr.src_addr, &ipv6->mySource, sizeof(ipv6_psdhdr.src_addr));


### PR DESCRIPTION
- Add software based Field Engine instruction to fix ICMPv6 checksum
- Add functional tests
- Add examples

NOTES:

- I didn't get whether we could use `rte_raw_cksum` and corresponding methods, but I've used software FixIpv4 instruction as sample, hence extended `fast_csum`, and implemented ipv6 pseudo header checksum calculation
- stl packet builder scapy cannot find out offset names for some packet types (e.g. `ICMPv6ND_NA`, because they have static field `name` which doesn't match classname, however in `trex_stl_packet_builder_scapy.py` we use this construction  to obtain layer name from offset number
```python
# ...
    for pkt in self.pkt_iter():
            layer_name = pkt.__class__.__name__
            if pkt._offset > offset_int:
                break
# ...
```

I suppose this should be fixed (if possible) in separate PR.
- I'm not sure whether we should use one instruction for ICMP and ICMPv6, but I need ICMPv6 only, that's why I've implemented it alone.

