### PR TITLE
Fix gcc compilation failure: error: ‘dummy’ may be used uninitialized

### DIFF
--- a/src/common/gtest-all.cc
+++ b/src/common/gtest-all.cc
@@ -6953,12 +6953,12 @@ static int ExecDeathTestChildMain(void* child_arg) {
 // function, but we want to guard against the unlikely possibility of
 // a smart compiler optimizing the recursion away.
 bool StackLowerThanAddress(const void* ptr) {
-  int dummy;
+  int dummy = 0;
   return &dummy < ptr;
 }
 
 bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   return StackLowerThanAddress(&dummy);
 }
 


### PR DESCRIPTION
Fixes the below:
[118/346] Compiling ../src/tunnels/gtp_man.cpp
../../src/common/gtest-all.cc: In function ‘bool testing::internal::StackGrowsDown()’:
../../src/common/gtest-all.cc:6962:31: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
6962 | return StackLowerThanAddress(&dummy);
| ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
../../src/common/gtest-all.cc:6955:6: note: by argument 1 of type ‘const void*’ to ‘bool testing::internal::StackLowerThanAddress(const void*)’ declared here
6955 | bool StackLowerThanAddress(const void* ptr) {
| ^~~~~~~~~~~~~~~~~~~~~
../../src/common/gtest-all.cc:6961:7: note: ‘dummy’ declared here
6961 | int dummy;
| ^~~~~

Fixes: #792
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>