### PR TITLE
terminate l7_map flow immediately to prevent crash when all reference profiles are stopped.

### DIFF
--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -1047,13 +1047,13 @@ void CServerIpPayloadInfo::update_template_flows(CPerProfileCtx* pctx) {
                 flow->m_pctx->m_template_rw = new_pctx->m_template_rw;
             }
             else {
-                // trigger flow termination
-                flow->m_pctx->deactivate();
-                flow->m_pctx->set_nc(true);
-
                 // remove identifying template information
                 flow->m_payload_info = nullptr;
                 it = m_template_flows.erase(it);
+
+                // terminate flow immediately
+                CTcpPerThreadCtx* ctx = flow->m_pctx->m_ctx;
+                ctx->m_ft.terminate_flow(ctx, flow, true);
                 continue;
             }
         }


### PR DESCRIPTION
Hi, this change is to prevent crash from invalid memory access.

When the reference profile template was removed, `update_template_flows` tried to update it by new reference profile.
If there was no reference profile left, it triggerred graceful flow terminateion.
But, this graceful flow termination could access already freed memory (m_termplate_rw) and may cause crash.
So, I changed it to the immediate flow termination because the graceful way is not needed in this case.

@hhaim, please review my change and give your feedback.