### PR TITLE
prevent watchdog from lots of non-blocking send

### DIFF
--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -497,6 +497,7 @@ typedef uint8_t tcp_app_state_t;
 class CEmulTxQueue {
 public:
     CEmulTxQueue(){
+        m_q_tot_bytes=0;
         m_tx_offset=0;
         m_v_cc=0;
         m_wnd_div_2=0;
@@ -509,6 +510,7 @@ public:
     void add_buffer(CMbufBuffer * b){
         m_q.push_back(b);
         m_v_cc+=b->len();
+        m_q_tot_bytes+=b->len();
     }
 
     void subtract_bytes(uint32_t bytes){
@@ -531,6 +533,7 @@ private:
     uint32_t                    m_wnd_div_2; /* the TCP Tx window size */
     uint32_t                    m_v_cc; /* number of bytes in the app level queue -> me move bytes to TCP queue */
     uint32_t                    m_tx_offset; /* offset into the vector */
+    uint32_t                    m_q_tot_bytes; /* total bytes of all the buffers */
     std::vector<CMbufBuffer *>  m_q; /* queue of buffers */
 };
 


### PR DESCRIPTION
Hi, recently I've got a watchdog case at `tcp_socket.cpp:1097`.
```
1093         /* with new vector, calculate the sum again, could be size of 1 */
1094         for (i=0;i<(int)z; i++ ) {
1095             CMbufBuffer * b=m_q[i];
1096             uint32_t c_len =b->len();
1097             sum+=c_len;                       // <-- watchdog here
1098         }
```
This issue happened after #717 merged when my user sent tera-bytes in non-blocking mode. In this case, the number of buffers(`z`) could be about millions in there.

So, I removed the loop getting the total number of bytes in buffers by adding `m_q_tot_bytes`.
Furthermore, I made non-blocking send working only when there is a space in socket buffer using by `m_api->get_tx_sbspace(m_flow)`.
I think this change prevents the large number of buffers in `m_q`.

@hhaim could you check my changes and give your feedback?