### PR TITLE
prevent surplus packets from ARP on STLFlowLatencyStats

### DIFF
--- a/src/common/Network/Packet/MacAddress.h
+++ b/src/common/Network/Packet/MacAddress.h
@@ -23,6 +23,10 @@ limitations under the License.
 #define ETHER_ADDR_LEN  6 /**< Length of Ethernet address. */
 #endif
 
+#ifndef ETHER_GROUP_ADDR
+#define ETHER_GROUP_ADDR  0x01 /**< Multicast or broadcast Eth. address. */
+#endif
+
 class MacAddress
 {
 public:
@@ -99,6 +103,12 @@ public:
         static MacAddress defaultMac;
         return (*this == allZeros || *this == defaultMac);
     }
+
+    bool isUnicastAddress() const
+    {
+        return (data[0] & ETHER_GROUP_ADDR) == 0;
+    }
+
     void setIdentifierAsBogusAddr(uint32_t identifier)
     {
         *(uint32_t*)data = identifier;

--- a/src/stx/common/trex_latency_counters.cpp
+++ b/src/stx/common/trex_latency_counters.cpp
@@ -211,7 +211,9 @@ void RXLatency::handle_pkt(const rte_mbuf_t *m, int port) {
           if (m_rcv_all && (!is_flow_stat_id(ip_id) ||
               (fsp_head->magic == FLOW_STAT_PAYLOAD_MAGIC &&
                fsp_head->hw_id < MAX_FLOW_STATS_PAYLOAD))) {
-            ip_id = FLOW_STAT_PAYLOAD_IP_ID;
+            if ((rte_pktmbuf_mtod(m, EthernetHeader *))->getDestMacP()->isUnicastAddress()) {
+                ip_id = FLOW_STAT_PAYLOAD_IP_ID;
+            }
           }
           if (is_flow_stat_payload_id(ip_id)) {
             hr_time_t hr_time_now = os_get_hr_tick_64();


### PR DESCRIPTION
Hi, this PR is for issue #650 solution.

Since I didn't find the proper stub location for the `rte_ether.h`,
I added `MacAddress::isUnicastAddress` and used it.

@hhaim, please review my change and give your feedback.