### PR TITLE
multiple profiles share client IP info for port allocation in a DP core

### DIFF
--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -2998,6 +2998,7 @@ class CMbufBuffer;
 class CTcpCtxCb;
 class CSyncBarrier;
 class CAstfDB;
+class CIpInfoBase;
 
 class CFlowGenListPerThread {
 
@@ -3193,6 +3194,13 @@ public:
     CTupleGeneratorSmart             m_smart_gen;
 
     TrexMonitor                      m_monitor;
+
+private:
+    std::map<uint32_t, CIpInfoBase*> m_ip_info;
+public:
+    CIpInfoBase* get_ip_info(uint32_t ip);
+    void allocate_ip_info(CIpInfoBase* ip_info);
+    void release_ip_info(CIpInfoBase* ip_info);
 
 public:
     CNodeGenerator                   m_node_gen;


### PR DESCRIPTION
@hhaim, this PR is another trial for #376.
Recently I observed `err_dct` counter when I use the same client IP and server IP + server port (by l7_map) in the different profiles.
To avoid this situation, I made the info for the same client IP shared by multiple profiles in the same thread.
I located the shared IP info at CFlowGenListPerThread and it would be resolved by CTupleGeneratorSmart which instance is bounded to profile per thread.

Please check my changes and give your feedback.