### PR TITLE
ignore EEXIST error when binding identical cards

### DIFF
--- a/scripts/dpdk_nic_bind.py
+++ b/scripts/dpdk_nic_bind.py
@@ -675,10 +675,14 @@ def bind_one(dev_id, driver, force):
         try:
             f.write("%04x %04x" % (dev["Vendor"], dev["Device"]))
             f.close()
-        except:
-            print("Error: bind failed for %s - Cannot write new PCI ID to " \
-                "driver %s" % (dev_id, driver))
-            return
+        except IOError as ioex:
+            # in case we're binding two identical cards
+            if ioex.errno == errno.EEXIST:
+                f.close()
+            else:
+                print("Error: bind failed for %s - Cannot write new PCI ID to " \
+                    "driver %s" % (dev_id, driver))
+                return
 
     # do the bind by writing to /sys
     filename = "/sys/bus/pci/drivers/%s/bind" % driver


### PR DESCRIPTION
Linux 5.12 changed the behaviour of the sysfs interface:
adding the same device id twice now generates an error[1].

  echo "1af4 1041" > /sys/bus/pci/drivers/vfio-pci/new_id
  echo "1af4 1041" > /sys/bus/pci/drivers/vfio-pci/new_id
  -bash: echo: write error: File exists

Fix this by ignoring EEXIST errors when writing in that specific handle.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3853f9123c185eb4018f5ccd3cdda5968efb5e10

Signed-off-by: Matteo Croce <mcroce@microsoft.com>