### PR TITLE
ASTF traffic duration with nc option (#680)

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -651,7 +651,7 @@ class ASTFClient(TRexClient):
                 self.logger.info(format_text("Cannot remove a profile: %s is not state IDLE and state LOADED.\n" % profile_id, "bold", "magenta"))
 
     @client_api('command', True)
-    def start(self, mult = 1, duration = -1, nc = False, block = True, latency_pps = 0, ipv6 = False, pid_input = DEFAULT_PROFILE_ID, client_mask = 0xffffffff):
+    def start(self, mult = 1, duration = -1, nc = False, block = True, latency_pps = 0, ipv6 = False, pid_input = DEFAULT_PROFILE_ID, client_mask = 0xffffffff, e_duration = 0, t_duration = 0):
         """
             Start the traffic on loaded profile. Procedure is async.
 
@@ -681,6 +681,16 @@ class ASTFClient(TRexClient):
                 pid_input: string
                     Input profile ID
 
+                e_duration: float
+                    Maximum time to wait for one flow to be established.
+                    Stop the flow generation when this time is over. Stop immediately with nc.
+                    Disabled by default. Enabled by positive values.
+
+                t_duration: float
+                    Maximum time to wait for all the flow to terminate gracefully after duration.
+                    Stop immediately (overrides nc pararmeter) when this time is over.
+                    Disabled by default. Enabled by non-zero values.
+
             :raises:
                 + :exc:`TRexError`
         """
@@ -694,6 +704,8 @@ class ASTFClient(TRexClient):
             'latency_pps': latency_pps,
             'ipv6': ipv6,
             'client_mask': client_mask,
+            'e_duration': e_duration,
+            't_duration': t_duration,
             }
 
         self.ctx.logger.pre_cmd('Starting traffic.')
@@ -1330,6 +1342,8 @@ class ASTFClient(TRexClient):
                                          parsing_opts.FILE_PATH,
                                          parsing_opts.MULTIPLIER_NUM,
                                          parsing_opts.DURATION,
+                                         parsing_opts.ESTABLISH_DURATION,
+                                         parsing_opts.TERMINATE_DURATION,
                                          parsing_opts.ARGPARSE_TUNABLES,
                                          parsing_opts.ASTF_NC,
                                          parsing_opts.ASTF_LATENCY,
@@ -1378,7 +1392,7 @@ class ASTFClient(TRexClient):
             elif opts.servers_only:
                 kw['client_mask'] = 0
 
-            self.start(opts.mult, opts.duration, opts.nc, False, opts.latency_pps, opts.ipv6, pid_input = profile_id, **kw)
+            self.start(opts.mult, opts.duration, opts.nc, False, opts.latency_pps, opts.ipv6, pid_input = profile_id, e_duration = opts.e_duration, t_duration = opts.t_duration, **kw)
 
         return True
 

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -696,6 +696,24 @@ class OPTIONS_DB_ARGS:
          'default': -1.0,
          'help': "Set duration time for job."})
 
+    ESTABLISH_DURATION = ArgumentPack(
+        ['--e_duration'],
+        {'action': "store",
+         'metavar': 'TIME',
+         'dest': 'e_duration',
+         'type': match_time_unit,
+         'default': 0.0,
+         'help': "Set time limit for the first flow establishment."})
+
+    TERMINATE_DURATION = ArgumentPack(
+        ['--t_duration'],
+        {'action': "store",
+         'metavar': 'TIME',
+         'dest': 't_duration',
+         'type': match_time_unit,
+         'default': 0.0,
+         'help': "Set time limit waiting for all the flow to terminate gracefully."})
+
     TIMEOUT = ArgumentPack(
         ['-t'],
         {'action': "store",

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -667,9 +667,11 @@ struct CGenNodeTXFIF : public CGenNodeBase {
 public:
     CPerProfileCtx *    m_pctx;
     double              m_time_stop;
+    double              m_time_established;
+    double              m_terminate_duration;
     bool                m_set_nc;
 
-    uint8_t             m_pad_end[95];
+    uint8_t             m_pad_end[79];
 
     /* CACHE_LINE */
 #ifdef __PPC64__

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -366,6 +366,8 @@ void TrexAstf::start_transmit(cp_profile_id_t profile_id, const start_params_t &
     pid->set_factor(args.mult);
     pid->set_duration(args.duration);
     pid->set_nc_flow_close(args.nc);
+    pid->set_establish_timeout(args.e_duration);
+    pid->set_terminate_duration(args.t_duration);
 
     m_opts->m_astf_client_mask = args.client_mask;
     m_opts->preview.set_ipv6_mode_enable(args.ipv6);
@@ -965,7 +967,7 @@ void TrexAstfPerProfile::transmit() {
 
     profile_change_state(STATE_TX);
 
-    TrexCpToDpMsgBase *msg = new TrexAstfDpStart(m_dp_profile_id, m_duration, m_nc_flow_close);
+    TrexCpToDpMsgBase *msg = new TrexAstfDpStart(m_dp_profile_id, m_duration, m_nc_flow_close, m_establish_timeout, m_terminate_duration);
 
     m_astf_obj->send_message_to_all_dp(msg, true);
 }

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -130,6 +130,8 @@ public:
     void    set_profile_stopping(bool stopping) { m_profile_stopping = stopping; }
     void    set_nc_flow_close(bool nc) { m_nc_flow_close = nc; }
     void    set_duration(double duration) { m_duration = duration; }
+    void    set_establish_timeout(double timeout) { m_establish_timeout = timeout; }
+    void    set_terminate_duration(double duration) { m_terminate_duration = duration; }
     void    set_factor(double mult) { m_factor = mult; }
 
     /*
@@ -148,6 +150,8 @@ private:
     int16_t         m_partial_cores;
     bool            m_nc_flow_close;
     double          m_duration;
+    double          m_establish_timeout;
+    double          m_terminate_duration;
     double          m_factor;
     std::string     m_error;
 

--- a/src/stx/astf/trex_astf_defs.h
+++ b/src/stx/astf/trex_astf_defs.h
@@ -30,6 +30,8 @@ typedef struct {
     uint32_t    latency_pps;
     bool        ipv6;
     uint32_t    client_mask;
+    double      e_duration;
+    double      t_duration;
 } start_params_t;
 
 

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -52,6 +52,8 @@ struct profile_param {
     profile_id_t    m_profile_id;
     double          m_duration;
     bool            m_nc_flow_close;
+    double          m_establish_timeout;
+    double          m_terminate_duration;
 };
 
 class TrexAstfDpCore : public TrexDpCore {
@@ -76,7 +78,7 @@ public:
      */
     virtual bool is_port_active(uint8_t port_id);
 
-    void start_transmit(profile_id_t profile_id, double duration, bool nc);
+    void start_transmit(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration);
     void stop_transmit(profile_id_t profile_id, uint32_t stop_id, bool set_nc);
     void stop_transmit(profile_id_t profile_id, bool set_nc);
     void update_rate(profile_id_t profile_id, double ratio);
@@ -111,7 +113,7 @@ protected:
     void set_profile_stop_id(profile_id_t profile_id, uint32_t stop_id);
 
     void get_scheduler_options(profile_id_t profile_id, bool& disable_client, double& d_time_flow, double& d_phase);
-    void start_profile_ctx(profile_id_t profile_id, double duration, bool nc);
+    void start_profile_ctx(profile_id_t profile_id, double duration, bool nc, double establish_timeout = 0.0, double terminate_duration = 0.0);
     void stop_profile_ctx(profile_id_t profile_id, uint32_t stop_id);
 
     std::vector<struct profile_param> m_sched_param;

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -34,20 +34,22 @@ TrexAstfDpCore* astf_core(TrexDpCore *dp_core) {
 /*************************
   start traffic message
  ************************/
-TrexAstfDpStart::TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc) {
+TrexAstfDpStart::TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration) {
     m_profile_id = profile_id;
     m_duration = duration;
     m_nc_flow_close = nc;
+    m_establish_timeout = establish_timeout;
+    m_terminate_duration = terminate_duration;
 }
 
 
 bool TrexAstfDpStart::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->start_transmit(m_profile_id, m_duration, m_nc_flow_close);
+    astf_core(dp_core)->start_transmit(m_profile_id, m_duration, m_nc_flow_close, m_establish_timeout, m_terminate_duration);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpStart::clone() {
-    return new TrexAstfDpStart(m_profile_id, m_duration, m_nc_flow_close);
+    return new TrexAstfDpStart(m_profile_id, m_duration, m_nc_flow_close, m_establish_timeout, m_terminate_duration);
 }
 
 /*************************

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -57,13 +57,15 @@ private:
  */
 class TrexAstfDpStart : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc);
+    TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration);
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
     profile_id_t m_profile_id;
     double m_duration;
     bool m_nc_flow_close;
+    double m_establish_timeout;
+    double m_terminate_duration;
 };
 
 /**

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -278,6 +278,8 @@ TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
     args.latency_pps = parse_uint32(params, "latency_pps", result);
     args.ipv6 = parse_bool(params, "ipv6", result);
     args.client_mask = parse_uint32(params, "client_mask", result);
+    args.e_duration = parse_double(params, "e_duration", result, 0.0);
+    args.t_duration = parse_double(params, "t_duration", result, 0.0);
 
     try {
         get_astf_object()->start_transmit(profile_id, args);

--- a/src/stx/astf_batch/trex_astf_batch.cpp
+++ b/src/stx/astf_batch/trex_astf_batch.cpp
@@ -101,6 +101,8 @@ TrexDpCoreAstfBatch::start_astf() {
         tx_node->m_type = CGenNode::TCP_TX_FIF;
         tx_node->m_time = now + d_phase + 0.1; /* phase the transmit a bit */
         tx_node->m_time_stop = 0.0;
+        tx_node->m_time_established = 0.0;
+        tx_node->m_terminate_duration = 0.0;
         tx_node->m_set_nc = false;
         tx_node->m_pctx = DEFAULT_PROFILE_CTX(m_core->m_c_tcp);
         m_core->m_node_gen.add_node((CGenNode*)tx_node);


### PR DESCRIPTION
Hi, this change is for the implementation of #680.

When `--nc` option is given, the new `m_traffic_duration` in `CGenNodeTXFIF` is used to check the `traffic duration` from `CPerProfileCtx`.
The connection established flow will be closed by `--nc` when the traffic duration is over the given `duration` value.

@hhaim, please review this change and give your feedback.