### PR TITLE
Fix bug with dpdk_setup_ports script

### DIFF
--- a/scripts/dpdk_setup_ports.py
+++ b/scripts/dpdk_setup_ports.py
@@ -96,9 +96,9 @@ class ConfigCreator(object):
                 for lcore in list(lcores):
                     if include_lcores and lcore not in include_lcores:
                         cores[core].remove(lcore)
-                    if exclude_lcores and lcore in exclude_lcores:
+                    elif exclude_lcores and lcore in exclude_lcores:
                         cores[core].remove(lcore)
-                    if lcore > self.MAX_LCORE_NUM:
+                    elif lcore > self.MAX_LCORE_NUM:
                         cores[core].remove(lcore)
                 if 0 in lcores:
                     self.has_zero_lcore = True


### PR DESCRIPTION
If the --cores-include flag was used, and the system has more lcores than
the current MAX_LCORE_NUM (63 on x86_64), then the script attempted to
remove some number of lcores from a list twice. This causes an error to be
thrown. Replacing "if" with "elif" prevents this behavior by ensuring that
the removal code is run at most once per lcore.

Signed-off-by: Owen Hilyard <ohilyard@iol.unh.edu>