### PR TITLE
update inactive reference template info on the fly

### DIFF
--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -1018,7 +1018,10 @@ bool CServerIpPayloadInfo::is_server_compatible(CTcpServerInfo* in_server) {
 
 CServerTemplateInfo* CServerIpPayloadInfo::get_reference_template_info() {
     if (likely(m_template_ref)) {
-        return m_template_ref;
+        if (likely(m_template_ref->get_profile_ctx()->is_open_flow_allowed())) {
+            return m_template_ref;
+        }
+        m_template_ref = nullptr;
     }
     for (auto it = m_payload_map.begin(); it != m_payload_map.end(); it++) {
         auto pctx = it->second.get_profile_ctx();


### PR DESCRIPTION
Hi, this change is to prevent SYN packet drop from unexpected inactive reference template.

The reference template will be deleted after the related profile is stopped.
But, when the profile is stopping, the template is still remained as a reference template, and the new open flow is rejected even though another profile is active.
This change will replace the inactive reference tempate to active one on the fly.

@hhaim please check my changes and give your feedback.