### PR TITLE
SFP+ link status fix for ixgbe

### DIFF
--- a/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.c
+++ b/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.c
@@ -230,7 +230,8 @@ static int ixgbe_dev_interrupt_action(struct rte_eth_dev *dev);
 static void ixgbe_dev_interrupt_handler(void *param);
 static void ixgbe_dev_interrupt_delayed_handler(void *param);
 static void *ixgbe_dev_setup_link_thread_handler(void *param);
-static void ixgbe_dev_cancel_link_thread(struct rte_eth_dev *dev);
+static int ixgbe_dev_wait_setup_link_complete(struct rte_eth_dev *dev,
+					      uint32_t timeout_ms);
 
 static int ixgbe_add_rar(struct rte_eth_dev *dev,
 			struct rte_ether_addr *mac_addr,
@@ -2606,7 +2607,7 @@ ixgbe_dev_start(struct rte_eth_dev *dev)
 	PMD_INIT_FUNC_TRACE();
 
 	/* Stop the link setup handler before resetting the HW. */
-	ixgbe_dev_cancel_link_thread(dev);
+	ixgbe_dev_wait_setup_link_complete(dev, 0);
 
 	/* disable uio/vfio intr/eventfd mapping */
 	rte_intr_disable(intr_handle);
@@ -2893,7 +2894,7 @@ ixgbe_dev_stop(struct rte_eth_dev *dev)
 
 	PMD_INIT_FUNC_TRACE();
 
-	ixgbe_dev_cancel_link_thread(dev);
+	ixgbe_dev_wait_setup_link_complete(dev, 0);
 
 	/* disable interrupts */
 	ixgbe_disable_intr(hw);
@@ -4148,36 +4149,32 @@ out:
 	return ret_val;
 }
 
-/* return 1: setup complete, return 0: setup not complete, and wait timeout*/
+/*
+ * If @timeout_ms was 0, it means that it will not return until link complete.
+ * It returns 1 on complete, return 0 on timeout.
+ */
 static int
-ixgbe_dev_wait_setup_link_complete(struct rte_eth_dev *dev)
+ixgbe_dev_wait_setup_link_complete(struct rte_eth_dev *dev, uint32_t timeout_ms)
 {
-#define DELAY_INTERVAL 100 /* 100ms */
-#define MAX_TIMEOUT    90 /* 9s (90 * 100ms) in total */
+#define WARNING_TIMEOUT    9000 /* 9s  in total */
 	struct ixgbe_adapter *ad = dev->data->dev_private;
-	int timeout = MAX_TIMEOUT;
+	uint32_t timeout = timeout_ms ? timeout_ms : WARNING_TIMEOUT;
 
-	while (rte_atomic32_read(&ad->link_thread_running) && timeout) {
-		msec_delay(DELAY_INTERVAL);
+	while (rte_atomic32_read(&ad->link_thread_running)) {
+		msec_delay(1);
 		timeout--;
+
+		if (timeout_ms) {
+			if (!timeout)
+				return 0;
+		} else if (!timeout) {
+			/* It will not return until link complete */
+			timeout = WARNING_TIMEOUT;
+			PMD_DRV_LOG(ERR, "IXGBE link thread not complete too long time!");
+		}
 	}
 
-
-	return !!timeout;
-}
-
-static void
-ixgbe_dev_cancel_link_thread(struct rte_eth_dev *dev)
-{
-	struct ixgbe_adapter *ad = dev->data->dev_private;
-	void *retval;
-
-	if (!ixgbe_dev_wait_setup_link_complete(dev)) {
-		pthread_cancel(ad->link_thread_tid);
-		pthread_join(ad->link_thread_tid, &retval);
-		rte_atomic32_clear(&ad->link_thread_running);
-		PMD_DRV_LOG(ERR, "Link thread not complete, cancel it!");
-	}
+	return 1;
 }
 
 static void *
@@ -4191,6 +4188,7 @@ ixgbe_dev_setup_link_thread_handler(void *param)
 	u32 speed;
 	bool autoneg = false;
 
+	pthread_detach(pthread_self());
 	speed = hw->phy.autoneg_advertised;
 	if (!speed)
 		ixgbe_get_link_capabilities(hw, &speed, &autoneg);
@@ -4287,8 +4285,8 @@ ixgbe_dev_link_update_share(struct rte_eth_dev *dev,
 	if (link_up == 0) {
 		if (ixgbe_get_media_type(hw) == ixgbe_media_type_fiber) {
 			intr->flags |= IXGBE_FLAG_NEED_LINK_CONFIG;
-			if (ixgbe_dev_wait_setup_link_complete(dev) &&
-			    rte_atomic32_test_and_set(&ad->link_thread_running)) {
+			ixgbe_dev_wait_setup_link_complete(dev, 0);
+			if (rte_atomic32_test_and_set(&ad->link_thread_running)) {
 				if (rte_ctrl_thread_create(&ad->link_thread_tid,
 					"ixgbe-link-handler",
 					NULL,
@@ -5328,7 +5326,7 @@ ixgbevf_dev_start(struct rte_eth_dev *dev)
 	PMD_INIT_FUNC_TRACE();
 
 	/* Stop the link setup handler before resetting the HW. */
-	ixgbe_dev_cancel_link_thread(dev);
+	ixgbe_dev_wait_setup_link_complete(dev, 0);
 
 	err = hw->mac.ops.reset_hw(hw);
 	if (err) {
@@ -5426,7 +5424,7 @@ ixgbevf_dev_stop(struct rte_eth_dev *dev)
 
 	PMD_INIT_FUNC_TRACE();
 
-	ixgbe_dev_cancel_link_thread(dev);
+	ixgbe_dev_wait_setup_link_complete(dev, 0);
 
 	ixgbevf_intr_disable(dev);
 

--- a/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.c
+++ b/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.c
@@ -4148,16 +4148,35 @@ out:
 	return ret_val;
 }
 
+/* return 1: setup complete, return 0: setup not complete, and wait timeout*/
+static int
+ixgbe_dev_wait_setup_link_complete(struct rte_eth_dev *dev)
+{
+#define DELAY_INTERVAL 100 /* 100ms */
+#define MAX_TIMEOUT    90 /* 9s (90 * 100ms) in total */
+	struct ixgbe_adapter *ad = dev->data->dev_private;
+	int timeout = MAX_TIMEOUT;
+
+	while (rte_atomic32_read(&ad->link_thread_running) && timeout) {
+		msec_delay(DELAY_INTERVAL);
+		timeout--;
+	}
+
+
+	return !!timeout;
+}
+
 static void
 ixgbe_dev_cancel_link_thread(struct rte_eth_dev *dev)
 {
 	struct ixgbe_adapter *ad = dev->data->dev_private;
 	void *retval;
 
-	if (rte_atomic32_read(&ad->link_thread_running)) {
+	if (!ixgbe_dev_wait_setup_link_complete(dev)) {
 		pthread_cancel(ad->link_thread_tid);
 		pthread_join(ad->link_thread_tid, &retval);
 		rte_atomic32_clear(&ad->link_thread_running);
+		PMD_DRV_LOG(ERR, "Link thread not complete, cancel it!");
 	}
 }
 
@@ -4268,7 +4287,8 @@ ixgbe_dev_link_update_share(struct rte_eth_dev *dev,
 	if (link_up == 0) {
 		if (ixgbe_get_media_type(hw) == ixgbe_media_type_fiber) {
 			intr->flags |= IXGBE_FLAG_NEED_LINK_CONFIG;
-			if (rte_atomic32_test_and_set(&ad->link_thread_running)) {
+			if (ixgbe_dev_wait_setup_link_complete(dev) &&
+			    rte_atomic32_test_and_set(&ad->link_thread_running)) {
 				if (rte_ctrl_thread_create(&ad->link_thread_tid,
 					"ixgbe-link-handler",
 					NULL,


### PR DESCRIPTION
For some SFP+ modules the link status is not correctly detected with the ixgbe driver, this leads to error that complains the link being down when in reality the link is already up

```
port : 0 
------------
link         :  Link Down
promiscuous  : 0 
EAL: Error - exiting with code: 1
  Cause:  One of the links is down 
```

This PR takes two commit from DPDK to fix the link status issue:
* dpdk/DPDK@efa8c72f1e net/ixgbe: fix link status inconsistencies
* dpdk/DPDK@d68ab7a9f9 net/ixgbe: fix resource leak after thread exits normally

Resolves #527