### PR TITLE
change the number of ARP requests for gw address resolution

### DIFF
--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -552,6 +552,7 @@ public:
         m_learn_mode = 0;
         m_debug_pkt_proto = 0;
         m_arp_ref_per = 120; // in seconds
+        m_arp_req_limit = 10;
         m_rx_thread_enabled = false;
         cfg_file = "";
         client_cfg_file = "";
@@ -614,6 +615,7 @@ public:
     uint8_t         m_learn_mode;
     uint16_t        m_debug_pkt_proto;
     uint16_t        m_arp_ref_per;
+    uint16_t        m_arp_req_limit; // limit the initial ARP req for GW address
     uint8_t         m_dummy_count;
     uint8_t         m_reta_mask;
     bool            m_rx_thread_enabled;


### PR DESCRIPTION
Hi, this PR is to change the number of ARP requests for GW address resolution during `t-rex-64` startup.
The previous implementation has the hard-coded number 10.
My user wants to start DUT and T-Rex machine simultaneously to save startup time.
Sometimes DUT cannot reply to the ARP request in time. If the GW address resolution is failed at startup, the user should additional ARP requests for the test cases.
So I added a new command-line option `--limit-arp-request <count>`. If the value is 0, it will go until the GW address is resolved.

@hhaim what do you think about this change? Please review it and give your feedback.