### PR TITLE
remove temporary stats clear of ASTF profile

### DIFF
--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -738,13 +738,8 @@ bool TrexAstfProfile::is_safe_update_stats() {
 
 void TrexAstfProfile::clear_stats() {
     TrexAstf *stx = get_astf_object();
-    vector<CSTTCp *> sttcp_list = get_sttcp_list();
 
-    // Clear all stats inclusing accumulating stats
     if (stx->get_state() == STATE_BUILD) {
-        for (auto mlpstt : sttcp_list) {
-            mlpstt->clear_counters(false);
-        }
         m_stt_stopped_cp->clear_counters(false);
         m_stt_total_cp->clear_counters(false);
 


### PR DESCRIPTION
Hi, I've met the case an ASTF profile reports zero stats values temporarily.
This PR removes the temporary clear of ASTF profile stats and fix the issue.

During the BUILD to TX transition, all profile statistics are removed but they are restored instantly by `CGlobalTRex::update_stats()`.
This clearing action is useless and giving a temporary unexpected report.

@hhaim, please check my change and give your feedback.