### PR TITLE
net/mlx5: fix the drop action for the DR/DV

### DIFF
--- a/src/dpdk/drivers/net/mlx5/linux/mlx5_os.c
+++ b/src/dpdk/drivers/net/mlx5/linux/mlx5_os.c
@@ -325,7 +325,17 @@ mlx5_alloc_shared_dr(struct mlx5_priv *priv)
 			goto error;
 		}
 		sh->fdb_domain = domain;
-		sh->esw_drop_action = mlx5_glue->dr_create_flow_action_drop();
+	}
+	/*
+	 * The drop action is just some dummy placeholder in rdma-core. It
+	 * does not belong to domains and has no any attributes, and, can be
+	 * shared by the entire device.
+	 */
+	sh->dr_drop_action = mlx5_glue->dr_create_flow_action_drop();
+	if (!sh->dr_drop_action) {
+		DRV_LOG(ERR, "FDB mlx5dv_dr_create_flow_action_drop");
+		err = errno;
+		goto error;
 	}
 #endif
 	if (!sh->tunnel_hub)
@@ -361,9 +371,9 @@ error:
 		mlx5_glue->dr_destroy_domain(sh->fdb_domain);
 		sh->fdb_domain = NULL;
 	}
-	if (sh->esw_drop_action) {
-		mlx5_glue->destroy_flow_action(sh->esw_drop_action);
-		sh->esw_drop_action = NULL;
+	if (sh->dr_drop_action) {
+		mlx5_glue->destroy_flow_action(sh->dr_drop_action);
+		sh->dr_drop_action = NULL;
 	}
 	if (sh->pop_vlan_action) {
 		mlx5_glue->destroy_flow_action(sh->pop_vlan_action);
@@ -418,9 +428,9 @@ mlx5_os_free_shared_dr(struct mlx5_priv *priv)
 		mlx5_glue->dr_destroy_domain(sh->fdb_domain);
 		sh->fdb_domain = NULL;
 	}
-	if (sh->esw_drop_action) {
-		mlx5_glue->destroy_flow_action(sh->esw_drop_action);
-		sh->esw_drop_action = NULL;
+	if (sh->dr_drop_action) {
+		mlx5_glue->destroy_flow_action(sh->dr_drop_action);
+		sh->dr_drop_action = NULL;
 	}
 #endif
 	if (sh->pop_vlan_action) {

--- a/src/dpdk/drivers/net/mlx5/mlx5.h
+++ b/src/dpdk/drivers/net/mlx5/mlx5.h
@@ -710,7 +710,7 @@ struct mlx5_dev_ctx_shared {
 	struct mlx5_hlist *flow_tbls;
 	struct mlx5_flow_tunnel_hub *tunnel_hub;
 	/* Direct Rules tables for FDB, NIC TX+RX */
-	void *esw_drop_action; /* Pointer to DR E-Switch drop action. */
+	void *dr_drop_action; /* Pointer to DR E-Switch drop action. */
 	void *pop_vlan_action; /* Pointer to DR pop VLAN action. */
 	struct mlx5_hlist *encaps_decaps; /* Encap/decap action hash list. */
 	struct mlx5_hlist *modify_cmds;

--- a/src/dpdk/drivers/net/mlx5/mlx5_flow_dv.c
+++ b/src/dpdk/drivers/net/mlx5/mlx5_flow_dv.c
@@ -11993,11 +11993,19 @@ flow_dv_apply(struct rte_eth_dev *dev, struct rte_flow *flow,
 		n = dv->actions_n;
 		if (dh->fate_action == MLX5_FLOW_FATE_DROP) {
 			if (dv->transfer) {
-				dv->actions[n++] = priv->sh->esw_drop_action;
+				MLX5_ASSERT(priv->sh->dr_drop_action);
+				dv->actions[n++] = priv->sh->dr_drop_action;
 			} else {
+#ifdef HAVE_MLX5DV_DR
+				/* DR supports drop action placeholder. */
+				MLX5_ASSERT(priv->sh->dr_drop_action);
+				dv->actions[n++] = priv->sh->dr_drop_action;
+#else
+				/* For DV we use the explicit drop queue. */
 				MLX5_ASSERT(priv->drop_queue.hrxq);
 				dv->actions[n++] =
 						priv->drop_queue.hrxq->action;
+#endif
 			}
 		} else if ((dh->fate_action == MLX5_FLOW_FATE_QUEUE &&
 			   !dv_h->rix_sample && !dv_h->rix_dest_array)) {
@@ -13705,7 +13713,8 @@ mlx5_flow_dv_discover_counter_offset_support(struct rte_eth_dev *dev)
 						    &actions[0]);
 	if (ret)
 		goto err;
-	actions[1] = priv->drop_queue.hrxq->action;
+	actions[1] = sh->dr_drop_action ? sh->dr_drop_action :
+					  priv->drop_queue.hrxq->action;
 	dv_attr.match_criteria_enable = flow_dv_matcher_enable(mask.buf);
 	ret = mlx5_flow_os_create_flow_matcher(sh->ctx, &dv_attr, tbl->obj,
 					       &matcher);


### PR DESCRIPTION
There are multiple branches in rdma-core library backing:
the rte flows:
  - Verbs
  - Direct Verbs (DV)
  - Direct Rules (DR)

The Verbs API always requires the specifying the queue even
if there is the drop action in the flow, though the kernel
optimizes out the actual queue usage for the flows containing
the drop action. The PMD handles the dedicated Rx queue to
provide Verbs API compatibility.

The DV/DR API does not require explicit specifying the queue
at the flow creation, but PMD still specified the dedicated
drop queue as action. It performed the packet forwarding to
the dummy queue (that was not polled at all) causing the
steering pipeline resources usage and degrading the overall
packet processing rate. For example, with inserted flow to
drop all the ingress packets the statistics reported only
15Mpps of 64B packets were received over 100Gbps line.

Since the Direct Rule API for E-Switch was introduced the
rdma-core supports the dedicated drop action, that is recognized
both for DV and DR and can be used for the entire device in
unified fashion, regardless of steering domain. The similar drop
action was introduced for E-Switch, the usage of this one can be
extended for other steering domains, not for E-Switch's one only.

This patch:
  - renames esw_drop_action to dr_drop_action to emphasize
    the global nature of the variable (not only E-Switch domain)
  - specifies this global drop action instead
    of dedicated drop queue

[1] In DPDK Upstream: http://patches.dpdk.org/project/dpdk/patch/20210405095901.29202-1-viacheslavo@nvidia.com/
[2] T-Rex issue: https://github.com/cisco-system-traffic-generator/trex-core/issues/632

Signed-off-by: Viacheslav Ovsiienko <viacheslavo@nvidia.com>