### PR TITLE
Latency Measurement by HW timestamping with IEEE 1588 packets in Latency Stream

### DIFF
--- a/src/pal/linux_dpdk/dpdk_2102_x86_64/rte_config.h
+++ b/src/pal/linux_dpdk/dpdk_2102_x86_64/rte_config.h
@@ -154,4 +154,11 @@
 #define TREX_PATCH 1
 #define TREX_PATCH_LOW_LATENCY 1
 
+/*
+ * Enable this to test Latency
+ * using HW timestamping by using
+ * IEEE 1588 feature
+ */
+//#define RTE_LIBRTE_IEEE1588 1
+
 #endif /* _RTE_CONFIG_H_ */

--- a/src/stx/common/trex_latency_counters.h
+++ b/src/stx/common/trex_latency_counters.h
@@ -156,7 +156,21 @@ private:
         uint32_t &pkt_seq,
         uint32_t &exp_seq);
 
+#ifdef LATENCY_IEEE_1588_TIMESTAMPING
+    void save_timestamps_for_sync_pkt(
+        const rte_mbuf_t *m,
+        flow_stat_payload_header *fsp_head,
+        int port);
+    void update_timestamps_for_fup_pkt(
+        flow_stat_payload_header *fsp_head);
+#endif /* LATENCY_IEEE_1588_TIMESTAMPING */
 public:
+
+#ifdef LATENCY_IEEE_1588_TIMESTAMPING
+    uint32_t m_fup_seq_exp; // expected next seq num for Followup packet
+    uint64_t m_sync_arrival_time_nsec;
+    uint64_t m_sync_arrival_time_sec;
+#endif /* LATENCY_IEEE_1588_TIMESTAMPING */
 
     rx_per_flow_t         m_rx_pg_stat[MAX_FLOW_STATS];
     rx_per_flow_t         m_rx_pg_stat_payload[MAX_FLOW_STATS_PAYLOAD];


### PR DESCRIPTION
[TREX Latency Measurement using PTP packets in Latency Stream.docx](https://github.com/cisco-system-traffic-generator/trex-core/files/6542031/TREX.Latency.Measurement.using.PTP.packets.in.Latency.Stream.docx)

Using the 2-step mechanism of PTP protocol we send the accurate timestamp (t1)
of SYNC packet which is read from the NIC in a Follow Up packet rather than in
the same packet. Received timestamp (t2) is still taken on the first packet
(SYNC) itself. In this way with a combination of software(PTP protocol, DPDK
APIs) and HW support (leveraging IEEE 1588 support) the accuracy of latency
and jitter measurements can be improved.

Currently all changes are under a macro and shouldn't impact any existing functionality.
We are also looking currently on how to make it work by run-time checks rather than compile time macro.
But would want to keep it for a later commit and keep macro for the Initial commit.

Please refer to the attached document for more details on implementation and testing 

Signed-off-by: Abhiram R N <arn@redhat.com>