### PR TITLE
fix trex-console exception on template_group

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -1673,7 +1673,8 @@ class ASTFClient(TRexClient):
 
         opts = parser.parse_args(shlex.split(line))
 
-        if not opts:
+        if not opts or not opts.command:
+            parser.print_help()
             return
 
         pid_input = opts.profiles
@@ -1681,6 +1682,7 @@ class ASTFClient(TRexClient):
 
         for profile_id in valid_pids:
             if opts.command == 'names':
+                print(format_text("Profile ID: %s" % profile_id, 'bold'))
                 self.traffic_stats._show_tg_names(start=opts.start, amount=opts.amount, pid_input = profile_id)
             elif opts.command == 'stats':
                 try:


### PR DESCRIPTION
Hi, this minor change is to avoid an exception when `template_group` command used in `trex-console`.
```
trex>template_group 
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
....
..../automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py", line 1679, in template_group_line
    pid_input = opts.profiles
AttributeError: 'Namespace' object has no attribute 'profiles'
Shutting down RPC client

```

@hhaim please check my changes and give your feedback.
