### PR TITLE
prevent crash from possible null astf_db case

### DIFF
--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -376,7 +376,9 @@ void TrexAstfDpCore::remove_astf_json(profile_id_t profile_id, CAstfDB* astf_db)
     // try removing the profile_ctx which contains statistics.
     m_flow_gen->remove_tcp_profile(profile_id);
 
-    astf_db->Delete();
+    if (astf_db) {
+        astf_db->Delete();
+    }
     report_finished(profile_id);
 }
 

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -465,6 +465,9 @@ TrexRpcCmdAstfGetTrafficDist::_run(const Json::Value &params, Json::Value &resul
     TrexAstfPerProfile *pid = get_astf_object()->get_profile(profile_id);
 
     auto db = CAstfDB::instance(pid->get_dp_profile_id());
+    if (!db) {
+        generate_execute_err(result, "No DB found for profile : " + profile_id);
+    }
     auto stx = get_astf_object();
     auto &api = get_platform_api();
 


### PR DESCRIPTION
Hi, I found another null pointer access possibility derived from the change #457.
Since remove_astf_json can receive null astf_db, I added the null pointer check.

@hhaim, please check my change and give your feedback.