### PR TITLE
Fix string casting issue on gcc11

### DIFF
--- a/src/stx/stl/trex_stl_fs.cpp
+++ b/src/stx/stl/trex_stl_fs.cpp
@@ -1323,7 +1323,7 @@ bool CFlowStatRuleMgr::dump_json(Json::Value &json, std::vector<uint32> pgids) {
     // build json report
     // general per port data
     for (auto &port: m_port_ids) {
-            std::string str_port = static_cast<std::ostringstream*>( &(std::ostringstream() << int(port) ) )->str();
+            std::string str_port = std::to_string(int(port));
             if (m_rx_cant_count_err[port] != 0)
                 s_data_section["g"]["rx_err"][str_port] = m_rx_cant_count_err[port];
             if (m_tx_cant_count_err[port] != 0)
@@ -1366,11 +1366,11 @@ bool CFlowStatRuleMgr::dump_json(Json::Value &json, std::vector<uint32> pgids) {
             }
         }
 
-        std::string str_user_id = static_cast<std::ostringstream*>( &(std::ostringstream() << user_id) )->str();
+        std::string str_user_id = std::to_string(user_id);
         v_data_section[str_user_id] = user_id_info->get_ver_id();
         // flow stat json
         for (auto &port: m_port_ids) {
-            std::string str_port = static_cast<std::ostringstream*>( &(std::ostringstream() << int(port) ) )->str();
+            std::string str_port = std::to_string(int(port));
             s_data_section[str_user_id]["rp"][str_port] = Json::Value::UInt64(user_id_info->get_rx_cntr(port).get_pkts());
             if (m_cap & TrexPlatformApi::IF_STAT_RX_BYTES_COUNT)
                 s_data_section[str_user_id]["rb"][str_port] = Json::Value::UInt64(user_id_info->get_rx_cntr(port).get_bytes());

--- a/src/time_histogram.cpp
+++ b/src/time_histogram.cpp
@@ -285,8 +285,7 @@ void CTimeHistogram::dump_json(Json::Value & json, bool add_histogram) {
         for (j = 0; j < HISTOGRAM_SIZE_LOG; j++) {
             for (i = 0; i < HISTOGRAM_SIZE; i++) {
                 if (m_hcnt[j][i] > 0) {
-                    std::string key = static_cast<std::ostringstream*>( &(std::ostringstream()
-                                                                          << int(base * (i + 1)) ) )->str();
+                    std::string key = std::to_string(int(base * (i + 1)));
                     json["histogram"][key] = Json::Value::UInt64(m_hcnt[j][i]);
                 }
             }


### PR DESCRIPTION
gcc11 does not allow 'taking address of rvalue' like:
&(std::ostringstream())

This leads to compilation errors on gcc11. Fix this issue by correctly
casting to string using std::to_string() on the offending lines

Signed-off-by: Michael Santana <msantana@redhat.com>