### PR TITLE
Bnxt xstats fix

### DIFF
--- a/src/dpdk/drivers/net/bnxt/bnxt_stats.c
+++ b/src/dpdk/drivers/net/bnxt/bnxt_stats.c
@@ -594,10 +594,15 @@ int bnxt_dev_xstats_get_op(struct rte_eth_dev *eth_dev,
 	if (rc)
 		return rc;
 
-	if (xstats == NULL)
-		return 0;
+	stat_count = RTE_DIM(bnxt_rx_stats_strings) +
+		RTE_DIM(bnxt_tx_stats_strings) +
+		RTE_DIM(bnxt_func_stats_strings) +
+		RTE_DIM(bnxt_rx_ext_stats_strings) +
+		RTE_DIM(bnxt_tx_ext_stats_strings) +
+		bnxt_flow_stats_cnt(bp);
 
-	memset(xstats, 0, sizeof(*xstats));
+	if (n < stat_count || xstats == NULL)
+		return stat_count;
 
 	bnxt_hwrm_func_qstats(bp, 0xffff, NULL, &func_qstats);
 	bnxt_hwrm_port_qstats(bp);
@@ -609,17 +614,7 @@ int bnxt_dev_xstats_get_op(struct rte_eth_dev *eth_dev,
 					(bp->fw_tx_port_stats_ext_size /
 					 stat_size));
 
-	count = RTE_DIM(bnxt_rx_stats_strings) +
-		RTE_DIM(bnxt_tx_stats_strings) +
-		RTE_DIM(bnxt_func_stats_strings) +
-		RTE_DIM(bnxt_rx_ext_stats_strings) +
-		RTE_DIM(bnxt_tx_ext_stats_strings) +
-		bnxt_flow_stats_cnt(bp);
-
-	stat_count = count;
-
-	if (n < count)
-		return count;
+	memset(xstats, 0, sizeof(*xstats));
 
 	count = 0;
 	for (i = 0; i < RTE_DIM(bnxt_rx_stats_strings); i++) {

--- a/src/dpdk/drivers/net/bnxt/bnxt_stats.c
+++ b/src/dpdk/drivers/net/bnxt/bnxt_stats.c
@@ -721,7 +721,7 @@ int bnxt_flow_stats_cnt(struct bnxt *bp)
 
 int bnxt_dev_xstats_get_names_op(struct rte_eth_dev *eth_dev,
 		struct rte_eth_xstat_name *xstats_names,
-		__rte_unused unsigned int limit)
+		unsigned int size)
 {
 	struct bnxt *bp = (struct bnxt *)eth_dev->data->dev_private;
 	const unsigned int stat_cnt = RTE_DIM(bnxt_rx_stats_strings) +
@@ -737,63 +737,62 @@ int bnxt_dev_xstats_get_names_op(struct rte_eth_dev *eth_dev,
 	if (rc)
 		return rc;
 
-	if (xstats_names != NULL) {
-		count = 0;
+	if (xstats_names == NULL || size < stat_cnt)
+		return stat_cnt;
 
-		for (i = 0; i < RTE_DIM(bnxt_rx_stats_strings); i++) {
-			strlcpy(xstats_names[count].name,
-				bnxt_rx_stats_strings[i].name,
+	for (i = 0; i < RTE_DIM(bnxt_rx_stats_strings); i++) {
+		strlcpy(xstats_names[count].name,
+			bnxt_rx_stats_strings[i].name,
+			sizeof(xstats_names[count].name));
+		count++;
+	}
+
+	for (i = 0; i < RTE_DIM(bnxt_tx_stats_strings); i++) {
+		strlcpy(xstats_names[count].name,
+			bnxt_tx_stats_strings[i].name,
+			sizeof(xstats_names[count].name));
+		count++;
+	}
+
+	for (i = 0; i < RTE_DIM(bnxt_func_stats_strings); i++) {
+		strlcpy(xstats_names[count].name,
+			bnxt_func_stats_strings[i].name,
+			sizeof(xstats_names[count].name));
+		count++;
+	}
+
+	for (i = 0; i < RTE_DIM(bnxt_rx_ext_stats_strings); i++) {
+		strlcpy(xstats_names[count].name,
+			bnxt_rx_ext_stats_strings[i].name,
+			sizeof(xstats_names[count].name));
+
+		count++;
+	}
+
+	for (i = 0; i < RTE_DIM(bnxt_tx_ext_stats_strings); i++) {
+		strlcpy(xstats_names[count].name,
+			bnxt_tx_ext_stats_strings[i].name,
+			sizeof(xstats_names[count].name));
+
+		count++;
+	}
+
+	if (bp->fw_cap & BNXT_FW_CAP_ADV_FLOW_COUNTERS &&
+	    bp->fw_cap & BNXT_FW_CAP_ADV_FLOW_MGMT &&
+	    BNXT_FLOW_XSTATS_EN(bp)) {
+		for (i = 0; i < bp->max_l2_ctx; i++) {
+			char buf[RTE_ETH_XSTATS_NAME_SIZE];
+
+			sprintf(buf, "flow_%d_bytes", i);
+			strlcpy(xstats_names[count].name, buf,
 				sizeof(xstats_names[count].name));
 			count++;
-		}
 
-		for (i = 0; i < RTE_DIM(bnxt_tx_stats_strings); i++) {
-			strlcpy(xstats_names[count].name,
-				bnxt_tx_stats_strings[i].name,
-				sizeof(xstats_names[count].name));
-			count++;
-		}
-
-		for (i = 0; i < RTE_DIM(bnxt_func_stats_strings); i++) {
-			strlcpy(xstats_names[count].name,
-				bnxt_func_stats_strings[i].name,
-				sizeof(xstats_names[count].name));
-			count++;
-		}
-
-		for (i = 0; i < RTE_DIM(bnxt_rx_ext_stats_strings); i++) {
-			strlcpy(xstats_names[count].name,
-				bnxt_rx_ext_stats_strings[i].name,
+			sprintf(buf, "flow_%d_packets", i);
+			strlcpy(xstats_names[count].name, buf,
 				sizeof(xstats_names[count].name));
 
 			count++;
-		}
-
-		for (i = 0; i < RTE_DIM(bnxt_tx_ext_stats_strings); i++) {
-			strlcpy(xstats_names[count].name,
-				bnxt_tx_ext_stats_strings[i].name,
-				sizeof(xstats_names[count].name));
-
-			count++;
-		}
-
-		if (bp->fw_cap & BNXT_FW_CAP_ADV_FLOW_COUNTERS &&
-		    bp->fw_cap & BNXT_FW_CAP_ADV_FLOW_MGMT &&
-		    BNXT_FLOW_XSTATS_EN(bp)) {
-			for (i = 0; i < bp->max_l2_ctx; i++) {
-				char buf[RTE_ETH_XSTATS_NAME_SIZE];
-
-				sprintf(buf, "flow_%d_bytes", i);
-				strlcpy(xstats_names[count].name, buf,
-					sizeof(xstats_names[count].name));
-				count++;
-
-				sprintf(buf, "flow_%d_packets", i);
-				strlcpy(xstats_names[count].name, buf,
-					sizeof(xstats_names[count].name));
-
-				count++;
-			}
 		}
 	}
 


### PR DESCRIPTION
This PR has two fixes for issues in the bnxt PMD xstats APIs that are currently causing memory corruption (overrun) issues in TRex.