### PR TITLE
Add profile state change tracking in ASTFClient

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
@@ -64,6 +64,11 @@ class CAstfTrafficStats(object):
         if pid_input in self.tg_names_dict.keys():
             self.tg_names_dict.pop(pid_input)
 
+    def _remove_stats(self, pid_input = DEFAULT_PROFILE_ID):
+        if pid_input in self._ref.keys():
+            self._ref.pop(pid_input)
+        self._clear_tg_name(pid_input)
+
 
     def _epoch_changed(self, new_epoch, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
         if is_sum:

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -112,6 +112,7 @@ class ASTFClient(TRexClient):
             self.STATE_ASTF_CLEANUP,
             self.STATE_ASTF_DELETE]
         self.astf_profile_state = {'_': 0}
+        self.profile_state_change = {}
 
     def get_mode(self):
         return "ASTF"
@@ -181,7 +182,7 @@ class ASTFClient(TRexClient):
                 self.ctx.logger.error('Last profile %s command failed: %s' % (profile_id, error))
 
         # update profile state
-        self.astf_profile_state[profile_id] = ctx_state
+        self._set_profile_state(profile_id, ctx_state)
 
         if error:
             return Event('server', 'error', 'Moved to profile %s state: %s after error: %s' % (profile_id, ctx_state, error))
@@ -197,9 +198,9 @@ class ASTFClient(TRexClient):
             if not self.sync_waiting:
                 self.ctx.logger.error('Last profile %s command failed: %s' % (profile_id, error))
 
-        # remove profile and template group name
-        self.astf_profile_state.pop(profile_id, None)
-        self.traffic_stats._clear_tg_name(profile_id) 
+        # remove profile and statistics references (including template group name)
+        self._remove_profile_state(profile_id)
+        self.traffic_stats._remove_stats(profile_id)
 
         if error:
             return Event('server', 'error', 'Can\'t remove profile %s after error: %s' % (profile_id, error))
@@ -228,16 +229,10 @@ class ASTFClient(TRexClient):
             if start == True:
                 raise TRexError("Cannot have %s as a profile value for start command" % ALL_PROFILE_ID)
             else:
-                self.sync()
                 # return profiles can be operational only for the requests.
                 # STATE_IDLE is operational for 'profile_clear.'
                 return [pid for pid, state in self.astf_profile_state.items()
                                 if state is not self.STATE_ASTF_DELETE]
-
-        for profile_id in profile_list:
-            if profile_id not in list(self.astf_profile_state.keys()):
-                self.sync()
-                break
 
         # Check if profile_id is a valid profile name
         for profile_id in profile_list:
@@ -263,27 +258,27 @@ class ASTFClient(TRexClient):
         return port_state
 
     def wait_for_steady(self, profile_id=None):
-        timer = PassiveTimer()
         while True:
-            state = self._get_profile_state(profile_id) if profile_id else self.state
+            state = self.__get_profile_state_with_change(profile_id) if profile_id else self.state
             if state not in self.transient_states:
                 break
+            time.sleep(0.001)
+        return state
 
-            if timer.has_elapsed(0.1):
-                self.sync()
-            else:
-                time.sleep(0.001)
+    def wait_for_transient(self, profile_id=None):
+        while True:
+            state = self.__get_profile_state_with_change(profile_id) if profile_id else self.state
+            if state in self.transient_states:
+                break
+            time.sleep(0.001)
+        return state
 
     def wait_for_profile_state(self, profile_id, wait_state, timeout = None):
         timer = PassiveTimer(timeout)
-        while self._get_profile_state(profile_id) != wait_state:
-            if timer.has_elapsed(0.1):
-                self.sync()
-            else:
-                time.sleep(0.001)
-
+        while self.__get_profile_state_with_change(profile_id) != wait_state:
             if timer.has_expired():
                 raise TRexTimeoutError(timeout)
+            time.sleep(0.001)
 
     def inc_epoch(self):
         rc = self._transmit('inc_epoch', {'handler': self.handler})
@@ -293,9 +288,48 @@ class ASTFClient(TRexClient):
 
     def _set_profile_state(self, profile_id, state):
         self.astf_profile_state[profile_id] = state
+        self.__update_profile_state_change(profile_id, state)
+
+    def _remove_profile_state(self, profile_id):
+        self.astf_profile_state.pop(profile_id, None)
+        self.__remove_profile_state_change(profile_id)
 
     def _get_profile_state(self, profile_id):
         return self.astf_profile_state.get(profile_id, self.STATE_IDLE) if self.is_dynamic else self.state
+
+    def __reset_profile_state_change(self, profile_id, reset_state = None):
+        if profile_id in self.profile_state_change:
+            state_changes = self.profile_state_change[profile_id]
+            if reset_state in state_changes:
+                # remove unused stacked changes
+                if state_changes[-1] == reset_state:
+                    self.profile_state_change[profile_id] = []
+                else:
+                    while state_changes and state_changes.pop(0) != reset_state:
+                        pass
+        else:
+            self.profile_state_change[profile_id] = []
+
+    def __remove_profile_state_change(self, profile_id):
+        self.profile_state_change.pop(profile_id, None)
+
+    def __update_profile_state_change(self, profile_id, state):
+        if profile_id not in self.profile_state_change:
+            self.profile_state_change[profile_id] = []
+        elif state > self.STATE_ASTF_LOADED:
+            self.__reset_profile_state_change(profile_id, self.STATE_ASTF_LOADED)
+        self.profile_state_change[profile_id].append(state)
+
+    def __get_profile_state_with_change(self, profile_id):
+        if profile_id and self.is_dynamic:
+            state_changes = self.profile_state_change.get(profile_id)
+            if state_changes:
+                state = state_changes.pop(0)
+            else:
+                state = self._get_profile_state(profile_id)
+            return state
+        else:
+            return self.state
 
     def _transmit_async(self, rpc_func, ok_states, bad_states = None, ready_state = None, **k):
         profile_id = k['params']['profile_id'] 
@@ -303,56 +337,46 @@ class ASTFClient(TRexClient):
         if bad_states is not None:
             bad_states = listify(bad_states)
 
-        self.wait_for_steady()
-        if rpc_func == 'start' and self.state is not self.STATE_TX:
-            self.inc_epoch()
+        #self.wait_for_steady()
+        #if rpc_func == 'start' and self.state is not self.STATE_TX:
+        #    self.inc_epoch()
 
         self.sync_waiting = True
         try:
+            state = self.wait_for_steady(profile_id)
             if ready_state:
                 assert ready_state not in self.transient_states
-                if self._get_profile_state(profile_id) != ready_state:
-                    self.wait_for_profile_state(profile_id, ready_state)
-            else:
-                self.wait_for_steady(profile_id)
+                if state != ready_state:
+                    self.wait_for_profile_state(profile_id, ready_state, timeout=60)
 
             rc = self._transmit(rpc_func, **k)
             if not rc:
                 return rc
+            state = self.wait_for_transient(profile_id)
 
-            timer = PassiveTimer()
+            state_changes = [state]
             while True:
-                state = self._get_profile_state(profile_id)
+                state = self.__get_profile_state_with_change(profile_id)
+                if not state_changes or state_changes[-1] != state:
+                    state_changes.append(state)
+
                 if state in ok_states:
                     return RC_OK()
 
-                # check transient state transition first to avoid wrong decision (e.g. 'start')
-                if ready_state and state in self.transient_states:
-                    ready_state = None
-
-                if self.last_profile_error.get(profile_id) or (not ready_state and bad_states and state in bad_states):
+                if self.last_profile_error.get(profile_id) or (bad_states and state in bad_states):
                     error = self.last_profile_error.pop(profile_id, None)
-                    general_error = 'Unknown error, state: {}, profile: {}'.format(state, profile_id)
+                    general_error = 'Unexpected state: {}, profile: {}, state changes: {}'.format(state, profile_id, state_changes)
                     return RC_ERR(error or general_error)
 
-                if timer.has_elapsed(0.2):
-                    self.sync() # in case state change lost in async(SUB/PUB) channel
-                else:
-                    time.sleep(0.001)
+                time.sleep(0.001)
         finally:
             self.sync_waiting = False
 
     def check_states(self, ok_states):
-        cnt = 0
         while True:
             if self.state in ok_states:
                 break
-            cnt = cnt + 1
-            if cnt % 10 == 0:
-                self.sync()
-            else:
-                time.sleep(0.1) # 100ms
-        self.sync() # guarantee to update profile states
+            time.sleep(0.1) # 100ms
     
     def _is_service_req(self):
         ''' Return False as service mode check is not required in ASTF '''
@@ -394,7 +418,7 @@ class ASTFClient(TRexClient):
                 self.latency_stats.reset()
                 self.clear_profile(False, pid_input=ALL_PROFILE_ID)
                 self.check_states(ok_states=[self.STATE_IDLE])
-                self.clear_stats(ports, pid_input = ALL_PROFILE_ID)
+                self.clear_stats(ports)
                 self.set_port_attr(ports,
                                    promiscuous = False if self.any_port.is_prom_supported() else None,
                                    link_up = True if restart else None)
@@ -444,7 +468,9 @@ class ASTFClient(TRexClient):
 
     @client_api('command', True)
     def sync(self):
-        self.epoch = None
+        if self.epoch is not None:
+            return self.astf_profile_state
+
         params = {'profile_id': "sync"}
         rc = self._transmit('sync', params)
 
@@ -560,7 +586,7 @@ class ASTFClient(TRexClient):
             try:
                 profile = ASTFProfile.load(profile, **tunables)
             except Exception as e:
-                self.astf_profile_state.pop(pid_input, None)
+                self._remove_profile_state(pid_input)
                 raise TRexError('Could not load profile: %s' % e)
 
             #when ".. -t --help", is called then return
@@ -633,7 +659,8 @@ class ASTFClient(TRexClient):
         valid_pids = self.validate_profile_id_input(pid_input)
 
         for profile_id in valid_pids:
-            profile_state = self.astf_profile_state.get(profile_id)
+            profile_state = self._get_profile_state(profile_id)
+
             if profile_state in ok_states:
                 params = {
                     'handler': self.handler,
@@ -747,13 +774,13 @@ class ASTFClient(TRexClient):
         valid_pids = self.validate_profile_id_input(pid_input)
 
         for profile_id in valid_pids:
-            profile_state = self.astf_profile_state.get(profile_id)
+            profile_state = self._get_profile_state(profile_id)
 
             # 'stop' will be silently ignored in server-side PARSE/BUILD state.
             # So, TX state should be forced to avoid unexpected hanging situation.
             if profile_state in {self.STATE_ASTF_PARSE, self.STATE_ASTF_BUILD}:
                 self.wait_for_profile_state(profile_id, self.STATE_TX)
-                profile_state = self.astf_profile_state.get(profile_id)
+                profile_state = self._get_profile_state(profile_id)
 
             if profile_state is self.STATE_TX:
                 params = {
@@ -770,7 +797,7 @@ class ASTFClient(TRexClient):
                 if not rc:
                     raise TRexError(rc.err())
 
-                profile_state = self.astf_profile_state.get(profile_id)
+                profile_state = self._get_profile_state(profile_id)
 
             if is_remove:
                 if profile_state is self.STATE_ASTF_CLEANUP:
@@ -1734,7 +1761,6 @@ class ASTFClient(TRexClient):
         table.set_cols_width([20]  + [20])
         table.header(["ID", "State"])
 
-        self.sync()
         profiles_state = sorted(self.get_profiles_state().items())
         for profile_id, state in profiles_state:
             table.add_row([

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -424,7 +424,6 @@ void TrexAstf::profile_clear(cp_profile_id_t profile_id){
         send_message_to_dp(0, msg);
     }
     else { // STATE_IDLE
-        pid->publish_astf_profile_clear();
         delete_profile(profile_id);
     }
 }
@@ -627,6 +626,8 @@ void TrexAstfProfile::add_profile(cp_profile_id_t profile_id) {
     m_profile_id_map[instance->get_dp_profile_id()] = profile_id;
     m_states_cnt[instance->get_profile_state()]++;
 
+    instance->publish_astf_profile_state();
+
     int i;
     CSTTCp* lpstt = instance->get_stt_cp();
     if (!lpstt->m_init){
@@ -659,6 +660,8 @@ bool TrexAstfProfile::delete_profile(cp_profile_id_t profile_id) {
 
     auto profile = m_profile_list[profile_id];
     profile->clear_counters(false);
+    profile->publish_astf_profile_clear();
+
     if (profile_id == DEFAULT_ASTF_PROFILE_ID) {
         profile->profile_change_state(STATE_IDLE);
         profile->profile_init();
@@ -671,7 +674,6 @@ bool TrexAstfProfile::delete_profile(cp_profile_id_t profile_id) {
 
         delete m_profile_list.find(profile_id)->second;
         m_profile_list.erase(profile_id);
-
     }
 
     return true;
@@ -1013,7 +1015,6 @@ void TrexAstfPerProfile::all_dp_cores_finished(bool partial) {
             break;
         case STATE_DELETE:
             CAstfDB::free_instance(m_dp_profile_id);
-            publish_astf_profile_clear();
             {
                 auto astf = m_astf_obj;
                 m_astf_obj->delete_profile(m_cp_profile_id);


### PR DESCRIPTION
Hi, this PR includes all the changes discussed in #708.

From now on, when the client needs to wait for a specific state, it won't miss the state by using the `self.__get_profile_state_with_change` method.

@hhaim, please check my changes and give your feedback.