### PR TITLE
configure --new-memory works w/o -o option

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -871,7 +871,7 @@ def configure(conf):
         s = '#ifndef RTE_EAL_NUMA_AWARE_HUGEPAGES\n'
         s += '#define RTE_EAL_NUMA_AWARE_HUGEPAGES 1\n'
         s += '#endif\n'
-        write_file(os.path.join(conf.options.out, H_DPDK_CONFIG), s)
+        write_file(os.path.join(conf.bldnode.abspath(), H_DPDK_CONFIG), s)
 
 def search_in_paths(paths):
     for path in paths:


### PR DESCRIPTION
Hi, this PR will fix the issue --new-memory does not work without -o option.

```
cd linux_dpdk/
./b configure --new-memory
./b build
```
This has been failed with the following message.
```
In file included from <command-line>:0:0:
../../src/../src/pal/linux_dpdk/dpdk_2102_x86_64/rte_config.h:164:1: fatal error: dpdk_config.h: No such file or directory
#endif /* _RTE_CONFIG_H_ */
^
compilation terminated.
```

The reason is that the implicit `dpdk_config.h` file is created in the current directory without `-o` option.
My change will fix this issue by creating the file in the `out` directory.

@hhaim, please review my change and give your feedback.