### PR TITLE
fix 2 potential buffer overflows in DpdkTRexPortAttr

### DIFF
--- a/src/dpdk_trex_port_attr.cpp
+++ b/src/dpdk_trex_port_attr.cpp
@@ -112,9 +112,13 @@ int DpdkTRexPortAttr::get_xstats_values(xstats_values_t &xstats_values) {
     if (size < 0) {
         return size;
     }
-    xstats_values_tmp.resize(size);
-    xstats_values.resize(size);
-    size = rte_eth_xstats_get(m_repid, xstats_values_tmp.data(), size);
+
+    do {
+        xstats_values_tmp.resize(size);
+        xstats_values.resize(size);
+        size = rte_eth_xstats_get(m_repid, xstats_values_tmp.data(), size);
+    } while (size > xstats_values_tmp.size());
+
     if (size < 0) {
         return size;
     }
@@ -129,9 +133,13 @@ int DpdkTRexPortAttr::get_xstats_names(xstats_names_t &xstats_names){
     if (size < 0) {
         return size;
     }
-    xstats_names_tmp.resize(size);
-    xstats_names.resize(size);
-    size = rte_eth_xstats_get_names(m_repid, xstats_names_tmp.data(), size);
+
+    do {
+        xstats_names_tmp.resize(size);
+        xstats_names.resize(size);
+        size = rte_eth_xstats_get_names(m_repid, xstats_names_tmp.data(), size);
+    } while (size > xstats_names_tmp.size());
+
     if (size < 0) {
         return size;
     }


### PR DESCRIPTION
Both rte_eth_xstats_get and rte_eth_xstats_get_names do not include
xstats in their return values if the provided buffer is NULL. This
resulted in a case where if the number of xstats is greater than 0,
both DpdkTRexPortAttr::get_xstats_values and
DpdkTRexPortAttr::get_xstats_names would attempt to write past
the end of the vector provided to hold the return value. This was
observed to cause segfaults on both Intel and Broadcom NICs.

It may be possible to remove the do-while loop by passing in a valid
buffer in place of the NULL in both of these methods. However, that may
be less reliable since the do-while loop will continue attempting to get
the information until either it is successful or an error code is
returned.

Signed-off-by: Owen Hilyard <ohilyard@iol.unh.edu>