### PR TITLE
fix GTPU inner header checksum issue

### DIFF
--- a/src/tunnels/gtp_tunnel.h
+++ b/src/tunnels/gtp_tunnel.h
@@ -19,8 +19,7 @@ public:
 
     GTPU(uint32_t teid, uint8_t src_ipv6[8], uint8_t dst_ipv6[8]);
 
-    ~GTPU(){
-     }
+    ~GTPU();
 
 
     virtual int Prepend(rte_mbuf * m, u_int16_t);

--- a/src/tunnels/tunnel.cpp
+++ b/src/tunnels/tunnel.cpp
@@ -12,6 +12,10 @@ uint16_t Tunnel::RxCallback(uint16_t port, uint16_t queue,
                 struct rte_mbuf *pkts[], uint16_t nb_pkts, uint16_t max_pkts,
                 void *user_param) {
 
+    if (!CGlobalInfo::m_options.m_ip_cfg[port].is_gtp_enabled()) {
+        return nb_pkts;
+    }
+
     GTPU t;
     u_int8_t i = 0;
 


### PR DESCRIPTION
Hi, this change is to fix following GTPU mode issues.

- #657 Inner packet header checksum could be invalid.
- #654 Memory leak in gtp_tunnel.cpp
- #652 disable tunnel adjust in port 1

@hhaim please check my changes and give your feedback.