### PR TITLE
secure updating DP profile ctx for stats.

### DIFF
--- a/src/44bsd/sim_cs_tcp.cpp
+++ b/src/44bsd/sim_cs_tcp.cpp
@@ -784,7 +784,8 @@ void CClientServerTcp::dump_counters(){
     stt_cp.m_init=true;
     stt_cp.Add(TCP_CLIENT_SIDE,&m_c_ctx);
     stt_cp.Add(TCP_SERVER_SIDE,&m_s_ctx);
-    stt_cp.update_profile_ctx();
+    stt_cp.AddProfileCtx(TCP_CLIENT_SIDE,DEFAULT_PROFILE_CTX(&m_c_ctx));
+    stt_cp.AddProfileCtx(TCP_SERVER_SIDE,DEFAULT_PROFILE_CTX(&m_s_ctx));
     stt_cp.Update();
     stt_cp.DumpTable();
     std::string json;

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4304,7 +4304,7 @@ COLD_FUNC void CGlobalTRex::update_stats(){
 
         if (lpstt->m_init){
             if (lpstt->need_profile_ctx_update()) {
-                if (!stx || (stx && stx->is_safe_update_stats())) {
+                if (!stx) { // non-ASTF case. ASTF updated by DP to CP message
                     lpstt->update_profile_ctx();
                 }
             }

--- a/src/sim/trex_sim_astf.cpp
+++ b/src/sim/trex_sim_astf.cpp
@@ -184,7 +184,8 @@ static void dump_tcp_counters(CTcpPerThreadCtx  *      c_ctx,
     stt_cp.m_init=true;
     stt_cp.Add(TCP_CLIENT_SIDE,c_ctx);
     stt_cp.Add(TCP_SERVER_SIDE,s_ctx);
-    stt_cp.update_profile_ctx();
+    stt_cp.AddProfileCtx(TCP_CLIENT_SIDE,DEFAULT_PROFILE_CTX(c_ctx));
+    stt_cp.AddProfileCtx(TCP_SERVER_SIDE,DEFAULT_PROFILE_CTX(s_ctx));
     stt_cp.Update();
     stt_cp.DumpTable();
     std::string json;

--- a/src/stt_cp.h
+++ b/src/stt_cp.h
@@ -100,7 +100,8 @@ class CSTTCp {
 public:
     void Create(uint32_t stt_id=0, uint16_t num_of_tg_ids=1, bool first_time=true);
     void Delete(bool last_time=true);
-    void Add(tcp_dir_t dir,CTcpPerThreadCtx* ctx);
+    void Add(tcp_dir_t dir, CTcpPerThreadCtx* ctx);
+    void AddProfileCtx(tcp_dir_t dir, CPerProfileCtx* pctx);
     void Init(bool first_time=true);
     void Update();
     void Accumulate(bool clear, bool calculate, CSTTCp* lpstt);
@@ -112,6 +113,7 @@ public:
     void UpdateTGNames(const std::vector<std::string>& tg_names);
     void DumpTGStats(Json::Value &result, const std::vector<uint16_t>& tg_ids);
     void UpdateTGStats(const std::vector<uint16_t>& tg_ids);
+    void clear_profile_ctx();
     void update_profile_ctx();
     bool need_profile_ctx_update() { return !m_profile_ctx_updated; }
 

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -109,6 +109,8 @@ public:
     void dp_core_finished();
     void dp_core_error(const std::string &err);
 
+    void add_dp_profile_ctx(CPerProfileCtx* client, CPerProfileCtx* server);
+
     /*
      * publish event for each profile
      */
@@ -355,6 +357,8 @@ public:
     }
 
     void dp_core_error(int thread_id, uint32_t dp_profile_id, const std::string &err);
+
+    void add_dp_profile_ctx(uint32_t dp_profile_id, void* client, void* server) override;
 
     state_e get_state() {
         return m_state;

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -415,7 +415,7 @@ void TrexAstfDpCore::create_tcp_batch(profile_id_t profile_id, double factor, CA
     }
 
     set_profile_state(profile_id, pSTATE_LOADED);
-    report_finished(profile_id);
+    report_profile_ctx(profile_id);
 }
 
 void TrexAstfDpCore::delete_tcp_batch(profile_id_t profile_id, bool do_remove, CAstfDB* astf_db) {
@@ -563,6 +563,13 @@ bool TrexAstfDpCore::sync_barrier() {
 
 void TrexAstfDpCore::report_finished(profile_id_t profile_id) {
     TrexDpToCpMsgBase *msg = new TrexDpCoreStopped(m_flow_gen->m_thread_id, profile_id);
+    m_ring_to_cp->SecureEnqueue((CGenNode *)msg, true);
+}
+
+void TrexAstfDpCore::report_profile_ctx(profile_id_t profile_id) {
+    CPerProfileCtx* client = m_flow_gen->m_c_tcp->get_profile_ctx(profile_id);
+    CPerProfileCtx* server = m_flow_gen->m_s_tcp->get_profile_ctx(profile_id);
+    TrexDpToCpMsgBase *msg = new TrexDpCoreProfileCtx(m_flow_gen->m_thread_id, profile_id, client, server);
     m_ring_to_cp->SecureEnqueue((CGenNode *)msg, true);
 }
 

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -67,6 +67,7 @@ public:
 protected:
     virtual bool rx_for_idle();
     void report_finished(profile_id_t profile_id = 0);
+    void report_profile_ctx(profile_id_t profile_id = 0);
     void report_error(profile_id_t profile_id, const std::string &error);
     bool sync_barrier();
     void report_dp_state();

--- a/src/stx/common/trex_messaging.cpp
+++ b/src/stx/common/trex_messaging.cpp
@@ -114,6 +114,13 @@ TrexDpCoreStopped::handle(void) {
 }
 
 bool
+TrexDpCoreProfileCtx::handle(void) {
+    get_stx()->add_dp_profile_ctx(m_profile_id, m_client_pctx, m_server_pctx);
+    get_stx()->dp_core_finished(m_thread_id, m_profile_id);
+    return true;
+}
+
+bool
 TrexDpCoreError::handle(void) {
     get_stx()->dp_core_error(m_thread_id, m_profile_id, m_err);
     return true;

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -292,6 +292,28 @@ private:
 };
 
 /**
+ * a message indicating that DP core stopped with profile ctx
+ */
+class TrexDpCoreProfileCtx : public TrexDpToCpMsgBase {
+public:
+
+    TrexDpCoreProfileCtx(int thread_id, profile_id_t profile_id, void* client, void* server) {
+        m_thread_id = thread_id;
+        m_profile_id = profile_id;
+        m_client_pctx = client;
+        m_server_pctx = server;
+    }
+
+    virtual bool handle(void);
+
+private:
+    int m_thread_id;
+    profile_id_t m_profile_id;
+    void* m_client_pctx;
+    void* m_server_pctx;
+};
+
+/**
  * a message indicating that DP core encountered error
  */
 class TrexDpCoreError : public TrexDpToCpMsgBase {

--- a/src/stx/common/trex_stx.cpp
+++ b/src/stx/common/trex_stx.cpp
@@ -168,6 +168,10 @@ TrexSTX::dp_core_finished(int thread_id, uint32_t profile_id) {
 }
 
 void
+TrexSTX::add_dp_profile_ctx(uint32_t profile_id, void* client, void* server) {
+}
+
+void
 TrexSTX::dp_core_error(int thread_id, uint32_t profile_id, const std::string &err) {
 }
 

--- a/src/stx/common/trex_stx.h
+++ b/src/stx/common/trex_stx.h
@@ -146,6 +146,7 @@ public:
      * DP core has finished
      */
     virtual void dp_core_finished(int thread_id, uint32_t profile_id);
+    virtual void add_dp_profile_ctx(uint32_t profile_id, void* client, void* server);
 
     /**
      * DP core encountered error


### PR DESCRIPTION
Hi, this PR is to secure DP profile ctx when build has been finished.
Current updating method (direct call of `ctx->get_profile_ctx()`) should secure the safe condition to avoid racing condition.
It may cause DP profile ctx is not updated until all profiles are in the stable state.
This change make it sure after the profile build finished from DP using by a new DP to CP message, `TrexDpCoreProfileCtx`.

@hhaim, please check my changes and give your feedback.