### PR TITLE
Fix GCC compilation error: clearing an object of non-trivial type ‘cl…

### DIFF
--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -532,7 +532,11 @@ public:
         m_vlan_port[1] = 100;
         memset(m_src_ipv6, 0, sizeof(m_src_ipv6));
         memset(m_dst_ipv6, 0, sizeof(m_dst_ipv6));
-        memset(m_ip_cfg, 0, sizeof(m_ip_cfg));
+        m_ip_cfg->set_ip(0);
+        m_ip_cfg->set_mask(0);
+        m_ip_cfg->set_def_gw(0);
+        m_ip_cfg->set_vlan(0);
+        m_ip_cfg->set_vxlan_fs(false);
         m_latency_rate = 0;
         m_latency_mask = 0xffffffff;
         m_latency_prev = 0;


### PR DESCRIPTION
…ass CPerPortIPCfg’

This small patch fixes the following error:
```
In file included from ../../src/tuple_gen.h:41,
                 from ../../src/bp_sim.h:53,
                 from ../../src/stx/common/trex_rx_packet_parser.cpp:22:
../../src/trex_global.h: In member function ‘void CParserOption::reset()’:
../../src/trex_global.h:535:15: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘class CPerPortIPCfg’; use assignment or value-initialization instead [-Werror=class-memaccess]
  535 |         memset(m_ip_cfg, 0, sizeof(m_ip_cfg));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/trex_global.h:474:7: note: ‘class CPerPortIPCfg’ declared here
  474 | class CPerPortIPCfg {
      |       ^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```
Note: there are other compilation errors with GCC (I'm using 11.1.1), but it's a start.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>