### PR TITLE
ASTF global tunable works per profile

### DIFF
--- a/doc/trex_astf.asciidoc
+++ b/doc/trex_astf.asciidoc
@@ -2806,13 +2806,13 @@ link:cp_astf_docs/index.html[python index]
 
 [options="header",cols="2,^2,^2,^1,^1,5"]
 |=================
-|  tunable      | min-max|default| per-template |global| Description  
-|   ip.tos    | uint8 |0 |+|+ <1>| ipv4/ipv6 TOS/Class. limitation LSB can't be set as it is used by hardware filter on some NICs
-|   ip.ttl    | uint8 |0 |+|+ <1>| ipv4/ipv6 TTL/TimeToLive. limitation can't be higher than 0x7f as it might used by some hardware filter on some NICs
+|  tunable      | min-max|default| per-template |global (profile)| Description
+|   ip.tos    | uint8 |0 |+|+| ipv4/ipv6 TOS/Class. limitation LSB can't be set as it is used by hardware filter on some NICs
+|   ip.ttl    | uint8 |0 |+|+| ipv4/ipv6 TTL/TimeToLive. limitation can't be higher than 0x7f as it might used by some hardware filter on some NICs
 |   ip.dont_use_inbound_mac | bool |0|-|+| server side will use configured src/dest MACs for the port or resolved gateway MAC instead of reflecting incoming MACs
-|   ipv6.src_msb    | string |0 |+|+ <1>| default IPv6.src MSB address. see Priority in ipv6 enable
-|   ipv6.dst_msb    | string |0 |+|+ <1>| default IPv6.dst MSB address. see Priority in ipv6 enable
-|   ipv6.enable     | bool   |0 |+|+ <1>| enable IPv6 for all templates. Priority is given for global (template come next) -- not as other tunable. It means that for mix of ipv4/ipv6 only per template should be used.
+|   ipv6.src_msb    | string |0 |+|+| default IPv6.src MSB address. see Priority in ipv6 enable
+|   ipv6.dst_msb    | string |0 |+|+| default IPv6.dst MSB address. see Priority in ipv6 enable
+|   ipv6.enable     | bool   |0 |+|+| enable IPv6 for all templates. Priority is given for global (template come next) -- not as other tunable. It means that for mix of ipv4/ipv6 only per template should be used.
 |   tcp.mss         | 10-9K  |1460|+|+| default MSS in bytes. 
 |   tcp.initwnd     | 1-20   |10|+|+| init window value in MSS units.  
 |   tcp.rxbufsize   | 1K-1M  |32K |+|+| socket rx buffer size in bytes. 
@@ -2822,7 +2822,7 @@ link:cp_astf_docs/index.html[python index]
 |   tcp.keepinit    |2-65533|5|-|+| value in second for TCP keepalive.
 |   tcp.keepidle    |2-65533|5|-|+| value in second for TCP keepidle
 |   tcp.keepintvl   |2-65533|7|-|+| value in second for TCP keepalive interval
-|   tcp.blackhole   |0,1,2|0|-|+| 0 - return RST packet in case of error. 1- return of RST only in SYN. 2- don't return any RST packet, make a blackhole 
+|   tcp.blackhole   |0,1,2|0|-|+| 0 - return RST packet in case of error. 1- return of RST only in SYN. 2- don't return any RST packet, make a blackhole.
 |   tcp.delay_ack_msec | 20-500|100|-|+| delay ack timeout in msec.  Reducing this value will reduce the performance but will reduce the active flows
 |   tcp.no_delay    | 0-3   | 0|+|+|  In case of 1 disable Nagle and force PUSH. from v2.79 it was changed and there are two bits 1- disable nagle, 0x2 force PUSH flag (*NOT* standard it just to simulate Spirent) and will respond with ACK immediately (standard). 
 |   tcp.no_delay_counter    | 0-65533   | 0|+|+|  number of recv bytes to wait until ack is sent. notice ack can be triggered by tcp timer, in order to ensure fixed number of sent packets until ack you should increase the *tcp.initwnd* tunable. otherewise no_delay_counter will race with the tcp timer.
@@ -2830,8 +2830,8 @@ link:cp_astf_docs/index.html[python index]
 |=================
 
 * There would be a performance impact when per-template tunables are used. Try to use global tunables.
-* When a profile is running, following profile's global tunables are ignored. But the global tunables marked <1> are available for each profile.
 * The tunables mechanism does not work with the basic simulator mode but only with the advanced simulator mode.
+* Please use the same tcp.blackhole value for all your profiles. Otherwise, the result will be unpredictable.
 
 === Counters reference 
 

--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -373,7 +373,8 @@ bool CFlowTable::update_new_template(CTcpPerThreadCtx * ctx,
         flow->m_app.start(false);
         assert(flow->is_activated()); /* flow is now activated */
     } else {    /* no matched template found, now mbuf should be freed */
-        if (ctx->tcp_blackhole == 0) {
+        CPerProfileCtx* pctx = FALLBACK_PROFILE_CTX(ctx);
+        if (pctx->m_tunable_ctx.tcp_blackhole == 0) {
             tcp_respond_rst(flow, lpTcp, ftuple);
         }
         FT_INC_SCNT(m_err_defer_no_template);
@@ -454,7 +455,7 @@ void       CFlowTable::generate_rst_pkt(CPerProfileCtx * pctx,
         return;
     }
 
-    flow->m_template.server_update_mac(pkt, pctx->m_ctx, port_id);
+    flow->m_template.server_update_mac(pkt, pctx, port_id);
     if (is_ipv6) {
         /* learn the ipv6 headers */
         flow->m_template.learn_ipv6_headers_from_network(ipv6);
@@ -678,7 +679,7 @@ bool CFlowTable::rx_handle_packet_udp_no_flow(CTcpPerThreadCtx * ctx,
         return(false);
     }
 
-    flow->m_template.server_update_mac(pkt, ctx, port_id);
+    flow->m_template.server_update_mac(pkt, pctx, port_id);
     if (is_ipv6) {
         /* learn the ipv6 headers */
         flow->m_template.learn_ipv6_headers_from_network(parser.m_ipv6);
@@ -754,7 +755,8 @@ bool CFlowTable::rx_handle_packet_tcp_no_flow(CTcpPerThreadCtx * ctx,
     }
         /* not found in flowtable , we are generating the flows*/
     if ( m_client_side ){
-        if ( ctx->tcp_blackhole ==0 ){
+        CPerProfileCtx* pctx = FALLBACK_PROFILE_CTX(ctx);
+        if (pctx->m_tunable_ctx.tcp_blackhole == 0) {
 
             uint32_t source_ip;
             if (parser.m_ipv4){
@@ -765,7 +767,7 @@ bool CFlowTable::rx_handle_packet_tcp_no_flow(CTcpPerThreadCtx * ctx,
                 source_ip =ipv6->getSourceIpv6LSB();
             }
 
-            generate_rst_pkt(FALLBACK_PROFILE_CTX(ctx),
+            generate_rst_pkt(pctx,
                            dest_ip,
                            source_ip,
                            dst_port,
@@ -787,8 +789,9 @@ bool CFlowTable::rx_handle_packet_tcp_no_flow(CTcpPerThreadCtx * ctx,
     /* server side */
     if (  (lpTcp->getFlags() & TCPHeader::Flag::SYN) ==0 ) {
         /* no syn */
-        if ( ctx->tcp_blackhole !=2 ){
-            generate_rst_pkt(FALLBACK_PROFILE_CTX(ctx),
+        CPerProfileCtx* pctx = FALLBACK_PROFILE_CTX(ctx);
+        if (pctx->m_tunable_ctx.tcp_blackhole != 2) {
+            generate_rst_pkt(pctx,
                              dest_ip,
                              tuple.get_src_ip(),
                              dst_port,
@@ -812,8 +815,11 @@ bool CFlowTable::rx_handle_packet_tcp_no_flow(CTcpPerThreadCtx * ctx,
     CTcpServerInfo *server_info = temp ? temp->get_server_info(): nullptr;
 
     if (!server_info || (!pctx->is_active() && pctx->get_nc())) {
-        if (ctx->tcp_blackhole ==0 ){
-          generate_rst_pkt(pctx ? pctx: FALLBACK_PROFILE_CTX(ctx),
+        if (!pctx) {
+            pctx = FALLBACK_PROFILE_CTX(ctx);
+        }
+        if (pctx->m_tunable_ctx.tcp_blackhole == 0) {
+          generate_rst_pkt(pctx,
                          dest_ip,
                          tuple.get_src_ip(),
                          dst_port,
@@ -874,7 +880,7 @@ bool CFlowTable::rx_handle_packet_tcp_no_flow(CTcpPerThreadCtx * ctx,
     }
 
     lptflow->set_s_tcp_info(tcp_data_ro, s_tune);
-    lptflow->m_template.server_update_mac(pkt, ctx, port_id);
+    lptflow->m_template.server_update_mac(pkt, lptflow->m_pctx, port_id);
     if (is_ipv6) {
         /* learn the ipv6 headers */
         lptflow->m_template.learn_ipv6_headers_from_network(parser.m_ipv6);

--- a/src/44bsd/sim_cs_tcp.cpp
+++ b/src/44bsd/sim_cs_tcp.cpp
@@ -580,7 +580,10 @@ int CClientServerTcp::test2(){
 
     uint32_t tx_num_bytes=100*1024;
 
-    c_flow = m_c_ctx.m_ft.alloc_flow(DEFAULT_PROFILE_CTX(&m_c_ctx),0x10000001,0x30000001,1025,80,m_vlan,false,NULL);
+    CPerProfileCtx* c_pctx = DEFAULT_PROFILE_CTX(&m_c_ctx);
+    CPerProfileCtx* s_pctx = DEFAULT_PROFILE_CTX(&m_s_ctx);
+
+    c_flow = m_c_ctx.m_ft.alloc_flow(c_pctx,0x10000001,0x30000001,1025,80,m_vlan,false,NULL);
     CFlowKeyTuple   c_tuple;
     c_tuple.set_src_ip(0x10000001);
     c_tuple.set_dst_ip(0x30000001);
@@ -597,9 +600,9 @@ int CClientServerTcp::test2(){
 
     app_c = &c_flow->m_app;
 
-        /* IW=1 */
-    m_c_ctx.tcp_initwnd = m_c_ctx.tcp_mssdflt;
-    m_s_ctx.tcp_initwnd = m_c_ctx.tcp_mssdflt;
+    /* IW=1 */
+    c_pctx->m_tunable_ctx.tcp_initwnd = c_pctx->m_tunable_ctx.tcp_mssdflt;
+    s_pctx->m_tunable_ctx.tcp_initwnd = s_pctx->m_tunable_ctx.tcp_mssdflt;
 
 
     /* CONST */
@@ -1068,17 +1071,20 @@ int CClientServerTcp::simple_http_generic(method_program_cb_t cb){
     CEmulApp * app_c;
     uint32_t http_r_size=32*1024;
 
+    CPerProfileCtx* c_pctx = DEFAULT_PROFILE_CTX(&m_c_ctx);
+    CPerProfileCtx* s_pctx = DEFAULT_PROFILE_CTX(&m_s_ctx);
+
     if (m_mss) {
         /* change context MSS */
-        m_c_ctx.tcp_mssdflt =m_mss;
-        m_s_ctx.tcp_mssdflt =m_mss;
+        c_pctx->m_tunable_ctx.tcp_mssdflt =m_mss;
+        s_pctx->m_tunable_ctx.tcp_mssdflt =m_mss;
     }
 
     /* IW=1 */
-    m_c_ctx.tcp_initwnd = m_c_ctx.tcp_mssdflt;
-    m_s_ctx.tcp_initwnd = m_c_ctx.tcp_mssdflt;
+    c_pctx->m_tunable_ctx.tcp_initwnd = c_pctx->m_tunable_ctx.tcp_mssdflt;
+    s_pctx->m_tunable_ctx.tcp_initwnd = s_pctx->m_tunable_ctx.tcp_mssdflt;
 
-    c_flow = m_c_ctx.m_ft.alloc_flow(DEFAULT_PROFILE_CTX(&m_c_ctx),0x10000001,0x30000001,1025,80,m_vlan,m_ipv6,NULL);
+    c_flow = m_c_ctx.m_ft.alloc_flow(c_pctx,0x10000001,0x30000001,1025,80,m_vlan,m_ipv6,NULL);
     CFlowKeyTuple   c_tuple;
     c_tuple.set_src_ip(0x10000001);
     c_tuple.set_sport(1025);
@@ -1199,9 +1205,11 @@ int CClientServerTcp::fill_from_file() {
     rw_db=CAstfDB::instance()->get_db_template_rw(0, m_gen,0,1,0);
 
 
+    CPerProfileCtx* c_pctx = DEFAULT_PROFILE_CTX(&m_c_ctx);
+    CPerProfileCtx* s_pctx = DEFAULT_PROFILE_CTX(&m_s_ctx);
 
-    m_c_ctx.update_tuneables(rw_db->get_c_tuneables());
-    m_s_ctx.update_tuneables(rw_db->get_s_tuneables());
+    c_pctx->update_tuneables(rw_db->get_c_tuneables());
+    s_pctx->update_tuneables(rw_db->get_s_tuneables());
 
     uint32_t dst_ip = 0x30000001;
     uint32_t src_ip = 0x10000001;
@@ -1215,7 +1223,7 @@ int CClientServerTcp::fill_from_file() {
     uint16_t temp_index = 0;
     uint16_t tg_id = ro_db->get_template_tg_id(temp_index);
 
-    c_flow = m_c_ctx.m_ft.alloc_flow(DEFAULT_PROFILE_CTX(&m_c_ctx),src_ip,dst_ip,src_port,dst_port,m_vlan,false,NULL,tg_id);
+    c_flow = m_c_ctx.m_ft.alloc_flow(c_pctx,src_ip,dst_ip,src_port,dst_port,m_vlan,false,NULL,tg_id);
 
     CFlowKeyTuple c_tuple;
     c_tuple.set_src_ip(src_ip);

--- a/src/44bsd/tcp_input.cpp
+++ b/src/44bsd/tcp_input.cpp
@@ -558,6 +558,7 @@ HOT_FUNC int tcp_flow_input(CPerProfileCtx * pctx,
     int off;
 
     CTcpPerThreadCtx * ctx = pctx->m_ctx;
+    CTcpTunableCtx * tctx = &pctx->m_tunable_ctx;
     uint8_t *optp;  // TCP option is exist  
 
     uint16_t tg_id = tp->m_flow->m_tg_id;
@@ -633,7 +634,7 @@ HOT_FUNC int tcp_flow_input(CPerProfileCtx * pctx,
      * Reset idle time and keep-alive timer.
      */
     tp->t_idle = 0;
-    tp->t_timer[TCPT_KEEP] = ctx->tcp_keepidle;
+    tp->t_timer[TCPT_KEEP] = tctx->tcp_keepidle;
 
     /*
      * Process options if not in LISTEN state,
@@ -812,7 +813,7 @@ HOT_FUNC int tcp_flow_input(CPerProfileCtx * pctx,
         tcp_rcvseqinit(tp);
         tp->t_flags |= TF_ACKNOW;
         tp->t_state = TCPS_SYN_RECEIVED;
-        tp->t_timer[TCPT_KEEP] = ctx->tcp_keepinit;
+        tp->t_timer[TCPT_KEEP] = tctx->tcp_keepinit;
         INC_STAT(pctx, tg_id, tcps_accepts);
         goto trimthenstep6;
         }
@@ -1174,7 +1175,7 @@ trimthenstep6:
                 if (tp->t_timer[TCPT_REXMT] == 0 ||
                     ti->ti_ack != tp->snd_una)
                     tp->t_dupacks = 0;
-                else if (++tp->t_dupacks == ctx->tcprexmtthresh) {
+                else if (++tp->t_dupacks == tctx->tcprexmtthresh) {
                     tcp_seq onxt = tp->snd_nxt;
                     u_int win =
                         bsd_umin(tp->snd_wnd, tp->snd_cwnd) / 2 / tp->t_maxseg;
@@ -1192,7 +1193,7 @@ trimthenstep6:
                     if (SEQ_GT(onxt, tp->snd_nxt))
                         tp->snd_nxt = onxt;
                     goto drop;
-                } else if (tp->t_dupacks > ctx->tcprexmtthresh) {
+                } else if (tp->t_dupacks > tctx->tcprexmtthresh) {
                     tp->snd_cwnd += tp->t_maxseg;
                     (void) tcp_output(pctx,tp);
                     goto drop;
@@ -1205,7 +1206,7 @@ trimthenstep6:
          * If the congestion window was inflated to account
          * for the other side's cached packets, retract it.
          */
-        if (tp->t_dupacks > ctx->tcprexmtthresh &&
+        if (tp->t_dupacks > tctx->tcprexmtthresh &&
             tp->snd_cwnd > tp->snd_ssthresh)
             tp->snd_cwnd = tp->snd_ssthresh;
         tp->t_dupacks = 0;
@@ -1293,7 +1294,7 @@ trimthenstep6:
                  */
                 if (so->so_state & US_SS_CANTRCVMORE) {
                     soisdisconnected(so);
-                    tp->t_timer[TCPT_2MSL] = ctx->tcp_maxidle;
+                    tp->t_timer[TCPT_2MSL] = tctx->tcp_maxidle;
                 }
                 tp->t_state = TCPS_FIN_WAIT_2;
             }
@@ -1687,11 +1688,11 @@ int tcp_mss(CPerProfileCtx * pctx,
         struct tcpcb *tp, 
         u_int offer){
 
-    CTcpPerThreadCtx * ctx = pctx->m_ctx;
+    CTcpTunableCtx * tctx = &pctx->m_tunable_ctx;
 
     if (tp->m_tuneable_flags<2) {
-        tp->snd_cwnd = ctx->tcp_initwnd;
-        return ctx->tcp_mssdflt;
+        tp->snd_cwnd = tctx->tcp_initwnd;
+        return tctx->tcp_mssdflt;
     } else {
 
         uint16_t init_win_factor;
@@ -1699,8 +1700,8 @@ int tcp_mss(CPerProfileCtx * pctx,
 
         CTcpTuneables *tune = tcp_get_parent_tunable(pctx,tp);
         if (!tune) {
-            tp->snd_cwnd = ctx->tcp_initwnd;
-            return ctx->tcp_mssdflt;
+            tp->snd_cwnd = tctx->tcp_initwnd;
+            return tctx->tcp_mssdflt;
         }
 
         if (tune->is_valid_field(CTcpTuneables::tcp_no_delay)){
@@ -1720,13 +1721,13 @@ int tcp_mss(CPerProfileCtx * pctx,
         if (tune->is_valid_field(CTcpTuneables::tcp_mss_bit)){
             mss = tune->m_tcp_mss;
         }else{
-            mss = ctx->tcp_mssdflt;
+            mss = tctx->tcp_mssdflt;
         }
 
         if (tune->is_valid_field(CTcpTuneables::tcp_initwnd_bit)){
             init_win_factor = tune->m_tcp_initwnd;
         }else{
-            init_win_factor = ctx->tcp_initwnd_factor;
+            init_win_factor = tctx->tcp_initwnd_factor;
         }
 
         tp->snd_cwnd = _update_initwnd(mss,init_win_factor);

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -586,10 +586,8 @@ void CFlowGenListPerThread::load_tcp_profile(profile_id_t profile_id, bool is_fi
     m_c_tcp->append_active_profile(profile_id);
     m_s_tcp->append_active_profile(profile_id);
 
-    if (is_first) {
-        m_c_tcp->update_tuneables(rw->get_c_tuneables());
-        m_s_tcp->update_tuneables(rw->get_s_tuneables());
-    }
+    m_c_tcp->get_profile_ctx(profile_id)->update_tuneables(rw->get_c_tuneables());
+    m_s_tcp->get_profile_ctx(profile_id)->update_tuneables(rw->get_s_tuneables());
 
     /* call startup for client side */
     m_c_tcp->call_startup(profile_id);
@@ -615,9 +613,6 @@ void CFlowGenListPerThread::unload_tcp_profile(profile_id_t profile_id, bool is_
     }
 
     if (is_last) {
-        m_c_tcp->reset_tuneables();
-        m_s_tcp->reset_tuneables();
-
         m_sched_accurate = false;
     }
 }


### PR DESCRIPTION
Hi, this PR is an implementation for per-profile global tunable discussion at #560.
`CTcpPerThreadCtx` tunable variables are moved to new `CTunableCtx` class.
As added to the document, the `tcp.blackhole` tunable will be used from any profile in an epoch.

@hhaim please check my changes and give your feedback.