### PR TITLE
dump latency abnormal packets

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -1950,7 +1950,7 @@ HOT_FUNC rte_mbuf* CCoreEthIFStateless::update_node_flow_stat(rte_mbuf *m, CGenN
         lp_stats->m_lat_data[hw_id_payload].inc_seq_num();
 #ifdef ERR_CNTRS_TEST
         if (temp % 10 == 0) {
-            fsp_head->seq = lp_stats->m_lat_data[hw_id_payload].inc_seq_num();
+            fsp_head->seq = lp_stats->m_lat_data[hw_id_payload].get_seq_num();
         }
         if ((temp - 1) % 100 == 0) {
             fsp_head->seq = lp_stats->m_lat_data[hw_id_payload].get_seq_num() - 4;

--- a/src/stx/common/trex_latency_counters.h
+++ b/src/stx/common/trex_latency_counters.h
@@ -101,6 +101,8 @@ public:
     void update_stats_for_pkt(flow_stat_payload_header *fsp_head,
                               uint32_t pkt_len,
                               hr_time_t hr_time_now);
+    void set_dump_info(const rte_mbuf_t *m, flow_stat_payload_header *fsp_head);
+    void dump_err_pkt(const char* info, bool dump_latency = false);
 
     Json::Value to_json() const;
 
@@ -163,6 +165,11 @@ public:
     CRFC2544Info         *m_rfc2544;
     CRxCoreErrCntrs      *m_err_cntrs;
     uint16_t              m_ip_id_base;
+
+    // to dump abnormal packets for inspection
+    bool                  m_dump_err_pkts;
+    const rte_mbuf_t     *m_dump_pkt;
+    struct flow_stat_payload_header *m_dump_fsp_head;
 };
 
 std::ostream& operator<<(std::ostream& os, const RXLatency& in);


### PR DESCRIPTION
Hi, this PR is a simple implementation for #586.

STL latency "bad_header" and "dup" packets will be dumped as text to the **console** (stdout).
It is the default action for the **`-v 7`** command-line option.

```
dup: pkt_seq 1558, hw_id = 0
dump mbuf at 0x1b3a47940, iova=0x1b3a479c0, buf_len=2112
  pkt_len=60, ol_flags=0x180, nb_segs=1, port=1, ptype=0x691
  segment at 0x1b3a47940, data=0x1b3a47a00, len=60, off=64, refcnt=1
  Dump data at [0x1b3a47a00], len=60
00000000: 02 DF 4B 5F 09 62 02 DF 4B 5F 08 62 08 00 45 01 | ..K_.b..K_.b..E.
00000010: 00 14 FF FF 00 00 40 00 3A E8 10 00 00 01 30 00 | ......@.:.....0.
00000020: 00 01 00 00 00 00 00 00 00 00 00 00 AB 07 00 00 | ................
00000030: 16 06 00 00 4E D9 6B 56 24 3C 30 01             | ....N.kV$<0.
```

@hhaim, please review my changes and give your opinion.