### PR TITLE
docs: fix simple typo, persistance -> persistence

### DIFF
--- a/src/44bsd/tcp_output.cpp
+++ b/src/44bsd/tcp_output.cpp
@@ -870,7 +870,7 @@ void tcp_setpersist(CPerProfileCtx * pctx,
     assert(tp->t_timer[TCPT_REXMT]==0);
 
     /*
-     * Start/restart persistance timer.
+     * Start/restart persistence timer.
      */
     TCPT_RANGESET(tp->t_timer[TCPT_PERSIST],
         t * tcp_backoff[tp->t_rxtshift],

--- a/src/44bsd/tcp_timer.h
+++ b/src/44bsd/tcp_timer.h
@@ -43,7 +43,7 @@
 #define TCPT_NTIMERS    4
 
 #define TCPT_REXMT  0       /* retransmit */
-#define TCPT_PERSIST    1       /* retransmit persistance */
+#define TCPT_PERSIST    1       /* retransmit persistence */
 #define TCPT_KEEP   2       /* keep alive */
 #define TCPT_2MSL   3       /* 2*msl quiet time timer */
 
@@ -97,7 +97,7 @@
                            if 0, no idea yet */
 #define TCPTV_SRTTDFLT  (2)     /* assumed RTT if no info */
 
-#define TCPTV_PERSMIN   (  5*PR_SLOWHZ)     /* retransmit persistance */
+#define TCPTV_PERSMIN   (  5*PR_SLOWHZ)     /* retransmit persistence */
 #define TCPTV_PERSMAX   ( 10*PR_SLOWHZ)     /* maximum persist interval */
 
 #define TCPTV_KEEP_INIT ( 5*PR_SLOWHZ)     /* initial connect keep alive */


### PR DESCRIPTION
There is a small typo in src/44bsd/tcp_output.cpp, src/44bsd/tcp_timer.h.

Should read `persistence` rather than `persistance`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md