### PR TITLE
use TCP slow timer tick as defined

### DIFF
--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -884,8 +884,7 @@ void CTcpPerThreadCtx::init_sch_rampup(profile_id_t profile_id){
 }
 
 int CTcpTunableCtx::convert_slow_sec_to_ticks(uint16_t sec) {
-    // tcp_slow_fast_ratio + 1 for the slow_tcp bug (tick starts at 0, ratio at 1)
-    float sec_to_ticks = 1000.0f / ((tcp_slow_fast_ratio + 1) * TCP_TIMER_TICK_FAST_MS);
+    float sec_to_ticks = 1000.0f / TCP_TIMER_TICK_SLOW_MS;
     return int(round(float(sec) * sec_to_ticks));
 }
 

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -1728,11 +1728,10 @@ public:
 
 inline void CTcpFlow::on_tick(){
         on_fast_tick();
+        m_tick++;
         if (m_tick == m_pctx->m_tunable_ctx.tcp_slow_fast_ratio) {
-            m_tick=0;
             on_slow_tick();
-        }else{
-            m_tick++;
+            m_tick=0;
         }
 }
 


### PR DESCRIPTION
Hi, this PR is for issue #639.

From this change, TCP slow timer tick would be as defined TCP_TIMER_TICK_SLOW_MS, 500ms.

@hhaim please give your feedback.