### PR TITLE
Prevent additional SYN sent until ESTABLISHED

### DIFF
--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -380,7 +380,7 @@ CEmulAppCmd* CEmulApp::process_cmd_one(CEmulAppCmd * cmd){
             m_q.subtract_bytes(add_to_queue);
 
             m_state=te_SEND;
-            if (get_interrupt()==false) {
+            if (get_interrupt()==false && m_flags&taCONNECTED) {
                 m_api->tx_tcp_output(m_pctx,m_flow);
             }
 


### PR DESCRIPTION
Hi, this PR is to prevent unexpected SYN sent.

I met an issue that multiple SYNs were sent for the same flow when non-blocking send is used.
When I use the following program on the client-side, additional SYN will be sent.
```
    prog_c.set_send_blocking(False)
    prog_c.set_var("loop", loop)
    prog_c.set_label("a:")
    prog_c.send(data)
    prog_c.delay(20)         # <--  client app blocked here
    prog_c.jmp_nz("loop", "a:")
    prog_c.wait_for_peer_close()
```
When a flow is generated, `app->start(true)` and then `tcp_connect()` are called.
`app->start(true)` will be returned at the first `delay()` and `tcp_connect()` will send the first SYN packet.
The first `send()` will not call `tcp_output()` because the interrupt is true.
After 20 usec passed, the `app` will continue and perform the next `send()` without interrupt.
This time, `send()` will call `tcp_output()` and trigger the additional SYN packet if connection is not established yet.

My change will prevent the additional SYN packets until the connection is established.

@hhaim, please check my change and give your feedback.
