### PR TITLE
Added ip_header_offset yaml configuration for STF IP tunneling support

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -1963,6 +1963,7 @@ see xref:timer_w[Timer Wheel section]
        multi_flow_enabled: true     <8>
        flows_dirs: [0, 1]           <9>
        keep_src_port: true          <10>
+	   ip_header_offset: 50         <11>
 
 ----
 <1> The name of the template pcap file. Can be relative path from the t-rex-64 image directory, or an absolute path. The pcap file should include only one flow. (Exception: in case of plug-ins).
@@ -1977,7 +1978,7 @@ see xref:timer_w[Timer Wheel section]
 <9> New in version v2.62. Sets direction of flow(s). If set to 0, has no effect. If set to 1, server will initiate the flow (with its IP) towards client with original dest port. +
  Note: does *not* work with --learn modes.
 <10> New in version v2.66. Keep original TCP/UDP source port from pcap.
-
+<11> New. Client IP header offset in bytes. Useful when multiple IP headers are present in the capture (e.g. tunnelled traffic). Overrides default behaviour of parsing the first IP header found.  
 
 
 === Platform YAML (--cfg argument)

--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -1963,7 +1963,7 @@ see xref:timer_w[Timer Wheel section]
        multi_flow_enabled: true     <8>
        flows_dirs: [0, 1]           <9>
        keep_src_port: true          <10>
-	   ip_header_offset: 50         <11>
+       ip_header_offset: 50         <11>
 
 ----
 <1> The name of the template pcap file. Can be relative path from the t-rex-64 image directory, or an absolute path. The pcap file should include only one flow. (Exception: in case of plug-ins).

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -66,7 +66,7 @@ CFlowYamlInfo::CFlowYamlInfo() {
     m_multi_flow_was_set = false;
     m_keep_src_port = false;
     m_plugin_id = 0;
-	m_ip_header_offset = 0;
+    m_ip_header_offset = 0;
 }
 
 void CFlowYamlInfo::Dump(FILE *fd){
@@ -90,7 +90,7 @@ void CFlowYamlInfo::Dump(FILE *fd){
     fprintf(fd,"one_server_was_set  : %d \n",m_one_app_server_was_set?1:0);
     fprintf(fd,"multi_flow_enabled  : %d \n",m_multi_flow_was_set);
     fprintf(fd,"keep_src_port       : %d \n",m_keep_src_port);
-	fprintf(fd, "ip_header_offset       : %d \n", m_ip_header_offset);
+    fprintf(fd, "ip_header_offset       : %d \n", m_ip_header_offset);
 
     if (m_dpPkt) {
         m_dpPkt->Dump(fd);
@@ -834,74 +834,74 @@ void CPacketIndication::_ProcessPacket(CPacketParser *parser,
     m_is_ipv6 = false;
     m_is_ipv6_converted =false;
 
-	if (offset == 0){
-		// IP
-		switch (m_ether->getNextProtocol()) {
-		case EthernetHeader::Protocol::IP:
-			offset = 14;
-			l3.m_ipv4 = (IPHeader*)(packetBase + offset);
-			break;
-		case EthernetHeader::Protocol::IPv6:
-			offset = 14;
-			l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
-			m_is_ipv6 = true;
-			break;
-		case EthernetHeader::Protocol::VLAN:
-			m_cnt->m_vlan++;
-			switch (m_ether->getVlanProtocol()) {
-			case EthernetHeader::Protocol::IP:
-				offset = 18;
-				l3.m_ipv4 = (IPHeader*)(packetBase + offset);
-				break;
-			case EthernetHeader::Protocol::IPv6:
-				offset = 18;
-				l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
-				m_is_ipv6 = true;
-				break;
-			case EthernetHeader::Protocol::MPLS_Multicast:
-			case EthernetHeader::Protocol::MPLS_Unicast:
-				m_cnt->m_mpls++;
-				return;
+    if (offset == 0){
+        // IP
+        switch (m_ether->getNextProtocol()) {
+        case EthernetHeader::Protocol::IP:
+            offset = 14;
+            l3.m_ipv4 = (IPHeader*)(packetBase + offset);
+            break;
+        case EthernetHeader::Protocol::IPv6:
+            offset = 14;
+            l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
+            m_is_ipv6 = true;
+            break;
+        case EthernetHeader::Protocol::VLAN:
+            m_cnt->m_vlan++;
+            switch (m_ether->getVlanProtocol()) {
+            case EthernetHeader::Protocol::IP:
+                offset = 18;
+                l3.m_ipv4 = (IPHeader*)(packetBase + offset);
+                break;
+            case EthernetHeader::Protocol::IPv6:
+                offset = 18;
+                l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
+                m_is_ipv6 = true;
+                break;
+            case EthernetHeader::Protocol::MPLS_Multicast:
+            case EthernetHeader::Protocol::MPLS_Unicast:
+                m_cnt->m_mpls++;
+                return;
 
-			case EthernetHeader::Protocol::ARP:
-				m_cnt->m_arp++;
-				return;
+            case EthernetHeader::Protocol::ARP:
+                m_cnt->m_arp++;
+                return;
 
-			default:
-				m_cnt->m_non_ip++;
-				return; /* Non IP */
-			}
-			break;
-		case EthernetHeader::Protocol::ARP:
-			m_cnt->m_arp++;
-			return; /* Non IP */
-			break;
+            default:
+                m_cnt->m_non_ip++;
+                return; /* Non IP */
+            }
+            break;
+        case EthernetHeader::Protocol::ARP:
+            m_cnt->m_arp++;
+            return; /* Non IP */
+            break;
 
-		case EthernetHeader::Protocol::MPLS_Multicast:
-		case EthernetHeader::Protocol::MPLS_Unicast:
-			m_cnt->m_mpls++;
-			return; /* Non IP */
-			break;
+        case EthernetHeader::Protocol::MPLS_Multicast:
+        case EthernetHeader::Protocol::MPLS_Unicast:
+            m_cnt->m_mpls++;
+            return; /* Non IP */
+            break;
 
-		default:
-			m_cnt->m_non_ip++;
-			return; /* Non IP */
-		}
-	}
-	else{
-		uint8_t* ip_version = (uint8_t*)(packetBase + offset);
-		if ((*ip_version & 0xF0) == 0x40){
-			l3.m_ipv4 = (IPHeader*)(packetBase + offset);
-		}
-		else if ((*ip_version & 0xF0) == 0x60){
-			l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
-			m_is_ipv6 = true;
-		}
-		else {
-			fprintf(stderr, "Error: ip_header_offset must point to a valid IPv4 or IPv6 header\n");
-			exit(-1);
-		}
-	}
+        default:
+            m_cnt->m_non_ip++;
+            return; /* Non IP */
+        }
+    }
+    else{
+        uint8_t* ip_version = (uint8_t*)(packetBase + offset);
+        if ((*ip_version & 0xF0) == 0x40){
+            l3.m_ipv4 = (IPHeader*)(packetBase + offset);
+        }
+        else if ((*ip_version & 0xF0) == 0x60){
+            l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
+            m_is_ipv6 = true;
+        }
+        else {
+            fprintf(stderr, "Error: ip_header_offset must point to a valid IPv4 or IPv6 header\n");
+            exit(-1);
+        }
+    }
 
     if (is_ipv6() == false) {
         if( (offset+20) > (uint32_t)( m_packet->getTotalLen())   ){
@@ -1627,7 +1627,7 @@ enum CCapFileFlowInfo::load_cap_file_err CCapFileFlowInfo::load_cap_file(std::st
     bool is_multi_flow_enabled = flow_info.m_multi_flow_was_set;
     bool is_custom_dirs = (flow_info.m_flows_dirs.size() > 0);
     bool keep_src_port = flow_info.m_keep_src_port;
-	pkt_indication.m_ip_offset = flow_info.m_ip_header_offset;
+    pkt_indication.m_ip_offset = flow_info.m_ip_header_offset;
 
 
     CFlowTableMap flow;
@@ -2068,12 +2068,12 @@ void operator >> (const YAML::Node& node, CFlowYamlInfo & fi) {
         fi.m_keep_src_port = 0;
     }
 
-	if (node.FindValue("ip_header_offset")) {
-		node["ip_header_offset"] >> fi.m_ip_header_offset;
-	}
-	else {
-		fi.m_ip_header_offset = 0;
-	}
+    if (node.FindValue("ip_header_offset")) {
+        node["ip_header_offset"] >> fi.m_ip_header_offset;
+    }
+    else {
+        fi.m_ip_header_offset = 0;
+    }
 
     if ( node.FindValue("flows_dirs") ) {
         const YAML::Node& flows_dirs = node["flows_dirs"];
@@ -3152,7 +3152,7 @@ void CFlowGenListPerThread::init_from_global(){
         yaml_info->m_cap_mode =lp->m_info->m_cap_mode;
         yaml_info->m_plugin_id = lp->m_info->m_plugin_id;
         yaml_info->m_keep_src_port = lp->m_info->m_keep_src_port;
-		yaml_info->m_ip_header_offset = lp->m_info->m_ip_header_offset;
+        yaml_info->m_ip_header_offset = lp->m_info->m_ip_header_offset;
         yaml_info->m_one_app_server = lp->m_info->m_one_app_server;
         yaml_info->m_server_addr = lp->m_info->m_server_addr;
         yaml_info->m_dpPkt          =lp->m_info->m_dpPkt;

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -66,6 +66,7 @@ CFlowYamlInfo::CFlowYamlInfo() {
     m_multi_flow_was_set = false;
     m_keep_src_port = false;
     m_plugin_id = 0;
+	m_ip_header_offset = 0;
 }
 
 void CFlowYamlInfo::Dump(FILE *fd){
@@ -89,6 +90,7 @@ void CFlowYamlInfo::Dump(FILE *fd){
     fprintf(fd,"one_server_was_set  : %d \n",m_one_app_server_was_set?1:0);
     fprintf(fd,"multi_flow_enabled  : %d \n",m_multi_flow_was_set);
     fprintf(fd,"keep_src_port       : %d \n",m_keep_src_port);
+	fprintf(fd, "ip_header_offset       : %d \n", m_ip_header_offset);
 
     if (m_dpPkt) {
         m_dpPkt->Dump(fd);
@@ -824,7 +826,7 @@ void CPacketIndication::_ProcessPacket(CPacketParser *parser,
     Clean();
     CCPacketParserCounters * m_cnt=&parser->m_counter;
 
-    int offset = 0;
+    int offset = m_ip_offset;
     char * packetBase;
     packetBase = m_packet->raw;
     BP_ASSERT(packetBase);
@@ -832,62 +834,77 @@ void CPacketIndication::_ProcessPacket(CPacketParser *parser,
     m_is_ipv6 = false;
     m_is_ipv6_converted =false;
 
+	if (offset == 0){
+		// IP
+		switch (m_ether->getNextProtocol()) {
+		case EthernetHeader::Protocol::IP:
+			offset = 14;
+			l3.m_ipv4 = (IPHeader*)(packetBase + offset);
+			break;
+		case EthernetHeader::Protocol::IPv6:
+			offset = 14;
+			l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
+			m_is_ipv6 = true;
+			break;
+		case EthernetHeader::Protocol::VLAN:
+			m_cnt->m_vlan++;
+			switch (m_ether->getVlanProtocol()) {
+			case EthernetHeader::Protocol::IP:
+				offset = 18;
+				l3.m_ipv4 = (IPHeader*)(packetBase + offset);
+				break;
+			case EthernetHeader::Protocol::IPv6:
+				offset = 18;
+				l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
+				m_is_ipv6 = true;
+				break;
+			case EthernetHeader::Protocol::MPLS_Multicast:
+			case EthernetHeader::Protocol::MPLS_Unicast:
+				m_cnt->m_mpls++;
+				return;
 
-    // IP
-    switch( m_ether->getNextProtocol() ) {
-    case EthernetHeader::Protocol::IP :
-        offset = 14;
-        l3.m_ipv4 =(IPHeader *)(packetBase+offset);
-        break;
-    case EthernetHeader::Protocol::IPv6 :
-        offset = 14;
-        l3.m_ipv6 =(IPv6Header *)(packetBase+offset);
-        m_is_ipv6 = true;
-        break;
-    case EthernetHeader::Protocol::VLAN :
-        m_cnt->m_vlan++;
-        switch ( m_ether->getVlanProtocol() ){
-          case EthernetHeader::Protocol::IP:
-               offset = 18;
-               l3.m_ipv4 =(IPHeader *)(packetBase+offset);
-              break;
-          case EthernetHeader::Protocol::IPv6 :
-              offset = 18;
-              l3.m_ipv6 =(IPv6Header *)(packetBase+offset);
-              m_is_ipv6 = true;
-              break;
-          case EthernetHeader::Protocol::MPLS_Multicast   :
-          case EthernetHeader::Protocol::MPLS_Unicast  :
-              m_cnt->m_mpls++;
-              return;
+			case EthernetHeader::Protocol::ARP:
+				m_cnt->m_arp++;
+				return;
 
-        case EthernetHeader::Protocol::ARP :
-            m_cnt->m_arp++;
-            return;
+			default:
+				m_cnt->m_non_ip++;
+				return; /* Non IP */
+			}
+			break;
+		case EthernetHeader::Protocol::ARP:
+			m_cnt->m_arp++;
+			return; /* Non IP */
+			break;
 
-        default:
-            m_cnt->m_non_ip++;
-            return ; /* Non IP */
-            }
-        break;
-    case EthernetHeader::Protocol::ARP  :
-        m_cnt->m_arp++;
-        return; /* Non IP */
-        break;
+		case EthernetHeader::Protocol::MPLS_Multicast:
+		case EthernetHeader::Protocol::MPLS_Unicast:
+			m_cnt->m_mpls++;
+			return; /* Non IP */
+			break;
 
-    case EthernetHeader::Protocol::MPLS_Multicast   :
-    case EthernetHeader::Protocol::MPLS_Unicast  :
-        m_cnt->m_mpls++;
-        return; /* Non IP */
-        break;
-
-    default:
-        m_cnt->m_non_ip++;
-        return; /* Non IP */
-    }
+		default:
+			m_cnt->m_non_ip++;
+			return; /* Non IP */
+		}
+	}
+	else{
+		uint8_t* ip_version = (uint8_t*)(packetBase + offset);
+		if ((*ip_version & 0xF0) == 0x40){
+			l3.m_ipv4 = (IPHeader*)(packetBase + offset);
+		}
+		else if ((*ip_version & 0xF0) == 0x60){
+			l3.m_ipv6 = (IPv6Header*)(packetBase + offset);
+			m_is_ipv6 = true;
+		}
+		else {
+			fprintf(stderr, "Error: ip_header_offset must point to a valid IPv4 or IPv6 header\n");
+			exit(-1);
+		}
+	}
 
     if (is_ipv6() == false) {
-        if( (14+20) > (uint32_t)( m_packet->getTotalLen())   ){
+        if( (offset+20) > (uint32_t)( m_packet->getTotalLen())   ){
             m_cnt->m_ip_length_error++;
             return;
         }
@@ -1610,6 +1627,7 @@ enum CCapFileFlowInfo::load_cap_file_err CCapFileFlowInfo::load_cap_file(std::st
     bool is_multi_flow_enabled = flow_info.m_multi_flow_was_set;
     bool is_custom_dirs = (flow_info.m_flows_dirs.size() > 0);
     bool keep_src_port = flow_info.m_keep_src_port;
+	pkt_indication.m_ip_offset = flow_info.m_ip_header_offset;
 
 
     CFlowTableMap flow;
@@ -2049,6 +2067,13 @@ void operator >> (const YAML::Node& node, CFlowYamlInfo & fi) {
     }else{
         fi.m_keep_src_port = 0;
     }
+
+	if (node.FindValue("ip_header_offset")) {
+		node["ip_header_offset"] >> fi.m_ip_header_offset;
+	}
+	else {
+		fi.m_ip_header_offset = 0;
+	}
 
     if ( node.FindValue("flows_dirs") ) {
         const YAML::Node& flows_dirs = node["flows_dirs"];
@@ -3127,6 +3152,7 @@ void CFlowGenListPerThread::init_from_global(){
         yaml_info->m_cap_mode =lp->m_info->m_cap_mode;
         yaml_info->m_plugin_id = lp->m_info->m_plugin_id;
         yaml_info->m_keep_src_port = lp->m_info->m_keep_src_port;
+		yaml_info->m_ip_header_offset = lp->m_info->m_ip_header_offset;
         yaml_info->m_one_app_server = lp->m_info->m_one_app_server;
         yaml_info->m_server_addr = lp->m_info->m_server_addr;
         yaml_info->m_dpPkt          =lp->m_info->m_dpPkt;

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -491,7 +491,7 @@ struct CFlowYamlInfo {
     pool_index_t    m_server_pool_idx;
     uint32_t        m_server_addr;
     uint8_t         m_plugin_id; /* 0 - default , 1 - RTSP160 , 2- RTSP250 */
-	uint16_t		m_ip_header_offset;
+    uint16_t        m_ip_header_offset;
     bool            m_one_app_server;
     bool            m_one_app_server_was_set;
     bool            m_cap_mode;
@@ -1790,16 +1790,16 @@ public:
     CFlowKey            m_flow_key;
 
     uint8_t             m_ether_offset;
-	uint16_t            m_ip_offset;
-	uint16_t            m_udp_tcp_offset;
-	uint16_t            m_payload_offset;
+    uint16_t            m_ip_offset;
+    uint16_t            m_udp_tcp_offset;
+    uint16_t            m_payload_offset;
     uint8_t             m_rw_mbuf_size;    /* first R/W mbuf size 64/128/256 */
     uint8_t             m_pad1;
     uint16_t            m_ro_mbuf_size;    /* the size of the const mbuf, zero if does not exits */
 
 public:
 
-	CPacketIndication() : m_ip_offset(0) {}
+    CPacketIndication() : m_ip_offset(0) {}
     void Dump(FILE *fd,int verbose);
     void Clean();
     bool ConvertPacketToIpv6InPlace(CCapPktRaw * pkt,

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -491,6 +491,7 @@ struct CFlowYamlInfo {
     pool_index_t    m_server_pool_idx;
     uint32_t        m_server_addr;
     uint8_t         m_plugin_id; /* 0 - default , 1 - RTSP160 , 2- RTSP250 */
+	uint16_t		m_ip_header_offset;
     bool            m_one_app_server;
     bool            m_one_app_server_was_set;
     bool            m_cap_mode;
@@ -1789,9 +1790,9 @@ public:
     CFlowKey            m_flow_key;
 
     uint8_t             m_ether_offset;
-    uint8_t             m_ip_offset;
-    uint8_t             m_udp_tcp_offset;
-    uint8_t             m_payload_offset;
+	uint16_t            m_ip_offset;
+	uint16_t            m_udp_tcp_offset;
+	uint16_t            m_payload_offset;
     uint8_t             m_rw_mbuf_size;    /* first R/W mbuf size 64/128/256 */
     uint8_t             m_pad1;
     uint16_t            m_ro_mbuf_size;    /* the size of the const mbuf, zero if does not exits */

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -1799,6 +1799,7 @@ public:
 
 public:
 
+	CPacketIndication() : m_ip_offset(0) {}
     void Dump(FILE *fd,int verbose);
     void Clean();
     bool ConvertPacketToIpv6InPlace(CCapPktRaw * pkt,


### PR DESCRIPTION
The idea here is to allow the user to configure what the inner/subscriber IP layer offset is so that pcaps with IP tunneling are properly processed. The other option would have been to add various tunneling parsing support, but that approach is more complex and perhaps overkill for STF (since the mode is no longer actively being developed).