### PR TITLE
Use ==/!= operators for literal comparisons

### DIFF
--- a/scripts/automation/regression/functional_tests/trex_cfg_creator_test.py
+++ b/scripts/automation/regression/functional_tests/trex_cfg_creator_test.py
@@ -34,11 +34,11 @@ def create_config(cpu_topology, interfaces, *args, **kwargs):
 def verify_master_core0(output):
     output_yaml = yaml.safe_load(output)
     assert type(output_yaml) is list, 'Generated YAML should be list'
-    assert len(output_yaml) is 1, 'Generated YAML should be list with 1 element'
+    assert len(output_yaml) == 1, 'Generated YAML should be list with 1 element'
     output_yaml = output_yaml[0]
     assert 'platform' in output_yaml, 'Generated YAML has no platform section:\n%s' % output
     assert 'master_thread_id' in output_yaml['platform'], 'Generated YAML does not specify master thread id:\n%s' % output
-    assert output_yaml['platform']['master_thread_id'] is 0, 'Master thread id should be 0 in generated YAML, got:%s' % output_yaml['platform']['master_thread_id']
+    assert output_yaml['platform']['master_thread_id'] == 0, 'Master thread id should be 0 in generated YAML, got:%s' % output_yaml['platform']['master_thread_id']
 
 class TRexCfgCreator_Test:
 

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -305,7 +305,7 @@ class ASTFClient(TRexClient):
             bad_states = listify(bad_states)
 
         self.wait_for_steady()
-        if rpc_func is 'start' and self.state is not self.STATE_TX:
+        if rpc_func == 'start' and self.state is not self.STATE_TX:
             self.inc_epoch()
 
         self.sync_waiting = True

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -1096,12 +1096,12 @@ class ASTFIPGen(object):
 
         self.fields = {}
         self.fields['dist_client'] = dist_client
-        if dist_client.direction and dist_client.direction is not "c":
+        if dist_client.direction and dist_client.direction != "c":
             raise ASTFError("dist_client.direction is already dir:{0}".format(dist_client.direction))
         dist_client.direction = "c"
         dist_client.ip_offset = glob.ip_offset
         self.fields['dist_server'] = dist_server
-        if dist_server.direction and dist_server.direction is not "s":
+        if dist_server.direction and dist_server.direction != "s":
             raise ASTFError("dist_server.direction is already dir:{0}".format(dist_server.direction))
         dist_server.direction = "s"
         dist_server.ip_offset = glob.ip_offset
@@ -1784,7 +1784,7 @@ class ASTFProfile(object):
                 else:
                     if mode == "l7_percent" and l7_percent is None:
                         raise ASTFError("If one cap specifies l7_percent, then all should specify it")
-                    if mode is "cps" and l7_percent is not None:
+                    if mode == "cps" and l7_percent is not None:
                         raise ASTFError("Can't mix specifications of cps and l7_percent in same cap list")
 
                 total_payload += prog_c.payload_len

--- a/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
@@ -1274,7 +1274,7 @@ class AsyncKeysEngineConsole:
         if not common:
             common = partial
 
-        tokens.append(os.path.join(d, common) if d is not '.' else common)
+        tokens.append(os.path.join(d, common) if d != '.' else common)
 
         # reforge the line
         newline = ' '.join(tokens)

--- a/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_service.py
@@ -550,7 +550,7 @@ class Scapy_service(Scapy_service_api):
         protocol_str = self._protocol_struct(p_name)
         if protocol_str=='protocol not supported':
             return 'protocol not supported'
-        if len(protocol_str) is 0:
+        if len(protocol_str) == 0:
             return []
         tupled_protocol = self._parse_entire_description(protocol_str)
         return tupled_protocol

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_hltapi.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_hltapi.py
@@ -810,7 +810,7 @@ def STLHltStream(**user_kwargs):
         rate_key = intersect_rate_args[0]
     except IndexError:
         rate_key = 'rate_percent'
-    if rate_key is 'rate_percent' and float(kwargs['rate_percent']) > 100:
+    if rate_key == 'rate_percent' and float(kwargs['rate_percent']) > 100:
         raise STLError('rate_percent should not exceed 100%')
 
     if kwargs['length_mode'] == 'imix': # several streams with given length


### PR DESCRIPTION
Comparison between a literal and a variable with 'is' and 'is not' is prone to error since 'is' [checks for identity rather than equality](https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/), for example

```python3
>>> ''.join([c for c in 'abcd']) is 'abcd'
False
>>> ''.join([c for c in 'abcd']) == 'abcd'
True
```

This sometimes leads to issues that are hard to debug, so change those comparison to ==/!= instead.
