### PR TITLE
Fix memory leak and invalid access

### DIFF
--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -123,7 +123,6 @@ void    sbappend_bytes(struct tcp_socket *so,
 #define sorwakeup(so)   { sowakeup((so), &(so)->so_rcv); \
               if ((so)->so_upcall) \
                 (*((so)->so_upcall))((so), (so)->so_upcallarg, M_DONTWAIT); \
-                
             }
 #else
 

--- a/src/sim/trex_sim_stateful.cpp
+++ b/src/sim/trex_sim_stateful.cpp
@@ -490,7 +490,7 @@ bool CMergeCapFileRec::Create(std::string cap_file,
 
 
 
-#define MERGE_CAP_FILES (2)
+#define MERGE_CAP_FILES (3)
 
 class CMergeCapFile {
 public:

--- a/src/utils/utl_port_map.cpp
+++ b/src/utils/utl_port_map.cpp
@@ -157,6 +157,7 @@ int CPciPorts::set_cfg_input(dpdk_input_args_t & vec,
         lp->set_name(iname);
         
         if ( lp->parse(err)!=0){
+            delete lp;
             return(-1);
         }
         m_vec.push_back(lp);


### PR DESCRIPTION
Hi, this PR is to fix some memory leak possibilities and invalid access which are reported by `cppcheck`.

```
src/44bsd/tcp_socket.h:127: error: Invalid number of character '{' when these macros are defined: 'FIXME'.
src/44bsd/tcp_input.cpp:664: error: Uninitialized variable: ts_val
src/44bsd/tcp_input.cpp:688: error: Uninitialized variable: ts_ecr
src/astf/astf_db.cpp:1147: error: Memory leak: ret
src/astf/astf_db.cpp:1244: error: Memory leak: temp_rw
src/sim/trex_sim_stateful.cpp:585: error: Array 'merger.m[2]' accessed at index 2, which is out of bounds.
src/utils/utl_port_map.cpp:160: error: Memory leak: lp
```
I don't fix the errors in `src/44bsd/tcp_input.cpp` because they have no issue.

@hhaim please check my changes and give your feedback