### PR TITLE
ASTF prevents new server flow after stopped

### DIFF
--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -489,7 +489,7 @@ CUdpFlow * CFlowTable::alloc_flow_udp(CPerProfileCtx * pctx,
     flow->m_c_template_idx = template_id;
     flow->m_template.set_tuple(src,dst,src_port,dst_port,vlan,IPHeader::Protocol::UDP,tun_handle,is_ipv6);
     flow->init();
-    flow->m_pctx->m_flow_cnt++;
+    flow->m_pctx->append_flow(flow);
     return(flow);
 }
 
@@ -512,14 +512,14 @@ CTcpFlow * CFlowTable::alloc_flow(CPerProfileCtx * pctx,
     flow->m_c_template_idx = template_id;
     flow->m_template.set_tuple(src,dst,src_port,dst_port,vlan,IPHeader::Protocol::TCP,tun_handle,is_ipv6);
     flow->init();
-    flow->m_pctx->m_flow_cnt++;
+    flow->m_pctx->append_flow(flow);
     return(flow);
 }
 
 HOT_FUNC void CFlowTable::free_flow(CFlowBase * flow){
     assert(flow);
     CPerProfileCtx* pctx = flow->m_pctx;
-    flow->m_pctx->m_flow_cnt--;
+    flow->m_pctx->remove_flow(flow);
     flow->m_pctx->on_flow_close();
 
     if ( flow->is_udp() ){

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -754,6 +754,13 @@ void CFlowGenListPerThread::load_tcp_profile() {
 void CFlowGenListPerThread::unload_tcp_profile(profile_id_t profile_id, bool is_last, CAstfDB* astf_db) {
     m_s_tcp->remove_server_ports(profile_id);
 
+    // server flow may be left when an unexpected packet received after the profile stopped.
+    if (m_s_tcp->profile_flow_cnt(profile_id) > 0) {
+        m_s_tcp->cleanup_profile_flows(profile_id);
+    }
+    assert(m_s_tcp->profile_flow_cnt(profile_id) == 0);
+    assert(m_c_tcp->profile_flow_cnt(profile_id) == 0);
+
     m_c_tcp->remove_active_profile(profile_id);
     m_s_tcp->remove_active_profile(profile_id);
 


### PR DESCRIPTION
Hi, I had met a crash case due to a flow with a removed profile.
I found the reason and this PR would fix it.

@hhaim, please check my change and give your feedback.