### PR TITLE
ASTF stops DP core servers after all clients stopped.

### DIFF
--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -651,7 +651,7 @@ bool CFlowTable::rx_handle_packet_udp_no_flow(CTcpPerThreadCtx * ctx,
     CPerProfileCtx *pctx = temp ? temp->get_profile_ctx(): nullptr;
     CTcpServerInfo *server_info = temp ? temp->get_server_info(): nullptr;
 
-    if (!server_info || (!pctx->is_active() && pctx->get_nc())) {
+    if (!server_info || !pctx->is_open_flow_allowed()){
         rte_pktmbuf_free(mbuf);
         FT_INC_SCNT(m_err_no_template);
         return(false);
@@ -817,7 +817,7 @@ bool CFlowTable::rx_handle_packet_tcp_no_flow(CTcpPerThreadCtx * ctx,
     CPerProfileCtx *pctx = temp ? temp->get_profile_ctx(): nullptr;
     CTcpServerInfo *server_info = temp ? temp->get_server_info(): nullptr;
 
-    if (!server_info || (!pctx->is_active() && pctx->get_nc())) {
+    if (!server_info || !pctx->is_open_flow_allowed()) {
         if (!pctx) {
             pctx = FALLBACK_PROFILE_CTX(ctx);
         }

--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -443,7 +443,7 @@ bool CTcpFlow::check_template_assoc_by_l7_data(uint8_t* l7_data, uint16_t l7_len
 
     if (temp) {
         CPerProfileCtx* pctx = temp->get_profile_ctx();
-        if (pctx->is_active() || !pctx->get_nc()) {
+        if (pctx->is_open_flow_allowed()) {
             m_template_info = temp;
             return true;
         }
@@ -1028,7 +1028,7 @@ CServerTemplateInfo* CServerIpPayloadInfo::get_reference_template_info() {
             m_template_ref = &it->second;
             break;
         }
-        if (!pctx->get_nc()) {
+        if (pctx->is_open_flow_allowed()) {
             m_template_ref = &it->second;
         }
     }

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -967,7 +967,8 @@ public:
     CTcpTunableCtx      m_tunable_ctx;
 
 private:
-    bool                m_stopped;
+    bool                m_stopping;
+    bool                m_stopped;  /* reported to CP */
     bool                m_nc_flow_close;
 
     bool                m_on_flow; /* dedicated to a flow */
@@ -982,12 +983,16 @@ public:
             m_sch_rampup = nullptr;
         }
     }
-    void activate() { m_stopped = false; }
-    void deactivate() { m_stopped = true; }
-    bool is_active() { return m_stopped == false; }
+    void activate() { m_stopping = false; m_stopped = false; }
+    void deactivate() { m_stopping = true; }
+    bool is_active() { return m_stopping == false; }
+    void set_stopped() { m_stopped = true; }
+    bool is_stopped() { return m_stopped == true; }
 
     void set_nc(bool nc) { m_nc_flow_close = nc; }
     bool get_nc() { return m_nc_flow_close; }
+
+    bool is_open_flow_allowed() { return is_active()/* || (!get_nc() && !is_stopped())*/; }
 
     void on_flow_close() {
         if (m_flow_cnt == 0 && !is_active()) {

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -754,6 +754,9 @@ void CFlowGenListPerThread::load_tcp_profile() {
 void CFlowGenListPerThread::unload_tcp_profile(profile_id_t profile_id, bool is_last, CAstfDB* astf_db) {
     m_s_tcp->remove_server_ports(profile_id);
 
+    assert(m_c_tcp->profile_flow_cnt(profile_id) == 0);
+    assert(m_s_tcp->profile_flow_cnt(profile_id) == 0);
+
     m_c_tcp->remove_active_profile(profile_id);
     m_s_tcp->remove_active_profile(profile_id);
 

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -103,8 +103,9 @@ public:
     void build();
     void transmit();
     void cleanup();
-    void all_dp_cores_finished();
+    void all_dp_cores_finished(bool partial=false);
     void dp_core_finished();
+    void dp_core_finished_partial();
     void dp_core_error(const std::string &err);
 
     void add_dp_profile_ctx(CPerProfileCtx* client, CPerProfileCtx* server);
@@ -144,6 +145,7 @@ private:
     bool            m_profile_stopping;
 
     int16_t         m_active_cores;
+    int16_t         m_partial_cores;
     bool            m_nc_flow_close;
     double          m_duration;
     double          m_factor;
@@ -237,6 +239,7 @@ public:
     void shutdown(bool post_shutdown);
 
     void dp_core_finished(int thread_id, uint32_t dp_profile_id);
+    void dp_core_finished_partial(int thread_id, uint32_t dp_profile_id);
 
     void dp_core_state(int thread_id, int state);
 
@@ -302,6 +305,7 @@ public:
      * Stop transmit
      */
     void stop_transmit(cp_profile_id_t profile_id);
+    void stop_transmit_final(cp_profile_id_t profile_id);
 
     /**
      * Clear profile

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -77,7 +77,7 @@ public:
     virtual bool is_port_active(uint8_t port_id);
 
     void start_transmit(profile_id_t profile_id, double duration, bool nc);
-    void stop_transmit(profile_id_t profile_id, uint32_t stop_id);
+    void stop_transmit(profile_id_t profile_id, uint32_t stop_id, bool set_nc);
     void stop_transmit(profile_id_t profile_id);
     void update_rate(profile_id_t profile_id, double ratio);
     void create_tcp_batch(profile_id_t profile_id, double factor, CAstfDB* astf_db);
@@ -97,6 +97,7 @@ public:
 protected:
     virtual bool rx_for_idle();
     void report_finished(profile_id_t profile_id = 0);
+    void report_finished_partial(profile_id_t profile_id);
     void report_profile_ctx(profile_id_t profile_id = 0);
     void report_error(profile_id_t profile_id, const std::string &error);
     bool sync_barrier();
@@ -157,7 +158,7 @@ protected:
         return m_profile_states[profile_id];
     }
     void set_profile_active(profile_id_t profile_id);
-    void set_profile_stopping(profile_id_t profile_id);
+    void set_profile_stopping(profile_id_t profile_id, bool stop_all=true);
     int active_profile_cnt() { return m_active_profile_cnt; }
     int profile_cnt() { return m_profile_states.size(); }
 

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -60,7 +60,13 @@ TrexAstfDpStop::TrexAstfDpStop(profile_id_t profile_id, uint32_t stop_id) {
 }
 
 bool TrexAstfDpStop::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->stop_transmit(m_profile_id, m_stop_id);
+    if (m_core) {   // from add_profile_duration()
+        astf_core(dp_core)->stop_transmit(m_profile_id, m_stop_id, false);
+    }
+    else {
+        bool set_nc = (m_stop_id != 0); // override nc when CP requests
+        astf_core(dp_core)->stop_transmit(m_profile_id, m_stop_id, set_nc);
+    }
     return true;
 }
 

--- a/src/stx/common/trex_messaging.cpp
+++ b/src/stx/common/trex_messaging.cpp
@@ -109,7 +109,12 @@ TrexDpPortEventMsg::handle() {
 
 bool
 TrexDpCoreStopped::handle(void) {
-    get_stx()->dp_core_finished(m_thread_id, m_profile_id);
+    if (m_partial) {
+        get_stx()->dp_core_finished_partial(m_thread_id, m_profile_id);
+    }
+    else {
+        get_stx()->dp_core_finished(m_thread_id, m_profile_id);
+    }
     return true;
 }
 

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -277,18 +277,20 @@ private:
 class TrexDpCoreStopped : public TrexDpToCpMsgBase {
 public:
 
-    TrexDpCoreStopped(int thread_id, profile_id_t profile_id) {
+    TrexDpCoreStopped(int thread_id, profile_id_t profile_id, bool is_partial=false) {
         m_thread_id = thread_id;
         m_profile_id = profile_id;
+        m_partial = is_partial;
     }
 
-    TrexDpCoreStopped(int thread_id) : TrexDpCoreStopped(thread_id, 0) {}
+    TrexDpCoreStopped(int thread_id) : TrexDpCoreStopped(thread_id, 0, false) {}
 
     virtual bool handle(void);
 
 private:
     int m_thread_id;
     profile_id_t m_profile_id;
+    bool m_partial;
 };
 
 /**

--- a/src/stx/common/trex_stx.cpp
+++ b/src/stx/common/trex_stx.cpp
@@ -168,6 +168,10 @@ TrexSTX::dp_core_finished(int thread_id, uint32_t profile_id) {
 }
 
 void
+TrexSTX::dp_core_finished_partial(int thread_id, uint32_t profile_id) {
+}
+
+void
 TrexSTX::add_dp_profile_ctx(uint32_t profile_id, void* client, void* server) {
 }
 

--- a/src/stx/common/trex_stx.h
+++ b/src/stx/common/trex_stx.h
@@ -146,6 +146,7 @@ public:
      * DP core has finished
      */
     virtual void dp_core_finished(int thread_id, uint32_t profile_id);
+    virtual void dp_core_finished_partial(int thread_id, uint32_t profile_id);
     virtual void add_dp_profile_ctx(uint32_t profile_id, void* client, void* server);
 
     /**


### PR DESCRIPTION
Hi, this PR is another solution for PR #618.

This change separates the DP core report of TX finished.
CP will send the stop request finally after all DP core clients stopped.
This makes DP core servers confirm that there would be no surplus flows.
After the server stopped, open flows are not allowed anymore.

@hhaim, please look at this change also. If you like this one, I will give up PR #618.
