### PR TITLE
STF tunneling ip variation (max_ip_tunnels)

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -1964,6 +1964,7 @@ see xref:timer_w[Timer Wheel section]
        flows_dirs: [0, 1]           <9>
        keep_src_port: true          <10>
        ip_header_offset: 50         <11>
+       max_ip_tunnels: 1000         <12>
 
 ----
 <1> The name of the template pcap file. Can be relative path from the t-rex-64 image directory, or an absolute path. The pcap file should include only one flow. (Exception: in case of plug-ins).
@@ -1978,7 +1979,8 @@ see xref:timer_w[Timer Wheel section]
 <9> New in version v2.62. Sets direction of flow(s). If set to 0, has no effect. If set to 1, server will initiate the flow (with its IP) towards client with original dest port. +
  Note: does *not* work with --learn modes.
 <10> New in version v2.66. Keep original TCP/UDP source port from pcap.
-<11> New. Client IP header offset in bytes. Useful when multiple IP headers are present in the capture (e.g. tunnelled traffic). Overrides default behaviour of parsing the first IP header found.  
+<11> New Client IP header offset in bytes. Useful when multiple IP headers are present in the capture (e.g. tunnelled traffic). Overrides default behaviour of parsing the first IP header found.
+<12> New If IP tunneling is present in the template, it configures the maximum number of tunnels. The outer IPs are adjusted by incrementing them by (inner src IP % max_ip_tunnels).
 
 
 === Platform YAML (--cfg argument)

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -67,6 +67,7 @@ CFlowYamlInfo::CFlowYamlInfo() {
     m_keep_src_port = false;
     m_plugin_id = 0;
     m_ip_header_offset = 0;
+    m_max_ip_tunnels = 1;
 }
 
 void CFlowYamlInfo::Dump(FILE *fd){
@@ -91,6 +92,7 @@ void CFlowYamlInfo::Dump(FILE *fd){
     fprintf(fd,"multi_flow_enabled  : %d \n",m_multi_flow_was_set);
     fprintf(fd,"keep_src_port       : %d \n",m_keep_src_port);
     fprintf(fd, "ip_header_offset       : %d \n", m_ip_header_offset);
+    fprintf(fd, "max_ip_tunnels       : %d \n", m_max_ip_tunnels);
 
     if (m_dpPkt) {
         m_dpPkt->Dump(fd);
@@ -338,8 +340,8 @@ void CPacketIndication::Clone(CPacketIndication * obj,CCapPktRaw * pkt){
     m_packet_padding = obj->m_packet_padding;
     /* copy offsets*/
     m_ether_offset   = obj->m_ether_offset;
-	m_tunnel_ip_offset = obj->m_tunnel_ip_offset;
-	m_is_ipv6_tunnel = obj->m_is_ipv6_tunnel;
+    m_tunnel_ip_offset = obj->m_tunnel_ip_offset;
+    m_is_ipv6_tunnel = obj->m_is_ipv6_tunnel;
     m_ip_offset      = obj->m_ip_offset;
     m_udp_tcp_offset = obj->m_udp_tcp_offset;;
     m_payload_offset = obj->m_payload_offset;
@@ -379,7 +381,7 @@ void CPacketIndication::Dump(FILE *fd,int verbose){
     fprintf(fd," offsets \n");
     fprintf(fd," ------\n");
     fprintf(fd," eth       : %d \n",(int)m_ether_offset);
-	fprintf(fd," tunnel ip : %d \n", (int)m_tunnel_ip_offset);
+    fprintf(fd," tunnel ip : %d \n", (int)m_tunnel_ip_offset);
     fprintf(fd," ip        : %d \n",(int)m_ip_offset);
     fprintf(fd," udp/tcp   : %d \n",(int)m_udp_tcp_offset);
     fprintf(fd," payload   : %d \n",(int)m_payload_offset);
@@ -486,6 +488,7 @@ void CCPacketParserCounters::Dump(FILE *fd){
 
 bool CPacketParser::Create(){
     m_counter.Clear();
+    m_ip_header_offset = 0;
     return (true);
 }
 
@@ -889,12 +892,12 @@ void CPacketIndication::_ProcessPacket(CPacketParser *parser,
         m_cnt->m_non_ip++;
         return; /* Non IP */
     }
-    if (m_ip_offset){
-		// Keep track of the tunnel IP header offset we found above
-		m_tunnel_ip_offset = offset;
-		m_is_ipv6_tunnel = m_is_ipv6;
-		m_is_ipv6 = false;
-		offset = m_ip_offset;
+    if (parser->m_ip_header_offset != 0){
+        // Keep track of the tunnel IP header offset we found above
+        m_tunnel_ip_offset = offset;
+        offset = parser->m_ip_header_offset;
+        m_is_ipv6_tunnel = m_is_ipv6;
+        m_is_ipv6 = false;
         uint8_t* ip_version = (uint8_t*)(packetBase + offset);
         if ((*ip_version & 0xF0) == 0x40){
             l3.m_ipv4 = (IPHeader*)(packetBase + offset);
@@ -1633,12 +1636,11 @@ enum CCapFileFlowInfo::load_cap_file_err CCapFileFlowInfo::load_cap_file(std::st
     bool is_multi_flow_enabled = flow_info.m_multi_flow_was_set;
     bool is_custom_dirs = (flow_info.m_flows_dirs.size() > 0);
     bool keep_src_port = flow_info.m_keep_src_port;
-    pkt_indication.m_ip_offset = flow_info.m_ip_header_offset;
-
 
     CFlowTableMap flow;
 
     parser.Create();
+    parser.m_ip_header_offset = flow_info.m_ip_header_offset;
     flow.Create(0);
     CFlow * first_flow=0;
     bool first_flow_fif_is_swap=false;
@@ -1761,6 +1763,7 @@ enum CCapFileFlowInfo::load_cap_file_err CCapFileFlowInfo::load_cap_file(std::st
             }
             pkt_indication.m_desc.SetInitSide(is_init_side);
             pkt_indication.m_desc.setKeepSrcPort(keep_src_port);
+            pkt_indication.m_desc.SetMaxIpTunnels(flow_info.m_max_ip_tunnels);
             Append(&pkt_indication);
         }else{
             fprintf(stderr, "ERROR packet %d is not supported, should be Ethernet/IP(0x0800)/(TCP|UDP) format try to convert it using Wireshark !\n",cnt);
@@ -2072,6 +2075,13 @@ void operator >> (const YAML::Node& node, CFlowYamlInfo & fi) {
         node["keep_src_port"] >> fi.m_keep_src_port;
     }else{
         fi.m_keep_src_port = 0;
+    }
+
+    if (node.FindValue("max_ip_tunnels")) {
+        node["max_ip_tunnels"] >> fi.m_max_ip_tunnels;
+    }
+    else {
+        fi.m_max_ip_tunnels = 1;
     }
 
     if (node.FindValue("ip_header_offset")) {
@@ -3159,6 +3169,7 @@ void CFlowGenListPerThread::init_from_global(){
         yaml_info->m_plugin_id = lp->m_info->m_plugin_id;
         yaml_info->m_keep_src_port = lp->m_info->m_keep_src_port;
         yaml_info->m_ip_header_offset = lp->m_info->m_ip_header_offset;
+        yaml_info->m_max_ip_tunnels = lp->m_info->m_max_ip_tunnels;
         yaml_info->m_one_app_server = lp->m_info->m_one_app_server;
         yaml_info->m_server_addr = lp->m_info->m_server_addr;
         yaml_info->m_dpPkt          =lp->m_info->m_dpPkt;

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -2079,6 +2079,10 @@ void operator >> (const YAML::Node& node, CFlowYamlInfo & fi) {
 
     if (node.FindValue("max_ip_tunnels")) {
         node["max_ip_tunnels"] >> fi.m_max_ip_tunnels;
+        if (fi.m_max_ip_tunnels == 0) {
+            fprintf(stderr, " max_ip_tunnel has to be greater than 0\n");
+            exit(-1);
+        }
     }
     else {
         fi.m_max_ip_tunnels = 1;


### PR DESCRIPTION
I've added a new configuration, max_ip_tunnels, to control the number of unique tunnels by changing the outer IP addresses based on the inner source IP. To calculate the outer IPs I'm using:

tunnel IP = template tunnel IP + (current inner source IP % max_ip_tunnels)
