### PR TITLE
fix crash by no flow variable in StreamVm from #484

### DIFF
--- a/src/stx/stl/trex_stl_stream_vm.cpp
+++ b/src/stx/stl/trex_stl_stream_vm.cpp
@@ -683,7 +683,9 @@ void StreamVm::build_flow_var_table() {
 
 void StreamVm::alloc_bss(){
     free_bss();
-    m_bss=(uint8_t *)malloc(m_cur_var_offset);
+    if (m_cur_var_offset) {
+        m_bss=(uint8_t *)malloc(m_cur_var_offset);
+    }
 }
 
 void StreamVm::clean_max_field_cnt(){

--- a/src/stx/stl/trex_stl_stream_vm.h
+++ b/src/stx/stl/trex_stl_stream_vm.h
@@ -2090,10 +2090,12 @@ public:
     }
 
     uint8_t* clone_bss(){
-        assert(m_bss_size>0);
-        uint8_t *p=(uint8_t *)malloc(m_bss_size);
-        assert(p);
-        memcpy(p,m_bss_ptr,m_bss_size);
+        uint8_t *p=nullptr;
+        if (m_bss_size>0) {
+            p=(uint8_t *)malloc(m_bss_size);
+            assert(p);
+            memcpy(p,m_bss_ptr,m_bss_size);
+        }
         return (p);
     }
 


### PR DESCRIPTION
@hhaim, #484 enabled fix_checksum_hw without flow variables for flow latency stats.
Recently, I received crash issue when there is no flow variable.
There are some assert code to check bss_size should not be 0. I'd missed the code at change #484.

```
assert: ../../../../trex-core/src/stx/stl/trex_stl_stream_vm.h:2039 StreamVmDp::StreamVmDp(uint8_t*, uint16_t, uint8_t*, uint32_t, uint16_t, uint16_t, bool, bool) Assertion 'bss_size' failed.
```

Please check my change and give your feedback.