### PR TITLE
Increment STL API version

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -117,7 +117,7 @@ class STLClient(TRexClient):
 
         """
 
-        api_ver = {'name': 'STL', 'major': 4, 'minor': 7}
+        api_ver = {'name': 'STL', 'major': 4, 'minor': 8}
 
         TRexClient.__init__(self,
                             api_ver,

--- a/src/stx/stl/trex_stl.cpp
+++ b/src/stx/stl/trex_stl.cpp
@@ -163,7 +163,7 @@ TrexStatelessMulticoreSoftwareFSLatencyStats::reset_rx_stats(uint8_t port_id, co
 TrexStateless::TrexStateless(const TrexSTXCfg &cfg) : TrexSTX(cfg) {
     /* API core version */
     const int API_VER_MAJOR = 4;
-    const int API_VER_MINOR = 7;
+    const int API_VER_MINOR = 8;
     
     /* init the RPC table */
     TrexRpcCommandsTable::get_instance().init("STL", API_VER_MAJOR, API_VER_MINOR);


### PR DESCRIPTION
When I submitted PR for icmpv6 fix, I took FE value_list PR as reference, and forgot about STL API version increment, but I think it's requred. PLS correct if I'm wrong.


- FE instruction was added, and newer client will show error with older trex about
  unknown instruction type

Signed-off-by: Egor Blagov <e.m.blagov@gmail.com>