### PR TITLE
fix SLRO mbuf double free issue

### DIFF
--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -227,7 +227,7 @@ class CTcpRxOffloadBuf {
 
 public:
     void set(CTcpFlow*, struct rte_mbuf*, TCPHeader*, CFlowKeyFullTuple&);
-    void clear();
+    void clear_flow();
     void reset();
     bool is_active() const { return m_flow != nullptr; }
     CTcpFlow* get_flow() const { return m_flow; }

--- a/src/44bsd/netinet/tcp_input.c
+++ b/src/44bsd/netinet/tcp_input.c
@@ -908,7 +908,7 @@ tcp_do_segment(struct mbuf *m, struct tcphdr *th, struct socket *so,
             if (so->so_rcv.sb_state & SBS_CANTRCVMORE) {
                 m_freem(m);
             } else {
-                m_adj_fix(m, drop_hdrlen, tlen);	/* delayed header drop */
+                m = m_adj_fix(m, drop_hdrlen, tlen);	/* delayed header drop */
                 sbappendstream_locked(&so->so_rcv, m, 0, so);
             }
             tp->t_flags |= TF_WAKESOR;
@@ -1954,7 +1954,7 @@ step6:
         tcp_seq save_start = th->th_seq;
         tcp_seq save_rnxt  = tp->rcv_nxt;
         int     save_tlen  = tlen;
-        m_adj_fix(m, drop_hdrlen, tlen);	/* delayed header drop */
+        m = m_adj_fix(m, drop_hdrlen, tlen);	/* delayed header drop */
         /*
          * Insert segment which includes th into TCP reassembly queue
          * with control block tp.  Set thflags to whether reassembly now

--- a/src/44bsd/netinet/tcp_mbuf.h
+++ b/src/44bsd/netinet/tcp_mbuf.h
@@ -8,7 +8,7 @@ struct mbuf;
 extern "C" {
 #endif
 
-void m_adj_fix(struct mbuf *, int, int);
+struct mbuf* m_adj_fix(struct mbuf *, int, int);
 void m_trim(struct mbuf *, int);
 void m_freem(struct mbuf *);
 uint32_t m_pktlen(struct mbuf *);

--- a/src/44bsd/tcp_input.cpp
+++ b/src/44bsd/tcp_input.cpp
@@ -75,7 +75,7 @@ static inline void tcp_pktmbuf_trim(struct rte_mbuf *m, uint16_t len){
  * Drop TCP, IP headers and TCP options. go to L7 
    remove pad if exists
  */
-static inline void tcp_pktmbuf_fix_mbuf(struct rte_mbuf *m, 
+static inline void tcp_pktmbuf_fix_mbuf(struct rte_mbuf *& m,
                                         uint16_t adj_len,
                                         uint16_t l7_len){
 
@@ -104,10 +104,11 @@ static inline void tcp_pktmbuf_fix_mbuf(struct rte_mbuf *m,
 
 /* tcp_mbuf.h */
 
-void
+struct mbuf *
 m_adj_fix(struct mbuf *m, int req_len, int l7_len)
 {
-    tcp_pktmbuf_fix_mbuf((struct rte_mbuf *)m, req_len, l7_len);
+    tcp_pktmbuf_fix_mbuf((struct rte_mbuf *&)m, req_len, l7_len);
+    return m;
 }
 
 void


### PR DESCRIPTION
Hi, this PR is to fix mbuf double-free issue due to SLRO.

There were two reasons:
1. when flow is closed by the merged packets in flush_bufs(), mbuf would be freed twice due to the remaining m_lro_buf info.
2. when drop_hdrlen is greater than the first mbuf's data_len, the first mbuf is freed by m_adj_fix and freed again as a handled one.

My change will fix these issues.

@hhaim, please check my fix and give your feedback.