### PR TITLE
add --new-memory option to build with new DPDK memory subsystem.

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -6240,7 +6240,9 @@ COLD_FUNC int  update_dpdk_args(void){
         }
     }
 
+#ifndef DPDK_NEW_MEMORY
     SET_ARGS("--legacy-mem");
+#endif
 
     if ( lpop->prefix.length() ) {
         SET_ARGS("--file-prefix");


### PR DESCRIPTION
Hi, this PR is an implementation of issue #480.

I added generated dpdk_config.h to override RTE_EAL_NUMA_AWARE_HUGEPAGES configuration in rte_config.h dynamically.
```
cd linux_dpdk/
./b configure --new-memory
./b build
```
@hhaim what do you think about this change?