### PR TITLE
Solution for "portattr -a doesn't print all ports #807"

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -3582,7 +3582,7 @@ class TRexClient(object):
             return
 
         # for each port, fetch port status
-        port_status = [self.ports[port_id].get_port_status() for port_id in ports[:4]]
+        port_status = [self.ports[port_id].get_port_status() for port_id in ports]
 
         # merge
         table = TRexTextTable.merge(port_status)


### PR DESCRIPTION
Hi, Please review the code changes. I have tested it with trex server running in astf mode and trex-console.
Any feedback is welcomed.