### PR TITLE
Added ASTF profile start reports error for no available node memory

### DIFF
--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -1013,6 +1013,7 @@ void TrexAstfPerProfile::dp_core_error(const string &err) {
             m_error = err;
             break;
         case STATE_BUILD:
+        case STATE_TX:
             m_error = err;
             break;
         default:

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -450,6 +450,13 @@ void TrexAstfDpCore::start_transmit(profile_id_t profile_id, double duration, bo
         report_error(profile_id, "Start of invalid profile state " + std::to_string(get_profile_state(profile_id)));
         return;
     }
+#ifndef TREX_SIM
+    /* prevent from no_memory_error, reserve 1 for add_global_duration */
+    if (rte_mempool_avail_count(m_flow_gen->m_node_pool) <= 1) {
+        report_error(profile_id, "Not enough node object to start_transmit");
+        return;
+    }
+#endif
 
     set_profile_state(profile_id, pSTATE_STARTING);
 


### PR DESCRIPTION
Hi, this PR is to prevent server crash from no available node memory.

Currently, if `create_node()` is failed due to lack of node memory, it raises TRex server crash. But I think It's not appropriate because there are many profiles are running successfully already. So I think it is better to reject the last profile request.

@hhaim please check my changes and give your feedback.