### PR TITLE
Bump m_rw_mbuf_size to 255 if udp/tcp offsets are larger than 128

### DIFF
--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -277,7 +277,7 @@ void CPacketIndication::UpdateMbufSize(){
 		m_rw_mbuf_size = 255;
 	}
 	else{
-        printf(" ERROR packet r/w is more than 128 bytes. it is not supported \n");
+        printf(" ERROR packet r/w is more than 255 bytes. it is not supported \n");
         exit(1);
     }
  

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -269,15 +269,18 @@ void CPacketIndication::UpdateMbufSize(){
 
     if (offset<=64) {
         m_rw_mbuf_size=64;
-    }else{
-        if (offset<=128) {
-            m_rw_mbuf_size=128;
-        }else{
-            printf(" ERROR packet r/w is more than 128 bytes. it is not supported \n");
-            exit(1);
-        }
     }
-
+	else if (offset <= 128) {
+		m_rw_mbuf_size = 128;
+	}
+	else if (offset <= 255) {
+		m_rw_mbuf_size = 255;
+	}
+	else{
+        printf(" ERROR packet r/w is more than 128 bytes. it is not supported \n");
+        exit(1);
+    }
+ 
     uint16_t pkt_len = m_packet->getTotalLen();
 
     if ( pkt_len > m_rw_mbuf_size ) {


### PR DESCRIPTION
We ran into this issue by trying to configure vxlan IPv6 tunnels that add up to UDP/TCP offset >128