### PR TITLE
use master thread's NUMA node for messaging socket_id.

### DIFF
--- a/src/msg_manager.cpp
+++ b/src/msg_manager.cpp
@@ -32,6 +32,7 @@ bool CMessagingManager::Create(uint8_t num_dp_threads,std::string a_name){
     assert(m_cp_to_dp==0);
     m_cp_to_dp = new CNodeRing[num_dp_threads] ;
     m_dp_to_cp = new CNodeRing[num_dp_threads];
+    int master_socket_id = rte_lcore_to_socket_id(CGlobalInfo::m_socket.get_master_phy_id());
     int i;
     for (i=0; i<num_dp_threads; i++) {
         CNodeRing * lp;
@@ -39,11 +40,11 @@ bool CMessagingManager::Create(uint8_t num_dp_threads,std::string a_name){
 
         lp=getRingCpToDp(i);
         sprintf(name,"%s_to_%d",(char *)a_name.c_str(),i);
-        assert(lp->Create(std::string(name),1024,0)==true);
+        assert(lp->Create(std::string(name),1024,master_socket_id)==true);
 
         lp=getRingDpToCp(i);
         sprintf(name,"%s_from_%d",(char *)a_name.c_str(),i);
-        assert(lp->Create(std::string(name),1024,0)==true);
+        assert(lp->Create(std::string(name),1024,master_socket_id)==true);
 
     }
     assert(m_dp_to_cp);


### PR DESCRIPTION
@hhaim, from the PR #531, when only socket: 1 (NUMA node 1) is used, T-Rex can't start by assertion fail.
It's because CMessagingManager tries to allocate from dedicated NUMA node 0 that is not configured in this case.
My change uses master thread's NUMA node that should be configured.

Please check my changes and give your feedback.

P.S. In addition, from the PR #531, T-Rex also failed to start when master thread's NUMA node is not the same as interface's NUMA node. Since this usage is not recommended, I think I don't need to support it. What do you think about it?