### PR TITLE
Add bonding dpdk driver

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -813,6 +813,25 @@ Consider the following if using dummy ports for a single interface TRex generato
 | | ASTF | functional | full TCP stack
 |=================
 
+
+=== bonding interfaces
+
+It provides similar capabilities found in Linux bonding driver. Link Aggregation 802.3AD is supported in mode 4. See link:https://doc.dpdk.org/guides/prog_guide/link_bonding_poll_mode_drv_lib.html[here] for the details.
+
+Configuration example:
+
+[source,bash]
+----
+    ...
+    interfaces: [ '--vdev=net_bonding0,mode=0,slave=d8:00.0,slave=d8:00.1', 'dummy' ]
+    ...
+----
+
+The bonded device inherits attributes from the first slave device. All slave devices should have same speed and duplex.
+
+NOTE: When mode 4 is used, more settle time could be needed. Use -w command line option to give enough time for it.
+
+
 === Configuring for running with router (or other L3 device) as DUT
 
 You can follow link:trex_config_guide.html[this presentation] for an example of how to configure the router as a DUT.

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -1337,6 +1337,21 @@ dpdk_src_x86_64 = SrcGroup(dir='src/dpdk/',
                  'drivers/net/netvsc/hn_nvs.c',
                  'drivers/net/netvsc/hn_vf.c',
 
+                 #ip_frag
+                 'lib/librte_ip_frag/rte_ipv4_fragmentation.c',
+                 'lib/librte_ip_frag/rte_ipv6_fragmentation.c',
+                 'lib/librte_ip_frag/rte_ipv4_reassembly.c',
+                 'lib/librte_ip_frag/rte_ipv6_reassembly.c',
+                 'lib/librte_ip_frag/rte_ip_frag_common.c',
+                 'lib/librte_ip_frag/ip_frag_internal.c',
+
+                 #bonding
+                 'drivers/net/bonding/rte_eth_bond_api.c',
+                 'drivers/net/bonding/rte_eth_bond_pmd.c',
+                 'drivers/net/bonding/rte_eth_bond_flow.c',
+                 'drivers/net/bonding/rte_eth_bond_args.c',
+                 'drivers/net/bonding/rte_eth_bond_8023ad.c',
+                 'drivers/net/bonding/rte_eth_bond_alb.c',
 
                  ])
 
@@ -2025,6 +2040,7 @@ dpdk_includes_path =''' ../src/
                         ../src/dpdk/lib/librte_port/
                         ../src/dpdk/lib/librte_ring/
                         ../src/dpdk/lib/librte_timer/
+                        ../src/dpdk/lib/librte_ip_frag/
                         ../src/dpdk/
                         
                         ../src/dpdk/lib/librte_security/

--- a/src/dpdk/drivers/net/bonding/rte_eth_bond_pmd.c
+++ b/src/dpdk/drivers/net/bonding/rte_eth_bond_pmd.c
@@ -346,6 +346,9 @@ rx_burst_8023ad(void *queue, struct rte_mbuf **bufs, uint16_t nb_pkts,
 				   !rte_is_same_ether_addr(bond_mac,
 						       &hdr->d_addr)) ||
 				  (!allmulti &&
+#ifdef  TREX_PATCH
+				   !rte_is_broadcast_ether_addr(&hdr->d_addr) &&
+#endif
 				   rte_is_multicast_ether_addr(&hdr->d_addr)))))) {
 
 				if (hdr->ether_type == ether_type_slow_be) {
@@ -1738,6 +1741,16 @@ slave_configure(struct rte_eth_dev *bonded_eth_dev,
 	else
 		slave_eth_dev->data->dev_conf.rxmode.offloads &=
 				~DEV_RX_OFFLOAD_JUMBO_FRAME;
+
+#ifdef  TREX_PATCH
+	if (bonded_eth_dev->data->dev_conf.txmode.offloads &
+			DEV_TX_OFFLOAD_MULTI_SEGS)
+		slave_eth_dev->data->dev_conf.txmode.offloads |=
+			DEV_TX_OFFLOAD_MULTI_SEGS;
+	else
+		slave_eth_dev->data->dev_conf.txmode.offloads &=
+			~DEV_TX_OFFLOAD_MULTI_SEGS;
+#endif
 
 	nb_rx_queues = bonded_eth_dev->data->nb_rx_queues;
 	nb_tx_queues = bonded_eth_dev->data->nb_tx_queues;

--- a/src/dpdk_trex_port_attr.cpp
+++ b/src/dpdk_trex_port_attr.cpp
@@ -20,7 +20,8 @@ limitations under the License.
 using namespace std;
 
 DpdkTRexPortAttr::DpdkTRexPortAttr(uint8_t tvpid, uint8_t repid, bool is_virtual,
-        bool fc_change_allowed, bool is_prom_allowed, bool is_vxlan_fs_allowed, bool has_pci) {
+        bool fc_change_allowed, bool is_prom_allowed, bool is_vxlan_fs_allowed, bool has_pci,
+        bool device_flush_needed) {
 
     m_tvpid = tvpid;
     m_repid = repid;
@@ -36,6 +37,7 @@ DpdkTRexPortAttr::DpdkTRexPortAttr(uint8_t tvpid, uint8_t repid, bool is_virtual
     flag_is_link_change_supported = (set_link_up(true) != -ENOTSUP);
     flag_is_prom_change_supported = is_prom_allowed;
     flag_is_vxlan_fs_supported = is_vxlan_fs_allowed;
+    flag_is_device_flush_needed = device_flush_needed;
     update_device_info();
     update_description();
 }

--- a/src/drivers/trex_driver_base.cpp
+++ b/src/drivers/trex_driver_base.cpp
@@ -154,6 +154,7 @@ CTRexExtendedDriverDb::CTRexExtendedDriverDb() {
     register_driver(std::string("net_i40e_vf"), CTRexExtendedDriverI40evf::create);
     register_driver(std::string("net_ixgbe_vf"), CTRexExtendedDriverIxgbevf::create);
     register_driver(std::string("net_netvsc"), CTRexExtendedDriverNetvsc::create);
+    register_driver(std::string("net_bonding"), CTRexExtendedDriverBonding::create);
 
     /* raw socket */
     register_driver(std::string("net_af_packet"), CTRexExtendedDriverAfPacket::create);

--- a/src/drivers/trex_driver_virtual.h
+++ b/src/drivers/trex_driver_virtual.h
@@ -149,7 +149,7 @@ public:
     virtual bool is_support_for_rx_scatter_gather(){
 	return (true);
     }
-			    
+
     virtual TRexPortAttr* create_port_attr(tvpid_t tvpid,repid_t repid);
     virtual bool get_extended_stats(CPhyEthIF * _if,CPhyEthIFStats *stats);
     virtual void update_configuration(port_cfg_t * cfg);
@@ -170,6 +170,23 @@ public:
     virtual TRexPortAttr* create_port_attr(tvpid_t tvpid,repid_t repid);
     virtual bool get_extended_stats(CPhyEthIF * _if,CPhyEthIFStats *stats);
     virtual void update_configuration(port_cfg_t * cfg);
+};
+
+class CTRexExtendedDriverBonding : public CTRexExtendedDriverVirtBase {
+public:
+    CTRexExtendedDriverBonding();
+    static CTRexExtendedDriverBase * create(){
+        return ( new CTRexExtendedDriverBonding() );
+    }
+    virtual bool is_support_for_rx_scatter_gather(){
+	return (true);
+    }
+
+    virtual TRexPortAttr* create_port_attr(tvpid_t tvpid,repid_t repid);
+    virtual bool get_extended_stats(CPhyEthIF * _if,CPhyEthIFStats *stats);
+    virtual void update_configuration(port_cfg_t * cfg);
+    virtual int wait_for_stable_link();
+    virtual void wait_after_link_up();
 };
 
 

--- a/src/main_dpdk.h
+++ b/src/main_dpdk.h
@@ -242,6 +242,8 @@ class CPhyEthIF  {
 
     virtual void configure_rss();
 
+    void dev_flush();
+
 private:
     void conf_hardware_astf_rss();
     void conf_multi_rx();
@@ -330,7 +332,7 @@ class CGlobalTRexInterface  {
 };
 
 bool fill_pci_dev(struct rte_eth_dev_info *dev_info, struct rte_pci_device* pci_dev);
-void wait_x_sec(int sec);
+void wait_x_sec(int sec, bool dev_sync = false);
 
 typedef uint8_t tvpid_t; /* port ID of trex 0,1,2,3 up to MAX_PORTS*/
 typedef uint8_t repid_t; /* DPDK port id  */

--- a/src/stx/common/trex_dp_core.cpp
+++ b/src/stx/common/trex_dp_core.cpp
@@ -75,6 +75,8 @@ TrexDpCore::idle_state_loop() {
             continue;
         }
 
+        m_core->flush_tx_queue(); /* sync device tx */
+
         bool had_rx = rx_for_idle();
         if (had_rx) {
             counter = 0;

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -571,6 +571,8 @@ public:
         m_is_sleepy_scheduler = false;
         m_is_queuefull_retry  = true;
         m_is_vdev             = false;
+        m_is_devs_in_vdev     = false;
+        m_pdevs_in_vdev.clear();
         m_is_bird_enabled     = false;
         m_ezmq_ch_enabled     = false;
         m_emzq_ch_tcp         = false;
@@ -625,6 +627,8 @@ public:
     bool            m_is_sleepy_scheduler;   // sleep or busy wait on scheduler
     bool            m_is_queuefull_retry;    // retry on queue full
     bool            m_is_vdev;
+    bool            m_is_devs_in_vdev;
+    std::vector<std::string>    m_pdevs_in_vdev;
     bool            m_hdrh;        /* enable HDR histograms for latency */
     bool            m_is_bird_enabled;
     bool            m_ezmq_ch_enabled;

--- a/src/trex_port_attr.h
+++ b/src/trex_port_attr.h
@@ -73,6 +73,7 @@ public:
     virtual const struct rte_eth_dev_info* get_dev_info() const { return &m_dev_info; }
 
     virtual std::string get_rx_filter_mode() const;
+    virtual bool is_device_flush_needed() = 0;
 
 /*    SETTERS    */
     virtual int set_promiscuous(bool enabled) = 0;
@@ -130,7 +131,8 @@ class DpdkTRexPortAttr : public TRexPortAttr {
 public:
 
     DpdkTRexPortAttr(uint8_t tvpid, uint8_t repid, bool is_virtual, bool fc_change_allowed,
-            bool is_prom_allowed, bool is_vxlan_fs_allowed, bool has_pci);
+            bool is_prom_allowed, bool is_vxlan_fs_allowed, bool has_pci,
+            bool device_flush_needed = false);
 
 /*    UPDATES    */
     virtual void update_link_status();
@@ -146,6 +148,7 @@ public:
     virtual int get_flow_ctrl(int &mode);
     virtual void get_supported_speeds(supp_speeds_t &supp_speeds);
     virtual bool is_loopback() const;
+    virtual bool is_device_flush_needed() { return flag_is_device_flush_needed; }
 
 /*    SETTERS    */
     virtual int set_promiscuous(bool enabled);
@@ -173,6 +176,7 @@ private:
     std::vector <struct rte_eth_xstat> xstats_values_tmp;
     std::vector <struct rte_eth_xstat_name> xstats_names_tmp;
 
+    bool            flag_is_device_flush_needed;
 };
 
 /*
@@ -224,6 +228,7 @@ public:
     int set_vxlan_fs(vxlan_fs_ports_t &vxlan_fs_ports) { return -ENOTSUP; }
     bool is_loopback() const { return false; }
     std::string get_rx_filter_mode() {return "";}
+    bool is_device_flush_needed() { return false; }
 protected:
     void update_device_info() {}
     void update_description() {


### PR DESCRIPTION
Hi, this change is for issue #683.

- added `net_bonding` driver
- to get proper device information inherited from the slave devices, the initial configuration is called before the `bonding` device start.
- In mode 4 (802.3ad), it is necessary to do TX burst and RX burst at least every 100ms. added device flush to `wait_x_sec` and `idle_state_loop`. 
- DEV_TX_OFFLOAD_MULTI_SEGS is enabled by TREX_PATCH
 
To use the bonding device, add --vdev=net_bondingX... to the interfaces in trex_cfg.yaml.
```
  interfaces: [ '--vdev=net_bonding0,mode=4,slave=d8:00.0,slave=d8:00.1', 'dummy' ]
```

@hhaim please check my changes and give your feedback.
