### PR TITLE
Fix issue that non-blocking send wakes up following blocked commands

### DIFF
--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -616,7 +616,7 @@ int CEmulApp::on_bh_tx_acked(uint32_t tx_bytes){
     if (add_to_queue) {
         m_api->tx_sbappend(m_flow,add_to_queue);
     }
-    if (!(m_flags&taDO_WAIT_FOR_CLOSE) && is_next) {
+    if ((m_state == te_SEND) && is_next) {
         EMUL_LOG(0, "ON_BH_TX [%d]-ACK \n",m_debug_id);
         next();
     }


### PR DESCRIPTION
Hi, this PR would amend the previous fix at PR #580.
It had fixed the issue for the `wait_for_peer_close` only.
But there is the same issue on the `recv`, `delay` and `delay_rand` also.

@hhaim please check my change and give your feedback.