### PR TITLE
load astf_schema.json once for multiple profiles

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -37,6 +37,7 @@ inline std::string methodName(const std::string& prettyFunction)
 
 // make the class singleton
 astf_db_map_t CAstfDB::m_instances;
+CAstfJsonValidator* CAstfDB::m_validator = nullptr;
 
 
 void CAstfDB::Create(){
@@ -44,10 +45,12 @@ void CAstfDB::Create(){
         return;
     }
     m_client_config_info=0;
-    m_validator = new CAstfJsonValidator();
-    if (!m_validator->Create("astf_schema.json")) {
-        printf("Could not create ASTF validator using file astf_schema.json\n");
-        exit(-1);
+    if (m_validator == nullptr) {
+        m_validator = new CAstfJsonValidator();
+        if (!m_validator->Create("astf_schema.json")) {
+            printf("Could not create ASTF validator using file astf_schema.json\n");
+            exit(-1);
+        }
     }
     m_topo_mngr = new TopoMngr();
     m_factor = -1.0;
@@ -56,7 +59,7 @@ void CAstfDB::Create(){
 
 
 void CAstfDB::Delete(){
-    if ( m_validator ) {
+    if ( m_instances.empty() && m_validator ) {
         m_validator->Delete();
         delete m_validator;
         m_validator = nullptr;

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -623,7 +623,7 @@ private:
     CAstfDbRO           m_tcp_data[MAX_SOCKETS_SUPPORTED];
 
     ClientCfgDB        *m_client_config_info;
-    CAstfJsonValidator *m_validator;
+    static CAstfJsonValidator *m_validator;
     TopoMngr           *m_topo_mngr;
 
     uint16_t m_num_of_tg_ids;


### PR DESCRIPTION
Hi, this change is to load `astf_schema.json` file once for the performance of multiple profiles.

The additional profile creates a new CAstfDB instance. The instance allocates `m_validator` for it, but the `m_validator` is the same for all profiles. Furthermore, it initiates contents from `astf_schema.json` file each time.
It is performed in DP core and takes time. In my measurement, it showed up to several hundred milliseconds.
This change will remove this unnecessary file I/O and I expect better results during the additional profiles are added.

@hhaim please check my change and give your feedback.