### PR TITLE
Add async events reader mode support

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_subscriber.py
@@ -335,7 +335,7 @@ class TRexSubscriber():
                         name     = msg['name']
                         data     = msg['data']
                         msg_type = msg['type']
-                        if self.seq != 0:
+                        if self.seq != 0 and msg['seq'] != 0:
                             if msg['seq'] != self.seq:
                                 s = " SEQ ERROR {} {} ".format(msg['seq'],self.seq)
                                 raise Exception(s)

--- a/src/publisher/trex_publisher.h
+++ b/src/publisher/trex_publisher.h
@@ -35,7 +35,8 @@ class TrexPublisherCtx {
     Json::Value     m_qevents;
     dsec_t          m_last_query;
 
-    uint32_t        m_seq;  
+    uint32_t        m_seq;
+    bool            m_reader_mode;
 };
 
 class TrexPublisher {
@@ -111,7 +112,7 @@ public:
 
     virtual bool  get_queue_events(Json::Value & val,uint32_t session_id);
 
-    virtual bool  add_session_id(uint32_t session_id);
+    virtual bool  add_session_id(uint32_t session_id, bool is_reader);
 
     virtual bool  remove_session_id(uint32_t session_id);
 

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -247,6 +247,8 @@ TrexRpcCmdGetAsyncEvents::_run(const Json::Value &params, Json::Value &result) {
         res["data"]   = val;
     }else{
         res["data"]   = Json::arrayValue;
+        // add reader mode session implicitly
+        get_stx()->add_session_id(session_id);
     }
 
     return (TREX_RPC_CMD_OK);

--- a/src/stx/common/trex_stx.cpp
+++ b/src/stx/common/trex_stx.cpp
@@ -38,6 +38,10 @@ TrexSTX::TrexSTX(const TrexSTXCfg &cfg) : m_rpc_server(cfg.m_rpc_req_resp_cfg), 
     }
 }
 
+void TrexSTX::add_session_id(uint32_t session_id){
+    get_publisher()->add_session_id(session_id, true);  // reader mode
+}
+
 void TrexSTX::add_session_id(uint8_t port_id, 
                              uint32_t session_id){
     assert(session_id!=0);
@@ -48,7 +52,7 @@ void TrexSTX::add_session_id(uint8_t port_id,
 
     m_session_id_ports[port_id] = session_id;
     if ((get_ref_session_id(session_id)== 1) && (new_ref==0)){
-        get_publisher()->add_session_id(session_id);
+        get_publisher()->add_session_id(session_id, false); // port owner mode
     }   
     if ((old_id>0) && (old_ref==1) && (get_ref_session_id(old_id)==0)){
         get_publisher()->remove_session_id(old_id);

--- a/src/stx/common/trex_stx.h
+++ b/src/stx/common/trex_stx.h
@@ -121,6 +121,7 @@ public:
 
 
     void add_session_id(uint8_t port_id, uint32_t session_id);
+    void add_session_id(uint32_t session_id);   // for reader mode session
     void remove_session_id(uint8_t port_id);
     
     /**


### PR DESCRIPTION
Hi, this change is for issue #693.

Since there is no acquire in reader mode trex-console, I just added a session implicitly when the first `get_async_events` is requested.

@hhaim please check my changes and give your feedback