### PR TITLE
Remove ASTF DP flow node consumption for the profile duration.

### DIFF
--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -74,6 +74,9 @@ limitations under the License.
 #include "stl/trex_stl_fs.h"
 #include "hot_section.h"
 
+/* astf includes */
+#include "astf/trex_astf_dp_core.h"
+
 class CGenNodePCAP;
 
 #define FORCE_NO_INLINE __attribute__ ((noinline))
@@ -661,8 +664,9 @@ class CPerProfileCtx;
 struct CGenNodeTXFIF : public CGenNodeBase {
 public:
     CPerProfileCtx *    m_pctx;
+    double              m_time_stop;
 
-    uint8_t             m_pad_end[104];
+    uint8_t             m_pad_end[96];
 
     /* CACHE_LINE */
 #ifdef __PPC64__

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -273,6 +273,7 @@ void TrexAstfDpCore::start_profile_ctx(profile_id_t profile_id, double duration,
 
         tx_node->m_type = CGenNode::TCP_TX_FIF;
         tx_node->m_time = m_core->m_cur_time_sec + d_phase + 0.1; /* phase the transmit a bit */
+        tx_node->m_time_stop = (duration > 0) ? tx_node->m_time + duration : 0.0;
         tx_node->m_pctx = m_flow_gen->m_c_tcp->get_profile_ctx(profile_id);
         tx_node->m_pctx->m_tx_node = tx_node;
         m_flow_gen->m_node_gen.add_node((CGenNode*)tx_node);
@@ -281,8 +282,8 @@ void TrexAstfDpCore::start_profile_ctx(profile_id_t profile_id, double duration,
     set_profile_active(profile_id);
     set_profile_nc(profile_id, nc);
 
-    if ( duration > 0 ) {
-        add_profile_duration(profile_id, duration + d_phase + 1.0);
+    if ( disable_client && duration > 0 ) {
+        add_profile_duration(profile_id, duration + d_phase);
     }
 }
 
@@ -498,6 +499,12 @@ void TrexAstfDpCore::stop_transmit(profile_id_t profile_id, uint32_t stop_id) {
         report_error(profile_id, "Stop in unexpected DP core state: " + std::to_string(m_state));
         break;
     }
+}
+
+void TrexAstfDpCore::stop_transmit(profile_id_t profile_id) {
+    uint32_t tmp_stop_id = -1;
+    set_profile_stop_id(profile_id, tmp_stop_id);
+    stop_transmit(profile_id, tmp_stop_id);
 }
 
 void TrexAstfDpCore::scheduler(bool activate) {

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -53,6 +53,7 @@ public:
 
     void start_transmit(profile_id_t profile_id, double duration, bool nc);
     void stop_transmit(profile_id_t profile_id, uint32_t stop_id);
+    void stop_transmit(profile_id_t profile_id);
     void update_rate(profile_id_t profile_id, double ratio);
     void create_tcp_batch(profile_id_t profile_id, double factor, CAstfDB* astf_db);
     void delete_tcp_batch(profile_id_t profile_id, bool do_remove, CAstfDB* astf_db);

--- a/src/stx/astf_batch/trex_astf_batch.cpp
+++ b/src/stx/astf_batch/trex_astf_batch.cpp
@@ -100,6 +100,7 @@ TrexDpCoreAstfBatch::start_astf() {
         CGenNodeTXFIF *tx_node = (CGenNodeTXFIF*)m_core->create_node();
         tx_node->m_type = CGenNode::TCP_TX_FIF;
         tx_node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
+        tx_node->m_time_stop = 0.0;
         tx_node->m_pctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
         m_core->m_node_gen.add_node((CGenNode*)tx_node);
     }


### PR DESCRIPTION
Hi, this PR removes the DP flow node consumption for profile duration in ASTF mode.

Since the number of DP flow nodes is a constant 8192, maximum number of running profiles is limited by this number. If all profiles are running with duration, they will be half of without duration.
So, I'd like to remove this restriction. My change reuses TCP_TX_FIF node to trigger stopping profile after duration.

@hhaim, please check my changes and give your feedback.