### PR TITLE
Improve fetch_capture_packets to reduce RPC messages

### DIFF
--- a/src/stx/common/trex_pkt.cpp
+++ b/src/stx/common/trex_pkt.cpp
@@ -210,14 +210,14 @@ TrexPktBuffer::get_element_count() const {
 }
 
 Json::Value
-TrexPktBuffer::to_json() const {
+TrexPktBuffer::to_json(uint16_t snaplen) const {
 
     Json::Value output = Json::arrayValue;
 
     int tmp = m_tail;
     while (tmp != m_head) {
         const TrexPkt *pkt = m_buffer[tmp];
-        output.append(pkt->to_json());
+        output.append(pkt->to_json(snaplen));
         tmp = next(tmp);
     }
 

--- a/src/stx/common/trex_pkt.h
+++ b/src/stx/common/trex_pkt.h
@@ -83,13 +83,16 @@ public:
     }
     
     /* slow path and also RVO - pass by value is ok */
-    Json::Value to_json() const {
+    Json::Value to_json(uint16_t snaplen=0) const {
         Json::Value output;
+        uint16_t caplen = (snaplen == 0 || m_size < snaplen) ? m_size : snaplen;
+
         output["ts"]      = m_timestamp;
-        output["binary"]  = base64_encode(m_raw, m_size);
+        output["binary"]  = base64_encode(m_raw, caplen);
         output["port"]    = m_port;
         output["index"]   = Json::UInt64(m_index);
-        
+        output["wirelen"] = m_size;
+
         switch (m_origin) {
         case ORIGIN_TX:
             output["origin"]  = "TX";
@@ -101,7 +104,7 @@ public:
             output["origin"]  = "NONE";
             break;
         }
-        
+
         return output;
     }
 
@@ -198,7 +201,7 @@ public:
      * generate a JSON output of the queue
      * 
      */
-    Json::Value to_json() const;
+    Json::Value to_json(uint16_t snaplen=0) const;
 
     
     /**

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -1541,7 +1541,8 @@ TrexRpcCmdCapture::parse_cmd_fetch(const Json::Value &params, Json::Value &resul
     
     uint32_t capture_id = parse_uint32(params, "capture_id", result);
     uint32_t pkt_limit  = parse_uint32(params, "pkt_limit", result);
-    
+    uint16_t snaplen    = parse_uint16(params, "snaplen", result, 0);
+
     /* generate a fetch command */
     
     static MsgReply<TrexCaptureRCFetch> reply;
@@ -1562,7 +1563,7 @@ TrexRpcCmdCapture::parse_cmd_fetch(const Json::Value &params, Json::Value &resul
             
         result["result"]["pending"]     = rc.get_pending();
         result["result"]["start_ts"]    = rc.get_start_ts();
-        result["result"]["pkts"]        = pkt_buffer->to_json();
+        result["result"]["pkts"]        = pkt_buffer->to_json(snaplen);
  
         /* delete the buffer */
         delete pkt_buffer;


### PR DESCRIPTION
Hi, this PR is to improve fetch_capture_packets operation to reduce RPC messages.

**1. Background**
 Pakcet capture performance can be degraded by too many RPC messages and large packet binary size in RPC response.
 Improvement point is as below.
  - Reduce the number of RPC messages for fetching packets.
  - Reduce the amount of packet binary in RPC response

**2. Code changes**
(1) client side.
 Added new parameter in 'fetch_capture_packets'.
```
  - fetch_limit: limit the number of packets to be fetched with one RPC _transmit() call. Default is 50 for backward compatibility.
  - snaplen: snapshot length is the amount of data for each packet that is actually fetched. If snaplen is 0, fetch full packet without snapshot.
```
(2) server side.
 Packet 'binary' is cut by snaplen.
 Added new 'wirelen' field in RPC command response.
```
 'binary’  - binary bytes of the snapped packet
 ‘wirelen’ - the length of packet on the wire
```

**3. Backward compatibility**
It is fully backward compatible in new_client+old_server and old_client+new_server.

@hhaim, please review my change.