### PR TITLE
Changes to remove macro LATENCY_IEEE_1588_TIMESTAMPING in code

### DIFF
--- a/doc/trex_stateless.asciidoc
+++ b/doc/trex_stateless.asciidoc
@@ -3687,6 +3687,8 @@ Example using Python API:
 We expect next packet to arrive with sequence number 16.
 * Continuation of Scenario 2: Receive a packet with seq num 11. We increment 'seq_too_low' by 1. We increment 'out_of_order' by 1. We *decrement* 'dropped' by 1. (The assumption is that one of the packets that was considered as dropped before has actually arrived out of order.)
 
+
+
 ==== Tutorial: HLT profiles
 
 HLTAPI traffic_config() function has a set of arguments for creating streams. +
@@ -3995,6 +3997,48 @@ You can simulate the profile using the STL simulator:
 ----
 [bash]>./stl-sim -f stl/dependent_field_engine_vars.py -o b.pcap
 ----
+
+
+==== Tutorial: Latency using hardware assist
+
+This feature is a combination of software and hardware NIC’s IEEE 1588 support. It is disable by default and should be enabled by this compilation flag RTE_LIBRTE_IEEE1588. When enabled there is a 30%-10% performance impcat on i40e and mlx5 drivers.
+In HW terminology it is also referred as TimeSync feature. NIC can take timestamps of sent and received latency packets.
+Using DPDK APIs we can read these timestamps from the NIC HW register. Using the 2-step mechanism of IEEE 1588 (PTP) protocol we send the accurate timestamp (t1) which is read from the NIC in a Follow Up packet rather than in the same packet. Received timestamp (t2) is still taken on the first packet (SYNC) itself. In this way with a combination of software(PTP protocol, DPDK APIs) and HW support (leveraging IEEE 1588 support) more accurate latency and jitter measurements can be obtatined.
+
+*Limitations*::
+
+There are few limitations in this method of Latency Measurement which are listed below. (Some are Temporary)
+
+* The type and size of the latency packet is fixed. IP UDP packet with UDP payload carrying the PTP packet. Size is *106* bytes.
+* Since IEEE 1588 (PTP) protocol uses a well known port number. The latency stream which we create need to use destination port as *319*.
+* Not All types of NIC support this feature. Currently tested and verified on I40E. Around 8 types support IEEE 1588v2 as per DPDK documentation.
+* Since there is some work involved in DPDK to keep both Vector code and IEEE 1588 code working together currently we cannot enable the DPDK config (*RTE_LIBRTE_IEEE1588*) by default. So, in order to use this feature we need to enable RTE_LIBRTE_IEEE1588 config COMPILE time and then we can dynamically enable or disable this feature based on requirement.
+
+
+*How to Use*::
+
+There is a new property added in the Latency stream through which we can enable or disable IEEE_1588 in python script ( for enabling, ieee_1588 = true). Other than that the Type, packet size and port number needs to be set as mentioned above in limitations section. Also please refer to the example provided for the same. have a look
+
+`scripts/stl/udp_1pkt_src_ip_split_latency_ieee_1588.py`
+
+[source,python]
+----
+        # packet for IEEE 1588
+        base_lat_pkt = Ether()/IP(src=src_ip,dst=dst_ip)/UDP(dport=319,sport=1025)
+
+        pkt = STLPktBuilder(pkt = base_pkt/pad,
+                            vm = vm)
+        stream = [STLStream(packet = pkt,
+                            mode = STLTXCont(pps=1)),
+
+                  # latency stream
+                  STLStream(packet = STLPktBuilder(pkt = base_lat_pkt/pad_latency),
+                            mode = STLTXCont(pps=1000),
+                            flow_stats = STLFlowLatencyStats(pg_id = 12+port_id, ieee_1588 = True)) # enable 1588
+
+----
+
+You can query if the driver support this feature using get `get_system_info` API
 
 === Dynamic multiple profiles
 

--- a/doc/trex_stateless_latency_ieee_1588.asciidoc
+++ b/doc/trex_stateless_latency_ieee_1588.asciidoc
@@ -1,0 +1,26 @@
+Latency Measurments using IEEE 1588 packets in Latency Stream
+=============================================================
+
+== Feature Overview
+
+This feature is a combination of software and hardware NIC’s IEEE 1588 support. In HW terminology it is also referred as TimeSync feature. NIC can take timestamps of sent and received latency packets. Using DPDK APIs we can read these timestamps from the NIC HW register. Using the 2-step mechanism of IEEE 1588 (PTP) protocol we send the accurate timestamp (t1) which is read from the NIC in a Follow Up packet rather than in the same packet. Received timestamp (t2) is still taken on the first packet (SYNC) itself. In this way with a combination of software(PTP protocol, DPDK APIs) and HW support (leveraging IEEE 1588 support) more accurate latency and jitter measurements can be obtatined.
+
+== Limitations
+
+There are few limitations in this method of Latency Measurement which are listed below. (Some are Temporary)
+
+* The type and size of the latency packet is fixed. IP UDP packet with UDP payload carrying the PTP packet. Size is *106* bytes.
+* Since IEEE 1588 (PTP) protocol uses a well known port number. The latency stream which we create need to use destination port as *319*.
+* Not All types of NIC support this feature. Currently tested and verified on I40E. Around 8 types support IEEE 1588v2 as per DPDK documentation.
+* Since there is some work involved in DPDK to keep both Vector code and IEEE 1588 code working together currently we cannot enable the DPDK config (*RTE_LIBRTE_IEEE1588*) by default. So, in order to use this feature we need to enable RTE_LIBRTE_IEEE1588 config COMPILE time and then we can dynamically enable or disable this feature based on requirement.
+
+== How to Enable this Feature?
+
+Enable *RTE_LIBRTE_IEEE1588* in the corresponding DPDK config file (for example: src/pal/linux_dpdk/dpdk_2102_x86_64/rte_config.h) and build trex-core and copy the executables to the TRex Client.
+
+
+== How to Use?
+
+There is a new property added in the Latency stream through which we can enable or disable IEEE_1588 in python script ( for enabling, ieee_1588 = true). Other than that the Type, packet size and port number needs to be set as mentioned above in limitations section. Also please refer to the example provided for the same.
+
+scripts/stl/udp_1pkt_src_ip_split_latency_ieee_1588.py

--- a/scripts/automation/regression/functional_tests/stl_basic_tests.py
+++ b/scripts/automation/regression/functional_tests/stl_basic_tests.py
@@ -289,6 +289,7 @@ class CStlBasic_Test(functional_general_test.CGeneralFunctional_Test):
             'imix_wlc.py',          # expects tunables
             'udp_1pkt_vxlan.py',    # uses custom Scapy layer
             'icmpv6_fix_cs.py',     # cannot parse layer name from offset correctly (ICMPv6ND_NS classname and layer name do not match)
+            'udp_1pkt_src_ip_split_latency_ieee_1588.py', # cannot be tested on sim as IEEE 1588 is only supported on specific NICs
             ]
         exclude_dict = {}.fromkeys(exclude_list)
         output_file = os.path.join(self.generated_path, 'exported_to_code.py')

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -3424,6 +3424,7 @@ class TRexClient(object):
             print('  LED status:    %s' % info['led_change_supported'])
             print('  Flow control:  %s' % info['fc_supported'])
             print('  VXLAN FS:      %s' % info['is_vxlan_supported'])
+            print('  IEEE 1588:     %s' % info['is_ieee1588_supported'])
             print('')
         else:
             if not opts.ports:

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_port.py
@@ -668,6 +668,11 @@ class Port(object):
         else:
             info['is_vxlan_supported'] = 'N/A'
 
+        if 'is_ieee1588_supported' in info:
+            info['is_ieee1588_supported'] = 'yes' if info['is_ieee1588_supported'] else 'no'
+        else:
+            info['is_ieee1588_supported'] = 'N/A'
+
         if 'is_virtual' in info:
             info['is_virtual'] = 'yes' if info['is_virtual'] else 'no'
         else:

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_streams.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_streams.py
@@ -253,11 +253,12 @@ STLStreamDstMAC_PKT     =1
 STLStreamDstMAC_ARP     =2
 
 class STLFlowStatsInterface(object):
-    def __init__ (self, pg_id, vxlan):
+    def __init__ (self, pg_id, vxlan, ieee_1588):
         self.fields = {
             'enabled':      True,
             'stream_id':    pg_id,
             'vxlan':        vxlan,
+            'ieee_1588':    ieee_1588,
             }
 
     def to_json (self):
@@ -309,8 +310,8 @@ class STLFlowStats(STLFlowStatsInterface):
 
     """
 
-    def __init__(self, pg_id, vxlan = False):
-        super(STLFlowStats, self).__init__(pg_id, vxlan)
+    def __init__(self, pg_id, vxlan = False, ieee_1588 = False):
+        super(STLFlowStats, self).__init__(pg_id, vxlan, ieee_1588)
         self.fields['rule_type'] = 'stats'
 
 
@@ -325,8 +326,8 @@ class STLFlowLatencyStats(STLFlowStatsInterface):
 
     """
 
-    def __init__(self, pg_id, vxlan = False):
-        super(STLFlowLatencyStats, self).__init__(pg_id, vxlan)
+    def __init__(self, pg_id, vxlan = False, ieee_1588 = False):
+        super(STLFlowLatencyStats, self).__init__(pg_id, vxlan, ieee_1588)
         self.fields['rule_type'] = 'latency'
 
 

--- a/scripts/stl/udp_1pkt_src_ip_split_latency_ieee_1588.py
+++ b/scripts/stl/udp_1pkt_src_ip_split_latency_ieee_1588.py
@@ -1,0 +1,77 @@
+from trex_stl_lib.api import *
+import argparse
+
+
+
+# split the range of IP to cores 
+# add tunable by fsize to change the size of the frame 
+# latency frame is always 106 (uses IEEE 1588 HW support and DPDK APIs)
+# trex>start -f stl/udp_1pkt_src_ip_split_latency_ieee_1588.py -t fsize=64 -m 30% --port 0 --force
+#
+# 
+
+class STLS1(object):
+
+    def __init__ (self):
+        self.fsize  =64;
+        self.lfsize  =106; #The packets size in the latency stream with IEEE-1588 is fixed
+
+
+    def create_stream (self, dir,port_id):
+        # Create base packet and pad it to size
+        size = self.fsize - 4; # HW will add 4 bytes ethernet FCS
+
+        if dir==0:
+            src_ip="16.0.0.1"
+            dst_ip="48.0.0.1"
+        else:
+            src_ip="48.0.0.1"
+            dst_ip="16.0.0.1"
+
+        base_pkt = Ether()/IP(src=src_ip,dst=dst_ip)/UDP(dport=12,sport=1025)
+
+        pad = max(0, size - len(base_pkt)) * 'x'
+        pad_latency = max(0, (self.lfsize-4) - len(base_pkt)) * 'x'
+                             
+        vm = STLScVmRaw( [   STLVmFlowVar ( "ip_src",  min_value="10.0.0.1",
+                                            max_value="10.0.0.255", size=4, step=1,op="inc"),
+                             STLVmWrFlowVar (fv_name="ip_src", pkt_offset= "IP.src" ), # write ip to packet IP.src
+                             STLVmFixIpv4(offset = "IP")                                # fix checksum
+                                  ]
+                              ,cache_size =255 # the cache size
+                              );
+        #dport should be 319. Well known port for IEEE 1588 (PTP protocol)
+        base_lat_pkt = Ether()/IP(src=src_ip,dst=dst_ip)/UDP(dport=319,sport=1025)
+
+        pkt = STLPktBuilder(pkt = base_pkt/pad,
+                            vm = vm)
+        stream = [STLStream(packet = pkt,
+                            mode = STLTXCont(pps=1)),
+
+                  # latency stream   
+                  STLStream(packet = STLPktBuilder(pkt = base_lat_pkt/pad_latency),
+                            mode = STLTXCont(pps=1000),
+                            flow_stats = STLFlowLatencyStats(pg_id = 12+port_id, ieee_1588 = True))
+  
+        ]
+        return stream
+
+
+    def get_streams (self, direction, tunables, **kwargs):
+        parser = argparse.ArgumentParser(description='Argparser for {}'.format(os.path.basename(__file__)), 
+                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser.add_argument('--fsize',
+                            type=int,
+                            default=64,
+                            help="The packets size in the regular stream")
+        args = parser.parse_args(tunables)
+        self.fsize = args.fsize
+        return self.create_stream(direction,kwargs['port_id'])
+
+
+# dynamic load - used for trex console or simulator
+def register():
+    return STLS1()
+
+
+

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -1084,6 +1084,7 @@ public:
 
 private:
     int send_sl_node(CGenNodeStateless * node_sl);
+    void fill_fsp_head(struct flow_stat_payload_header *fsp_head, uint16_t hw_id);
     int send_pcap_node(CGenNodePCAP * pcap_node);
 
 };

--- a/src/dpdk_trex_port_attr.cpp
+++ b/src/dpdk_trex_port_attr.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 DpdkTRexPortAttr::DpdkTRexPortAttr(uint8_t tvpid, uint8_t repid, bool is_virtual,
         bool fc_change_allowed, bool is_prom_allowed, bool is_vxlan_fs_allowed, bool has_pci,
-        bool device_flush_needed) {
+        bool device_flush_needed, bool is_ieee1588_allowed) {
 
     m_tvpid = tvpid;
     m_repid = repid;
@@ -37,6 +37,7 @@ DpdkTRexPortAttr::DpdkTRexPortAttr(uint8_t tvpid, uint8_t repid, bool is_virtual
     flag_is_link_change_supported = (set_link_up(true) != -ENOTSUP);
     flag_is_prom_change_supported = is_prom_allowed;
     flag_is_vxlan_fs_supported = is_vxlan_fs_allowed;
+    flag_is_ieee1588_supported = is_ieee1588_allowed;
     flag_is_device_flush_needed = device_flush_needed;
     update_device_info();
     update_description();

--- a/src/drivers/trex_driver_i40e.cpp
+++ b/src/drivers/trex_driver_i40e.cpp
@@ -45,7 +45,7 @@ CTRexExtendedDriverBase40G::CTRexExtendedDriverBase40G() {
 TRexPortAttr* CTRexExtendedDriverBase40G::create_port_attr(tvpid_t tvpid,repid_t repid) {
     // disabling flow control on 40G using DPDK API causes the interface to malfunction
     bool fc_enabled = false;
-    return new DpdkTRexPortAttr(tvpid, repid, false, fc_enabled, true, hw_rx_stat_supported(), true);
+    return new DpdkTRexPortAttr(tvpid, repid, false, fc_enabled, true, hw_rx_stat_supported(), true, false, true);
 }
 
 int CTRexExtendedDriverBase40G::get_min_sample_rate(void){

--- a/src/gtest/trex_stateless_gtest.cpp
+++ b/src/gtest/trex_stateless_gtest.cpp
@@ -5075,6 +5075,7 @@ TEST_F(flow_stat_lat, pkt_decode) {
 }
 
 using flow_stat_payload_headers = std::vector<flow_stat_payload_header>;
+using flow_stat_payload_headers_ieee_1588 = std::vector<flow_stat_payload_header_ieee_1588>;
 using stats_for_pkt = std::tuple<rfc2544_info_t_, CRxCoreErrCntrs>;
 
 stats_for_pkt calculate_stats_for_pkts(
@@ -5099,6 +5100,35 @@ stats_for_pkt calculate_stats_for_pkts(
     std::for_each(fs_headers.begin(), fs_headers.end(),
                   [&latency_counter](flow_stat_payload_header& fsh){
         latency_counter.update_stats_for_pkt(&fsh, 10, 10);
+    });
+
+    rfc2544_info_t_ results;
+    rfc2544_info.export_data(results);
+    return stats_for_pkt(results, error_cntrs);
+}
+
+stats_for_pkt calculate_stats_for_pkts_ieee_1588(
+        flow_stat_payload_headers_ieee_1588& fs_headers,
+        bool rcv_all = true) {
+    // TODO: after further refactoring RXLatency::create should be used
+    //       to initialize RXLatency instance.
+    RXLatency latency_counter;
+
+    // TODO: Creating CRFC2544Info with unpredictable values and then calling
+    //       create() to reset the counters is unfortunate and should be fixed.
+    CRFC2544Info rfc2544_info;
+    rfc2544_info.create();
+
+    CRxCoreErrCntrs error_cntrs;
+
+    latency_counter.m_rcv_all = rcv_all;
+    latency_counter.m_rfc2544 = &rfc2544_info;
+    latency_counter.m_err_cntrs = &error_cntrs;
+    latency_counter.m_ip_id_base = 0;
+
+    std::for_each(fs_headers.begin(), fs_headers.end(),
+                  [&latency_counter](flow_stat_payload_header_ieee_1588& fsh){
+        latency_counter.update_stats_for_pkt_ieee_1588(&fsh, 10, 10);
     });
 
     rfc2544_info_t_ results;
@@ -5210,3 +5240,18 @@ TEST(latency_stats, out_of_order) {
     EXPECT_EQ(std::get<0>(results).get_ooo_cnt(), 1);
     EXPECT_EQ(std::get<0>(results).get_seq_err_ev_low(), 1);
 }
+
+#define PTP_DUMMY_PKT  {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}
+TEST(latency_stats, out_of_order_ieee_1588) {
+    flow_stat_payload_headers_ieee_1588 fs_headers = {
+        {PTP_DUMMY_PKT, FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
+        {PTP_DUMMY_PKT, FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 3, 0},
+        {PTP_DUMMY_PKT, FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 2, 0},
+        {PTP_DUMMY_PKT, FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 4, 0},
+    };
+
+    auto results = calculate_stats_for_pkts_ieee_1588(fs_headers, false);
+    EXPECT_EQ(std::get<0>(results).get_ooo_cnt(), 1);
+    EXPECT_EQ(std::get<0>(results).get_seq_err_ev_low(), 1);
+}
+

--- a/src/pal/linux/mbuf.h
+++ b/src/pal/linux/mbuf.h
@@ -95,6 +95,7 @@ struct rte_mbuf {
     } hash;                   /**< hash information */
 
     void *  dynfield_ptr;
+    uint16_t timesync;
 
 } ;
 
@@ -190,6 +191,7 @@ uint16_t rte_ipv6_phdr_cksum(const struct rte_ipv6_hdr *ipv6_hdr, uint64_t ol_fl
 
 #define PKT_TX_TCP_SEG       (1ULL << 50)
 
+#define PKT_RX_IEEE1588_TMST   (1ULL << 10) /* RX IEEE1588 L2/L4 timestamped packet. */
 
 
 void rte_pktmbuf_free(rte_mbuf_t *m);

--- a/src/pal/linux/rte_ethdev_includes.h
+++ b/src/pal/linux/rte_ethdev_includes.h
@@ -10,6 +10,11 @@ struct rte_eth_link {
 
 #define ETH_SPEED_NUM_100G    100000 /**< 100 Gbps */
 
+/**
+ * Force a structure to be packed
+ */
+#define __rte_packed __attribute__((__packed__))
+
 enum rte_eth_fc_mode {
 };
 
@@ -27,5 +32,11 @@ struct rte_eth_dev_info {
 
 struct rte_pci_device {
 };
+
+static inline int
+rte_eth_timesync_read_rx_timestamp(uint16_t port_id, struct timespec *timestamp,
+				   uint32_t flags){
+    return 0;
+}
 
 #endif /* __RTE_ETHDEV_INCLUDES_H__ */

--- a/src/stx/common/trex_latency_counters.h
+++ b/src/stx/common/trex_latency_counters.h
@@ -99,8 +99,12 @@ public:
 
     void handle_pkt(const rte_mbuf_t *m, int port);
     bool handle_flow_latency_stats(const rte_mbuf_t *m, uint32_t& ip_id,bool check_non_ip);
+    bool handle_flow_latency_stats_ieee_1588(const rte_mbuf_t *m, uint32_t& ip_id, int port);
     void update_flow_stats(const rte_mbuf_t *m, uint32_t ip_id);
     void update_stats_for_pkt(flow_stat_payload_header *fsp_head,
+                              uint32_t pkt_len,
+                              hr_time_t hr_time_now);
+    void update_stats_for_pkt_ieee_1588(flow_stat_payload_header_ieee_1588 *fsp_head,
                               uint32_t pkt_len,
                               hr_time_t hr_time_now);
     void set_dump_info(const rte_mbuf_t *m, flow_stat_payload_header *fsp_head);
@@ -141,13 +145,24 @@ private:
     bool handle_unexpected_flow(
         flow_stat_payload_header *fsp_head,
         CRFC2544Info *curr_rfc2544);
+    bool handle_unexpected_flow_ieee_1588(
+        flow_stat_payload_header_ieee_1588 *fsp_head,
+        CRFC2544Info *curr_rfc2544);
     void handle_correct_flow(
         flow_stat_payload_header *fsp_head,
         CRFC2544Info *curr_rfc2544,
         uint32_t pkt_len,
         hr_time_t hr_time_now);
+    void handle_correct_flow_ieee_1588(
+        flow_stat_payload_header_ieee_1588 *fsp_head,
+        CRFC2544Info *curr_rfc2544,
+        uint32_t pkt_len,
+        hr_time_t hr_time_now);
     void check_seq_number_and_update_stats(
         flow_stat_payload_header *fsp_head,
+        CRFC2544Info *curr_rfc2544);
+    void check_seq_number_and_update_stats_ieee_1588(
+        flow_stat_payload_header_ieee_1588 *fsp_head,
         CRFC2544Info *curr_rfc2544);
     void handle_seq_number_smaller_than_expected(
         CRFC2544Info *curr_rfc2544,
@@ -157,22 +172,18 @@ private:
         CRFC2544Info *curr_rfc2544,
         uint32_t &pkt_seq,
         uint32_t &exp_seq);
-
-#ifdef LATENCY_IEEE_1588_TIMESTAMPING
     void save_timestamps_for_sync_pkt(
         const rte_mbuf_t *m,
-        flow_stat_payload_header *fsp_head,
+        flow_stat_payload_header_ieee_1588 *fsp_head,
         int port);
     void update_timestamps_for_fup_pkt(
-        flow_stat_payload_header *fsp_head);
-#endif /* LATENCY_IEEE_1588_TIMESTAMPING */
+        flow_stat_payload_header_ieee_1588 *fsp_head);
 public:
 
-#ifdef LATENCY_IEEE_1588_TIMESTAMPING
     uint32_t m_fup_seq_exp; // expected next seq num for Followup packet
     uint64_t m_sync_arrival_time_nsec;
     uint64_t m_sync_arrival_time_sec;
-#endif /* LATENCY_IEEE_1588_TIMESTAMPING */
+    bool     m_is_ieee_ref_cnt_set;
 
     rx_per_flow_t         m_rx_pg_stat[MAX_FLOW_STATS];
     rx_per_flow_t         m_rx_pg_stat_payload[MAX_FLOW_STATS_PAYLOAD];

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -506,6 +506,7 @@ TrexRpcCmdGetSysInfo::_run(const Json::Value &params, Json::Value &result) {
         port_json["is_link_supported"]  = api.getPortAttrObj(i)->is_link_change_supported();
         port_json["is_prom_supported"]  = api.getPortAttrObj(i)->is_prom_change_supported();
         port_json["is_vxlan_supported"] = api.getPortAttrObj(i)->is_vxlan_fs_supported();
+        port_json["is_ieee1588_supported"] = api.getPortAttrObj(i)->is_ieee1588_supported();
         port_json["is_virtual"]         = api.getPortAttrObj(i)->is_virtual();
         
         port_json["supp_speeds"] = Json::arrayValue;

--- a/src/stx/stl/trex_stl_dp_core.cpp
+++ b/src/stx/stl/trex_stl_dp_core.cpp
@@ -490,6 +490,27 @@ rte_mbuf_t * CGenNodeStateless::alloc_flow_stat_mbuf(rte_mbuf_t *m, struct flow_
     }
 }
 
+/*
+ * Allocate mbuf for flow stat (and latency with IEEE 1588) info sending
+ * m - Original mbuf (can be complicated mbuf data structure)
+ * fsp_head  - return pointer in which the flow stat info should be filled
+ * return new mbuf structure in which the fsp_head can be written. If needed, orginal mbuf is freed.
+ */
+rte_mbuf_t * CGenNodeStateless::alloc_flow_stat_mbuf_ieee_1588(rte_mbuf_t *m,
+                                     struct flow_stat_payload_header_ieee_1588 *&fsp_head) {
+    rte_mbuf_t *m_ret = NULL;
+    uint16_t fsp_head_size = sizeof(struct flow_stat_payload_header_ieee_1588);
+
+    m_ret = CGlobalInfo::pktmbuf_alloc_local( get_socket_id(), rte_pktmbuf_data_len(m) );
+    assert(m_ret);
+    char *p = rte_pktmbuf_mtod(m, char*);
+    char *p_new = rte_pktmbuf_append(m_ret, rte_pktmbuf_data_len(m));
+    memcpy(p_new , p, rte_pktmbuf_data_len(m));
+    fsp_head = (struct flow_stat_payload_header_ieee_1588 *)(p_new + rte_pktmbuf_data_len(m) - fsp_head_size);
+    rte_pktmbuf_free(m);
+    return m_ret;
+}
+
 // test the const case of alloc_flow_stat_mbuf. The more complicated non const case is tested in the simulation.
 bool CGenNodeStateless::alloc_flow_stat_mbuf_test_const() {
     rte_mbuf_t *m, *m_test;

--- a/src/stx/stl/trex_stl_fs.h
+++ b/src/stx/stl/trex_stl_fs.h
@@ -50,8 +50,6 @@ typedef std::map<uint32_t, uint16_t>::iterator flow_stat_map_it_t;
 
 class CRxCore;
 
-#ifdef LATENCY_IEEE_1588_TIMESTAMPING
-
 /* Values for the PTP messageType field. */
 #define SYNC                  0x0
 #define DELAY_REQ             0x1
@@ -102,10 +100,16 @@ struct sync_msg {
 	struct tstamp       origin_tstamp;
 } __rte_packed;
 
-#endif /* LATENCY_IEEE_1588_TIMESTAMPING */
-
 struct flow_stat_payload_header {
-#ifdef LATENCY_IEEE_1588_TIMESTAMPING
+    uint8_t magic;
+    uint8_t flow_seq;
+    uint16_t hw_id;
+    uint32_t seq;
+    uint64_t time_stamp;
+    bool is_valid_ts(hr_time_t now);
+};
+
+struct flow_stat_payload_header_ieee_1588 {
     /*
      * Intentionally kept at the begining.
      * The PTP packet has to begin in the
@@ -113,19 +117,8 @@ struct flow_stat_payload_header {
      * header ends.
      */
     struct sync_msg ptp_message;
-#endif /* LATENCY_IEEE_1588_TIMESTAMPING */
-    uint8_t magic;
-    uint8_t flow_seq;
-    uint16_t hw_id;
-    uint32_t seq;
-    uint64_t time_stamp;
-#ifdef LATENCY_IEEE_1588_TIMESTAMPING
+    struct flow_stat_payload_header fsp_hdr;
 } __rte_packed;
-#else
-    bool is_valid_ts(hr_time_t now);
-};
-
-#endif /* LATENCY_IEEE_1588_TIMESTAMPING */
 
 class TrexFStatEx : public TrexException {
  public:

--- a/src/stx/stl/trex_stl_rpc_cmds.cpp
+++ b/src/stx/stl/trex_stl_rpc_cmds.cpp
@@ -496,6 +496,16 @@ TrexRpcCmdAddStream::_run(const Json::Value &params, Json::Value &result) {
 
             stream->m_rx_check.m_pg_id      = parse_uint32(rx, "stream_id", result);
             stream->m_rx_check.m_vxlan_skip = parse_bool(rx, "vxlan", result, false);
+            stream->m_rx_check.m_ieee_1588  = parse_bool(rx, "ieee_1588", result, false);
+            if(stream->m_rx_check.m_ieee_1588 == true) {
+                /* User enabled IEEE 1588 for Latency Measurment. Verify if its possible */
+                const TrexPlatformApi &api = get_platform_api();
+                if ( !(api.getPortAttrObj(stream->m_port_id)->is_ieee1588_supported())) {
+                    std::stringstream ss;
+                    ss << "Driver doesnt support IEEE-1588.";
+                    generate_execute_err(result, ss.str());
+                }
+            }
             std::string type = parse_string(rx, "rule_type", result);
             if (type == "latency") {
                 stream->m_rx_check.m_rule_type = TrexPlatformApi::IF_STAT_PAYLOAD;

--- a/src/stx/stl/trex_stl_stream.cpp
+++ b/src/stx/stl/trex_stl_stream.cpp
@@ -152,6 +152,7 @@ TrexStream::TrexStream(uint8_t type, uint8_t port_id, uint32_t stream_id, uint32
 
     m_rx_check.m_enabled = false;
     m_rx_check.m_vxlan_skip = false;
+    m_rx_check.m_ieee_1588 = false;
 
     m_burst_total_pkts=0; 
     m_num_bursts=1; 

--- a/src/stx/stl/trex_stl_stream.h
+++ b/src/stx/stl/trex_stl_stream.h
@@ -590,6 +590,7 @@ public:
         uint16_t  m_rule_type;
         uint32_t  m_pg_id;
         uint16_t  m_hw_id;
+        bool      m_ieee_1588;
     } m_rx_check;
 
     uint32_t   m_burst_total_pkts; /* valid in case of burst stSINGLE_BURST,stMULTI_BURST*/

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -321,6 +321,10 @@ public:
         return m_ref_stream_info->is_latency_stream();
     }
 
+    inline bool is_latency_ieee_1588_enabled() {
+        return m_ref_stream_info->m_rx_check.m_ieee_1588;
+    }
+
     inline void set_mbuf_cache_dir(pkt_dir_t  dir){
         if (dir) {
             m_flags |=NODE_FLAGS_DIR;
@@ -396,6 +400,9 @@ public:
 
     rte_mbuf_t   * alloc_flow_stat_mbuf(rte_mbuf_t *m, struct flow_stat_payload_header * &fsp_head
                                         , bool is_const);
+    rte_mbuf_t   * alloc_flow_stat_mbuf_ieee_1588(rte_mbuf_t *m,
+                                            struct flow_stat_payload_header_ieee_1588 * &fsp_head);
+
     bool alloc_flow_stat_mbuf_test_const();
     rte_mbuf_t   * alloc_node_with_vm();
 

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -439,6 +439,14 @@ public:
         return (btGetMaskBit32(m_flags1, 20, 20) ? true : false);
     }
 
+    void setLatencyIEEE1588Disable(bool enable) {
+        btSetMaskBit32(m_flags1, 24, 24, (enable ? 1 : 0) );
+    }
+
+    bool getLatencyIEEE1588Disable(){
+        return (btGetMaskBit32(m_flags1, 24, 24) ? true : false);
+    }
+
 public:
     void Dump(FILE *fd);
 

--- a/src/trex_port_attr.h
+++ b/src/trex_port_attr.h
@@ -61,6 +61,7 @@ public:
     virtual bool is_link_change_supported() { return flag_is_link_change_supported; }
     virtual bool is_prom_change_supported() { return flag_is_prom_change_supported; }
     virtual bool is_vxlan_fs_supported() { return flag_is_vxlan_fs_supported; }
+    virtual bool is_ieee1588_supported() { return flag_is_ieee1588_supported; }
     virtual const std::string &get_description() { return intf_info_st.description; }
     virtual int get_numa(void) { return intf_info_st.numa_node; }
     virtual const std::string& get_pci_addr(void) { return intf_info_st.pci_addr; }
@@ -117,6 +118,7 @@ protected:
     bool       flag_is_link_change_supported;
     bool       flag_is_prom_change_supported;
     bool       flag_is_vxlan_fs_supported;
+    bool       flag_is_ieee1588_supported;
 
     struct intf_info_st {
         std::string     pci_addr;
@@ -132,7 +134,7 @@ public:
 
     DpdkTRexPortAttr(uint8_t tvpid, uint8_t repid, bool is_virtual, bool fc_change_allowed,
             bool is_prom_allowed, bool is_vxlan_fs_allowed, bool has_pci,
-            bool device_flush_needed = false);
+            bool device_flush_needed = false,  bool is_ieee1588_allowed = false);
 
 /*    UPDATES    */
     virtual void update_link_status();
@@ -203,6 +205,7 @@ public:
         flag_is_link_change_supported = false;
         flag_is_prom_change_supported = false;
         flag_is_vxlan_fs_supported = false;
+        flag_is_ieee1588_supported = false;
         update_description();
     }
 


### PR DESCRIPTION
Adding feature support ‘--latency-ieee-1588’ . With this Latency
measurements use HW timestamping and without it default behavior
same as existing mechanism.
Note: Since there is some work involved in DPDK to keep both
Vector code and IEEE 1588 code working together currently we
cannot enable the DPDK config( RTE_LIBRTE_IEEE1588) by default.
So, in order to use this feature (--latency-ieee-1588) we need to
enable RTE_LIBRTE_IEEE1588 config COMPILE time and then we can
dynamically enable or disable HW timestamping based on requirement.

Signed-off-by: Abhiram R N <arn@redhat.com>