### PR TITLE
Automatic ASTF profile stop when there is no flow generation

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1189,6 +1189,9 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
     ret->set_tuneables(c_tune, s_tune);
 
     std::vector<double>  dist;
+
+    ret->set_flow_limited(true);
+
     // loop over all templates
     for (uint32_t index = 0; index < m_val["templates"].size(); index++) {
         CAstfPerTemplateRW *temp_rw = new CAstfPerTemplateRW();
@@ -1220,6 +1223,11 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
 
             /* there is a limit */
             temp_rw->set_limit(cnt, is_cont);
+            if (is_cont) {
+                ret->set_flow_limited(false);
+            }
+        } else {
+            ret->set_flow_limited(false);
         }
 
         CTcpTuneables *s_tuneable;

--- a/src/astf/astf_template_db.h
+++ b/src/astf/astf_template_db.h
@@ -155,6 +155,19 @@ public:
         m_s_tuneables = s_tune;
     }
 
+    void set_flow_limited(bool limited) { m_flow_limited = limited; }
+    bool has_flow_gen() {
+        if (m_flow_limited) {
+            for (auto rw: m_cap_gen) {
+                if (!rw->check_limit()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
 private:
     KxuNuRand *                       m_nru;
     KxuLCRand                         m_rnd;
@@ -163,6 +176,7 @@ private:
     astf_thread_id_t                  m_max_threads;
     CTcpTuneables *                   m_s_tuneables;
     CTcpTuneables *                   m_c_tuneables;
+    bool                              m_flow_limited;
 } ;
 
 

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -667,8 +667,9 @@ struct CGenNodeTXFIF : public CGenNodeBase {
 public:
     CPerProfileCtx *    m_pctx;
     double              m_time_stop;
+    bool                m_set_nc;
 
-    uint8_t             m_pad_end[96];
+    uint8_t             m_pad_end[95];
 
     /* CACHE_LINE */
 #ifdef __PPC64__

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -78,7 +78,7 @@ public:
 
     void start_transmit(profile_id_t profile_id, double duration, bool nc);
     void stop_transmit(profile_id_t profile_id, uint32_t stop_id, bool set_nc);
-    void stop_transmit(profile_id_t profile_id);
+    void stop_transmit(profile_id_t profile_id, bool set_nc);
     void update_rate(profile_id_t profile_id, double ratio);
     void create_tcp_batch(profile_id_t profile_id, double factor, CAstfDB* astf_db);
     void delete_tcp_batch(profile_id_t profile_id, bool do_remove, CAstfDB* astf_db);

--- a/src/stx/astf_batch/trex_astf_batch.cpp
+++ b/src/stx/astf_batch/trex_astf_batch.cpp
@@ -101,6 +101,7 @@ TrexDpCoreAstfBatch::start_astf() {
         tx_node->m_type = CGenNode::TCP_TX_FIF;
         tx_node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
         tx_node->m_time_stop = 0.0;
+        tx_node->m_set_nc = false;
         tx_node->m_pctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
         m_core->m_node_gen.add_node((CGenNode*)tx_node);
     }


### PR DESCRIPTION
Hi, I have prepared the PR for #676.

From this change,
1. ASTF profile stop automatically when there is no expected flow generation.
2. If it is started with duration and nc option, it tries to stop without nc during the duration, and stop with nc after the duration still the profile is stopping.

@hhaim, please review my changes and give your feedback.
