### PR TITLE
Additional GCC compilation error fixes

### DIFF
--- a/src/stx/stl/trex_stl_fs.cpp
+++ b/src/stx/stl/trex_stl_fs.cpp
@@ -112,11 +112,7 @@ void dbg_printf(const char *fmt, ...)
 /************** class CFlowStatUserIdInfo ***************/
 CFlowStatUserIdInfo::CFlowStatUserIdInfo(uint16_t l3_proto, uint8_t l4_proto, uint8_t ipv6_next_h) {
     m_rx_cntr->clear();
-    m_rx_cntr->set_byte_base(0);
-    m_rx_cntr->set_pkt_base(0);
     m_tx_cntr->clear();
-    m_tx_cntr->set_byte_base(0);
-    m_tx_cntr->set_pkt_base(0);
     m_hw_id = HW_ID_INIT;
     m_l3_proto = l3_proto;
     m_l4_proto = l4_proto;
@@ -164,13 +160,9 @@ void CFlowStatUserIdInfo::reset_hw_id() {
     int i;
     for(i = 0; i < TREX_MAX_PORTS; i++) {
         m_rx_cntr[i].clear();
-        m_rx_cntr[i].set_byte_base(0);
-        m_rx_cntr[i].set_pkt_base(0);
     }
     for(i = 0; i < TREX_MAX_PORTS; i++) {
         m_tx_cntr[i].clear();
-        m_tx_cntr[i].set_byte_base(0);
-        m_tx_cntr[i].set_pkt_base(0);
     }
 }
 

--- a/src/stx/stl/trex_stl_fs.cpp
+++ b/src/stx/stl/trex_stl_fs.cpp
@@ -111,8 +111,12 @@ void dbg_printf(const char *fmt, ...)
 
 /************** class CFlowStatUserIdInfo ***************/
 CFlowStatUserIdInfo::CFlowStatUserIdInfo(uint16_t l3_proto, uint8_t l4_proto, uint8_t ipv6_next_h) {
-    memset(m_rx_cntr, 0, sizeof(m_rx_cntr));
-    memset(m_tx_cntr, 0, sizeof(m_tx_cntr));
+    m_rx_cntr->clear();
+    m_rx_cntr->set_byte_base(0);
+    m_rx_cntr->set_pkt_base(0);
+    m_tx_cntr->clear();
+    m_tx_cntr->set_byte_base(0);
+    m_tx_cntr->set_pkt_base(0);
     m_hw_id = HW_ID_INIT;
     m_l3_proto = l3_proto;
     m_l4_proto = l4_proto;
@@ -157,8 +161,17 @@ void CFlowStatUserIdInfo::reset_hw_id() {
     FUNC_ENTRY;
 
     m_hw_id = HW_ID_INIT;
-    memset(m_rx_cntr, 0, sizeof(m_rx_cntr[0]) * TREX_MAX_PORTS);
-    memset(m_tx_cntr, 0, sizeof(m_tx_cntr[0]) * TREX_MAX_PORTS);
+    int i;
+    for(i = 0; i < TREX_MAX_PORTS; i++) {
+        m_rx_cntr[i].clear();
+        m_rx_cntr[i].set_byte_base(0);
+        m_rx_cntr[i].set_pkt_base(0);
+    }
+    for(i = 0; i < TREX_MAX_PORTS; i++) {
+        m_tx_cntr[i].clear();
+        m_tx_cntr[i].set_byte_base(0);
+        m_tx_cntr[i].set_pkt_base(0);
+    }
 }
 
 void CFlowStatUserIdInfo::update_vals(const rx_per_flow_t val, tx_per_flow_with_rate_t & to_update

--- a/src/stx/stl/trex_stl_fs.h
+++ b/src/stx/stl/trex_stl_fs.h
@@ -335,6 +335,8 @@ class tx_per_flow_with_rate_t_ : public tx_per_flow_t_ {
         tx_per_flow_t_::clear();
         m_p_rate = 0;
         m_b_rate = 0;
+        m_pkts_base = 0;
+        m_bytes_base = 0;
         m_last_rate_calc_time = 0;
         m_calc_time_valid = false;
     }

--- a/src/trex_watchdog.cpp
+++ b/src/trex_watchdog.cpp
@@ -30,6 +30,7 @@ limitations under the License.
 #include <execinfo.h>
 #include <cxxabi.h>
 #include <dlfcn.h>
+#include <memory>
 #include <pthread.h>
 #include <signal.h>
 #include <string.h>


### PR DESCRIPTION
1. Similar to 0bd600860fd504290c7c87adbf3044b970ed4b6d - clearing an object of non-trivial type
I'm less happy about this fix, as I'm using both the clear() method AND specific setters.
I wish I could just use clear()

2. Fixing this error:
```
../../src/trex_watchdog.cpp: In function ‘std::string exec(const char*)’:
../../src/trex_watchdog.cpp:52:10: error: ‘shared_ptr’ is not a member of ‘std’
   52 |     std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
      |          ^~~~~~~~~~
../../src/trex_watchdog.cpp:38:1: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   37 | #include <iostream>
  +++ |+#include <memory>
   38 | #include  <stdexcept>
../../src/trex_watchdog.cpp:52:25: error: expected primary-expression before ‘>’ token
   52 |     std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
      |                         ^
../../src/trex_watchdog.cpp:52:37: error: cannot convert ‘FILE*’ to ‘int*’
   52 |     std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
      |                                ~~~~~^~~~~~~~~~
      |                                     |
      |                                     FILE*
```
Note: there are other compilation errors with GCC (I'm using 11.1.1), squashing them slowly.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>