### PR TITLE
ASTF program adds rx_mode in UDP keepalive.

### DIFF
--- a/scripts/astf_schema.json
+++ b/scripts/astf_schema.json
@@ -242,6 +242,10 @@
                       "msec" : {
                           "type" : "integer",
                           "minimum": 0
+                      },
+
+                      "rx_mode" : {
+                          "type" : "boolean"
                       }   
                 },
                 "required": ["name","msec"]

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -83,7 +83,7 @@ class ASTFClient(TRexClient):
 
         """
 
-        api_ver = {'name': 'ASTF', 'major': 2, 'minor': 0}
+        api_ver = {'name': 'ASTF', 'major': 2, 'minor': 1}
 
         TRexClient.__init__(self,
                             api_ver,

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -138,10 +138,12 @@ class ASTFCmdSend(ASTFCmd):
         return ret
 
 class ASTFCmdKeepaliveMsg(ASTFCmd):
-    def __init__(self, msec):
+    def __init__(self, msec, rx_mode=False):
         super(ASTFCmdKeepaliveMsg, self).__init__()
         self.fields['name'] = 'keepalive'
         self.fields['msec'] = msec
+        if rx_mode:
+            self.fields['rx_mode'] = rx_mode
         self.stream=False
 
 
@@ -468,21 +470,25 @@ class ASTFProgram(object):
 
         self.fields['commands'].append(ASTFCmdTxMode(flags))
 
-    def set_keepalive_msg (self,msec):
+    def set_keepalive_msg (self,msec,rx_mode=False):
         """
         set_keepalive_msg (msec), set the keepalive timer for UDP flows 
 
         :parameters:
                   msec  : uint32_t
                    the keepalive time in msec 
+                  rx_mode  : bool
+                   reset by rx packets only. i.e. send_msg does not reset the keepalive timer.
         """
 
         ver_args = {"types":
-                    [{"name": "msec", 'arg': msec, "t": int}]
+                    [{"name": "msec", 'arg': msec, "t": int},
+                     {"name": "rx_mode", 'arg': rx_mode, "t": bool, "must": False}
+                    ]
                     }
         ArgVerify.verify(self.__class__.__name__ + "." + sys._getframe().f_code.co_name, ver_args)
 
-        self.fields['commands'].append(ASTFCmdKeepaliveMsg(msec))
+        self.fields['commands'].append(ASTFCmdKeepaliveMsg(msec, rx_mode))
 
 
     def recv_msg(self, pkts,clear=False):

--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -515,7 +515,8 @@ CEmulAppCmd* CEmulApp::process_cmd_one(CEmulAppCmd * cmd){
     case tcKEEPALIVE : 
         {
             m_state=te_NONE;
-            m_api->set_keepalive((CUdpFlow *)m_flow,cmd->u.m_keepalive.m_keepalive_msec);
+            m_api->set_keepalive((CUdpFlow *)m_flow,cmd->u.m_keepalive.m_keepalive_msec,
+                                 cmd->u.m_keepalive.m_rx_mode);
             return next_cmd();
         }
         break;

--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -357,6 +357,7 @@ struct CEmulAppCmdRxPkt {
 
 struct CEmulAppCmdKeepAlive {
     uint64_t        m_keepalive_msec; /* set keepalive in msec */
+    bool            m_rx_mode; /* keepalive in rx only */
 };
 
 
@@ -422,7 +423,8 @@ public:
                           )=0;
 
     virtual void set_keepalive(CUdpFlow *         flow,
-                               uint64_t           msec
+                               uint64_t           msec,
+                               bool               rx_mode
                                )=0;
 
 };

--- a/src/44bsd/tcp_var.h
+++ b/src/44bsd/tcp_var.h
@@ -708,7 +708,7 @@ public:
 
     void disconnect();
 
-    void set_keepalive(uint64_t  msec);
+    void set_keepalive(uint64_t msec, bool rx_mode);
 
     void on_tick();
 
@@ -750,6 +750,7 @@ private:
 
 public:
     CHTimerObj        m_keep_alive_timer; /* 32 bytes */ 
+    bool              m_keepalive_rx_mode; /* keepalive by rx only */
     uint32_t          m_keepalive_ticks;
     uint8_t           m_mbuf_socket;    /* mbuf socket */
     uint8_t           m_keepalive;      /* 1- no-alive 0- alive */
@@ -1665,8 +1666,8 @@ public:
     }
 
     virtual void set_keepalive(CUdpFlow *         flow,
-                               uint64_t           msec
-                               ){
+                               uint64_t           msec,
+                               bool               rx_mode){
         assert(0);
     }
 };
@@ -1718,9 +1719,9 @@ public:
     }
 
     virtual void set_keepalive(CUdpFlow *         flow,
-                               uint64_t           msec
-                               ){
-        flow->set_keepalive(msec);
+                               uint64_t           msec,
+                               bool               rx_mode){
+        flow->set_keepalive(msec, rx_mode);
     }
 };
 

--- a/src/44bsd/udp.cpp
+++ b/src/44bsd/udp.cpp
@@ -178,7 +178,9 @@ HOT_FUNC rte_mbuf_t   * CUdpFlow::alloc_and_build(CMbufBuffer *      buf){
 
 
 void CUdpFlow::send_pkt(CMbufBuffer *      buf){
-    m_keepalive=0;
+    if (!m_keepalive_rx_mode) {
+        m_keepalive=0;
+    }
     rte_mbuf_t   * m = alloc_and_build(buf);
     if (m==0) {
         return;
@@ -222,7 +224,8 @@ void CUdpFlow::keepalive_timer_start(bool init){
     m_remain_ticks -= ticks;
 }
 
-void CUdpFlow::set_keepalive(uint64_t  msec){
+void CUdpFlow::set_keepalive(uint64_t msec, bool rx_mode){
+    m_keepalive_rx_mode = rx_mode;
     m_keepalive_ticks = tw_time_msec_to_ticks(msec);
     /* stop and restart the timer with new time */
     m_pctx->m_ctx->m_timer_w.timer_stop(&m_keep_alive_timer);

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -574,6 +574,11 @@ void CAstfDB::fill_keepalive_pkt(uint32_t program_index,
     assert_cmd(program_index, cmd_index, "keepalive", cmd);
 
     res.u.m_keepalive.m_keepalive_msec =cmd["msec"].asUInt();
+    if (cmd["rx_mode"] != Json::nullValue) {
+        res.u.m_keepalive.m_rx_mode = cmd["rx_mode"].asBool();
+    } else {
+        res.u.m_keepalive.m_rx_mode = false;
+    }
 }
 
 

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -46,7 +46,7 @@ using namespace std;
 TrexAstf::TrexAstf(const TrexSTXCfg &cfg) : TrexSTX(cfg) {
     /* API core version */
     const int API_VER_MAJOR = 2;
-    const int API_VER_MINOR = 0;
+    const int API_VER_MINOR = 1;
     m_l_state = STATE_L_IDLE;
     m_latency_pps = 0;
     m_lat_with_traffic = false;


### PR DESCRIPTION
Hi, this PR is to add RX-only mode to the ASTF UDP keepalive feature.

Since the keepalive timer has been reset by default with TX/RX packets, during a flow sends packets by `send_msg`, the keepalive timeout would not occur even though there are no RX packets.
In this situation, I'd like to check the keepalive timeout by RX packets only. So I added the `rx_mode` to the `set_keepalive_msg`.

@hhaim, please review my changes and give your feedback.