### PR TITLE
reduce get_async_events requests

### DIFF
--- a/src/publisher/trex_publisher.cpp
+++ b/src/publisher/trex_publisher.cpp
@@ -196,6 +196,9 @@ TrexPublisher::publish_event(event_type_e type, const Json::Value &data) {
                 Json::Value valctx;
                 valctx =value;
                 valctx["seq"] = ctx->m_seq++;
+                if (ctx->m_qevents.empty()) {
+                    ctx->m_last_query = now_sec();
+                }
                 ctx->m_qevents.append(valctx);
             }
             else if (ctx->m_reader_mode) {


### PR DESCRIPTION
Hi, this change will reduce the `get_async_events` requests.

When there are lots of profiles are running, lots of state change events would be published simultaneously.
Since the `self.socket.recv()` get the event messages one by one, `get_async_events` requests by the following event messages would get a vacant response.
My change will send it once for all the event messages received at the same time.

In addition, I add a code to ignore other messages (trex-global, ...) and fix a minor bug derived from this change.

@hhaim, please check my changes and give your feedback.