### PR TITLE
Fix byte order in GTPU TEID

### DIFF
--- a/src/tunnels/gtp_tunnel.cpp
+++ b/src/tunnels/gtp_tunnel.cpp
@@ -392,8 +392,8 @@ void GTPU::store_ipv4_gtpu_info(uint32_t teid,uint32_t src_ip, uint32_t dst_ip, 
     ip->time_to_live = IPV4_HDR_TTL;
     ip->next_proto_id = IPPROTO_UDP;
     ip->hdr_checksum = 0;
-    ip->src_addr = rte_cpu_to_be_32(src_ip);
-    ip->dst_addr = rte_cpu_to_be_32(dst_ip);
+    ip->src_addr = src_ip;
+    ip->dst_addr = dst_ip;
 
     struct rte_udp_hdr *udp = &pre_cooked_hdr->udp;
 

--- a/src/tunnels/tunnel_factory_creator.cpp
+++ b/src/tunnels/tunnel_factory_creator.cpp
@@ -6,9 +6,9 @@ void *TunnelFactoryCreator::get_tunnel_object(client_tunnel_data_t data, uint8_t
     void *tunnel = NULL;
     if (tunnel_type == TUNNEL_TYPE_GTP){
         if (data.version == 4){
-            tunnel = (void*) new GTPU(PKT_HTONL(data.teid),
-                                           PKT_HTONL(data.u1.src_ipv4),
-                                           PKT_HTONL(data.u2.dst_ipv4));
+            tunnel = (void*) new GTPU(data.teid,
+                                           data.u1.src_ipv4,
+                                           data.u2.dst_ipv4);
          } else {
             tunnel = (void*) new GTPU(PKT_HTONL(data.teid),
                                            data.u1.src_ip,
@@ -22,9 +22,9 @@ void TunnelFactoryCreator::update_tunnel_object(client_tunnel_data_t data, void 
 {
     if (tunnel_type == TUNNEL_TYPE_GTP){
         if (data.version == 4){
-           ((GTPU *)tunnel)->update_ipv4_gtpu_info(PKT_HTONL(data.teid), PKT_HTONL(data.u1.src_ipv4), PKT_HTONL(data.u2.dst_ipv4));
+           ((GTPU *)tunnel)->update_ipv4_gtpu_info(data.teid, data.u1.src_ipv4, data.u2.dst_ipv4);
         } else {
-           ((GTPU *)tunnel)->update_ipv6_gtpu_info(PKT_HTONL(data.teid), data.u1.src_ip, data.u2.dst_ip);  
+           ((GTPU *)tunnel)->update_ipv6_gtpu_info(data.teid, data.u1.src_ip, data.u2.dst_ip);
         }
     }
 }


### PR DESCRIPTION
Also, don't do extra multiple host-to-network conversions for GTPU
tunnel fields.

`src_ip` / `dst_ip` are obtained using `inet_pton()` here:
https://github.com/cisco-system-traffic-generator/trex-core/blob/master/src/stx/astf/trex_astf_rpc_cmds.cpp#L855-L856
So no need to convert them to the network byte order.
For some reason, that conversion was being done twice, so the result was correct in the end, but I believe that it was unnecessary.

`TEID` was also being converted twice but as initially it was in the host byte order:
https://github.com/cisco-system-traffic-generator/trex-core/blob/master/src/stx/astf/trex_astf_rpc_cmds.cpp#L859
the resulting byte order was wrong. I have removed one of the conversions to make it right.
