### PR TITLE
Packet capture by endpoint

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -2056,6 +2056,7 @@ dpdk_includes_path =''' ../src/
                         ../src/dpdk/lib/librte_ring/
                         ../src/dpdk/lib/librte_timer/
                         ../src/dpdk/lib/librte_ip_frag/
+                        ../src/dpdk/lib/librte_pcapng/
                         ../src/dpdk/
                         
                         ../src/dpdk/lib/librte_security/

--- a/scripts/automation/trex_control_plane/interactive/trex/console/trex_capture.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/console/trex_capture.py
@@ -10,6 +10,9 @@ import os
 import sys
 import time
 
+import zmq
+import socket
+
 from scapy.layers.l2 import Ether
 
 from ..common.trex_types import *
@@ -106,6 +109,79 @@ class CaptureMonitorWriterStdout(CaptureMonitorWriter):
             self.logger.prompt_redraw()
 
     
+# a file monitor
+class CaptureMonitorWriterFile(CaptureMonitorWriter):
+    def __init__ (self, logger, filename):
+        self.logger      = logger
+
+        self.logger.pre_cmd("Starting file capture monitor - '{0}'".format(filename))
+        self.logger.post_cmd(RC_OK())
+
+        try:
+            host_ip = socket.gethostbyname(socket.gethostname())
+
+            self.context = zmq.Context()
+            self.socket = self.context.socket(zmq.PAIR)
+            self.socket.setsockopt(zmq.RCVTIMEO, 100)
+            zmq_port = self.socket.bind_to_random_port('tcp://*', min_port=5000)
+            self.endpoint = 'tcp://{0}:{1}'.format(host_ip, zmq_port)
+
+            self.fileout = open(filename, "wb")
+
+        except OSError as e:
+            self.deinit()
+            self.logger.post_cmd(RC_ERR(""))
+            raise TRexError("failed to init file monitor {0}\n{1}".format(filename, str(e)))
+
+        self.logger.info(format_text("\n*** use 'capture monitor stop' to abort capturing... ***\n", 'bold'))
+
+
+    def deinit (self):
+        try:
+            if self.fileout:
+                self.fileout.close()
+                self.fileout = None
+
+            if self.socket:
+                self.socket.close()
+                self.socket = None
+
+            if self.context:
+                self.context.destroy()
+                self.context = None
+
+        except OSError:
+            pass
+
+
+    def fetch_pkts (self, limit = 100):
+        pkts = []
+
+        try:
+            while len(pkts) < limit:
+                pkt = self.socket.recv(1) # non-block recv
+                pkts.append(pkt)
+
+        except zmq.ZMQError:
+            pass
+
+        return pkts
+
+
+    def handle_pkts (self, pkts):
+        byte_count = 0
+
+        try:
+            for pkt in pkts:
+                self.fileout.write(pkt)
+                byte_count += len(pkt)
+
+        except Exception as e:
+            raise TRexError('fail to write packets to file: {}'.format(str(e)))
+
+        return byte_count
+
+
 # a pipe based monitor
 class CaptureMonitorWriterPipe(CaptureMonitorWriter):
     def __init__ (self, logger, start_ts):
@@ -267,6 +343,7 @@ class CaptureMonitor(object):
         self.t           = None
         self.writer      = None
         self.capture_id  = None
+        self.endpoint    = None
         
         self.tx_port_list = tx_port_list
         self.rx_port_list = rx_port_list
@@ -283,13 +360,22 @@ class CaptureMonitor(object):
             
             
     def __start (self):
-        
+        # 'file:' type will use ZMQ endpoint
+        if self.mon_type.startswith('file:'):
+            output_filename = self.mon_type.split('file:')[1]
+            self.writer = CaptureMonitorWriterFile(self.logger, output_filename)
+
+            self.rate_pps = 0
+            self.endpoint = self.writer.endpoint
+            self.cmd_lock = None
+
         # create a capture on the server
         with self.logger.supress():
             data = self.client.start_capture(self.tx_port_list,
                                              self.rx_port_list,
                                              limit = self.rate_pps,
                                              mode = 'cyclic',
+                                             endpoint = self.endpoint,
                                              bpf_filter = self.bpf_filter)
 
         self.capture_id = data['id']
@@ -297,12 +383,15 @@ class CaptureMonitor(object):
         
 
         # create a writer
-        if self.mon_type == 'compact':
+        if self.writer:
+            pass
+        elif self.mon_type == 'compact':
             self.writer = CaptureMonitorWriterStdout(self.logger, True, start_ts)
         elif self.mon_type == 'verbose':
             self.writer = CaptureMonitorWriterStdout(self.logger, False, start_ts)
         elif self.mon_type == 'pipe':
             self.writer = CaptureMonitorWriterPipe(self.logger, start_ts)
+            self.cmd_lock = None
         else:
             raise TRexError('Internal error: unknown writer type')
 
@@ -373,6 +462,9 @@ class CaptureMonitor(object):
         return True
             
     def __lock (self):
+        if not self.cmd_lock:
+            return self.active
+
         while True:
             rc = self.cmd_lock.acquire(False)
             if rc:
@@ -383,6 +475,9 @@ class CaptureMonitor(object):
             time.sleep(0.1)
         
     def __unlock (self):
+        if not self.cmd_lock:
+            return
+
         self.cmd_lock.release()
         
     
@@ -420,7 +515,7 @@ class CaptureMonitor(object):
         while self.active:
             
             # sleep - if interrupt by graceful shutdown - go out
-            if not self.__sleep():
+            if not self.endpoint and not self.__sleep():
                 return
             
             # check that the writer is ok
@@ -434,16 +529,22 @@ class CaptureMonitor(object):
                 if not self.client.is_connected():
                     raise TRexError('client has been disconnected')
                     
-                rc = self.client._transmit("capture", params = {'command': 'fetch', 'capture_id': self.capture_id, 'pkt_limit': 10})
-                if not rc:
-                    raise TRexError(rc)
-                    
+                if not self.endpoint:
+                    rc = self.client._transmit("capture", params = {'command': 'fetch', 'capture_id': self.capture_id, 'pkt_limit': 10})
+                    if not rc:
+                        raise TRexError(rc)
+
+                    pkts = rc.data()['pkts']
+                else:
+                    pkts = self.writer.fetch_pkts()
+                    if not pkts:
+                        time.sleep(0.1)
+
             finally:
                 self.__unlock()
                 
 
             # no packets - skip
-            pkts = rc.data()['pkts']
             if not pkts:
                 continue
             
@@ -451,6 +552,7 @@ class CaptureMonitor(object):
             
             self.pkt_count  += len(pkts)
             self.byte_count += byte_count
+
 
 
 
@@ -492,7 +594,9 @@ class CaptureManager(object):
         self.record_start_parser.add_arg_list(parsing_opts.TX_PORT_LIST,
                                               parsing_opts.RX_PORT_LIST,
                                               parsing_opts.LIMIT,
-                                              parsing_opts.BPF_FILTER)
+                                              parsing_opts.BPF_FILTER,
+                                              parsing_opts.SNAPLEN,
+                                              parsing_opts.ENDPOINT)
 
         # stop
         self.record_stop_parser.add_arg_list(parsing_opts.CAPTURE_ID,
@@ -510,7 +614,9 @@ class CaptureManager(object):
         self.monitor_start_parser.add_arg_list(parsing_opts.TX_PORT_LIST,
                                                parsing_opts.RX_PORT_LIST,
                                                parsing_opts.MONITOR_TYPE,
-                                               parsing_opts.BPF_FILTER)
+                                               parsing_opts.BPF_FILTER,
+                                               parsing_opts.SNAPLEN,
+                                               parsing_opts.OUTPUT_FILENAME)
 
         
         
@@ -561,7 +667,7 @@ class CaptureManager(object):
             self.record_start_parser.formatted_error('please provide either --tx or --rx')
             return
 
-        rc = self.c.start_capture(opts.tx_port_list, opts.rx_port_list, opts.limit, mode = 'fixed', bpf_filter = opts.filter)
+        rc = self.c.start_capture(opts.tx_port_list, opts.rx_port_list, opts.limit, mode = 'fixed', bpf_filter = opts.filter, endpoint = opts.endpoint, snaplen = opts.snaplen)
         
         self.logger.info(format_text("*** Capturing ID is set to '{0}' ***".format(rc['id']), 'bold'))
         self.logger.info(format_text("*** Please call 'capture record stop --id {0} -o <out.pcap>' when done ***\n".format(rc['id']), 'bold'))
@@ -598,6 +704,8 @@ class CaptureManager(object):
             mon_type = 'verbose'
         elif opts.pipe:
             mon_type = 'pipe'
+        elif opts.output_filename:
+            mon_type = 'file' + ':' + opts.output_filename
             
         if not opts.tx_port_list and not opts.rx_port_list:
             self.monitor_start_parser.formatted_error('please provide either --tx or --rx')

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -644,6 +644,20 @@ class OPTIONS_DB_ARGS:
          'default':  1000,
          'type': int})
 
+    ENDPOINT = ArgumentPack(
+        ['-e', '--endpoint'],
+        {'help': 'Specify endpoint to write the packets',
+         'dest': 'endpoint',
+         'default': '',
+         'type': str})
+
+    SNAPLEN = ArgumentPack(
+        ['-s', '--snaplen'],
+        {'help': 'Limit the packet size to be written to the endpoint',
+         'dest': 'snaplen',
+         'default': 0,
+         'type': int})
+
     SUPPORTED = ArgumentPack(
         ['--supp'],
         {'help': 'Show which attributes are supported by current NICs',

--- a/src/dpdk/lib/librte_pcapng/meson.build
+++ b/src/dpdk/lib/librte_pcapng/meson.build
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2019 Microsoft Corporation
+
+if is_windows
+    build = false
+    reason = 'not supported on Windows'
+    subdir_done()
+endif
+
+sources = files('rte_pcapng.c')
+headers = files('rte_pcapng.h')
+
+deps += ['ethdev']

--- a/src/dpdk/lib/librte_pcapng/pcapng_proto.h
+++ b/src/dpdk/lib/librte_pcapng/pcapng_proto.h
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2019-2020 Microsoft Corporation
+ *
+ * PCAP Next Generation Capture File writer
+ *
+ * See: https://github.com/pcapng/pcapng/ for the file format.
+ */
+
+enum pcapng_block_types {
+	PCAPNG_INTERFACE_BLOCK		= 1,
+	PCAPNG_PACKET_BLOCK,		/* Obsolete */
+	PCAPNG_SIMPLE_PACKET_BLOCK,
+	PCAPNG_NAME_RESOLUTION_BLOCK,
+	PCAPNG_INTERFACE_STATS_BLOCK,
+	PCAPNG_ENHANCED_PACKET_BLOCK,
+
+	PCAPNG_SECTION_BLOCK		= 0x0A0D0D0A,
+};
+
+struct pcapng_option {
+	uint16_t code;
+	uint16_t length;
+	uint8_t data[];
+};
+
+#define PCAPNG_BYTE_ORDER_MAGIC 0x1A2B3C4D
+#define PCAPNG_MAJOR_VERS 1
+#define PCAPNG_MINOR_VERS 0
+
+enum pcapng_opt {
+	PCAPNG_OPT_END	= 0,
+	PCAPNG_OPT_COMMENT = 1,
+};
+
+struct pcapng_section_header {
+	uint32_t block_type;
+	uint32_t block_length;
+	uint32_t byte_order_magic;
+	uint16_t major_version;
+	uint16_t minor_version;
+	uint64_t section_length;
+};
+
+enum pcapng_section_opt {
+	PCAPNG_SHB_HARDWARE = 2,
+	PCAPNG_SHB_OS	    = 3,
+	PCAPNG_SHB_USERAPPL = 4,
+};
+
+struct pcapng_interface_block {
+	uint32_t block_type;	/* 1 */
+	uint32_t block_length;
+	uint16_t link_type;
+	uint16_t reserved;
+	uint32_t snap_len;
+};
+
+enum pcapng_interface_options {
+	PCAPNG_IFB_NAME	 = 2,
+	PCAPNG_IFB_DESCRIPTION,
+	PCAPNG_IFB_IPV4ADDR,
+	PCAPNG_IFB_IPV6ADDR,
+	PCAPNG_IFB_MACADDR,
+	PCAPNG_IFB_EUIADDR,
+	PCAPNG_IFB_SPEED,
+	PCAPNG_IFB_TSRESOL,
+	PCAPNG_IFB_TZONE,
+	PCAPNG_IFB_FILTER,
+	PCAPNG_IFB_OS,
+	PCAPNG_IFB_FCSLEN,
+	PCAPNG_IFB_TSOFFSET,
+	PCAPNG_IFB_HARDWARE,
+};
+
+struct pcapng_enhance_packet_block {
+	uint32_t block_type;	/* 6 */
+	uint32_t block_length;
+	uint32_t interface_id;
+	uint32_t timestamp_hi;
+	uint32_t timestamp_lo;
+	uint32_t capture_length;
+	uint32_t original_length;
+};
+
+/* Flags values */
+#define PCAPNG_IFB_INBOUND   0b01
+#define PCAPNG_IFB_OUTBOUND  0b10
+
+enum pcapng_epb_options {
+	PCAPNG_EPB_FLAGS = 2,
+	PCAPNG_EPB_HASH,
+	PCAPNG_EPB_DROPCOUNT,
+	PCAPNG_EPB_PACKETID,
+	PCAPNG_EPB_QUEUE,
+	PCAPNG_EPB_VERDICT,
+};
+
+enum pcapng_epb_hash {
+	PCAPNG_HASH_2COMP = 0,
+	PCAPNG_HASH_XOR,
+	PCAPNG_HASH_CRC32,
+	PCAPNG_HASH_MD5,
+	PCAPNG_HASH_SHA1,
+	PCAPNG_HASH_TOEPLITZ,
+};
+
+struct pcapng_simple_packet {
+	uint32_t block_type;	/* 3 */
+	uint32_t block_length;
+	uint32_t packet_length;
+};
+
+struct pcapng_statistics {
+	uint32_t block_type;	/* 5 */
+	uint32_t block_length;
+	uint32_t interface_id;
+	uint32_t timestamp_hi;
+	uint32_t timestamp_lo;
+};
+
+enum pcapng_isb_options {
+	PCAPNG_ISB_STARTTIME = 2,
+	PCAPNG_ISB_ENDTIME,
+	PCAPNG_ISB_IFRECV,
+	PCAPNG_ISB_IFDROP,
+	PCAPNG_ISB_FILTERACCEPT,
+	PCAPNG_ISB_OSDROP,
+	PCAPNG_ISB_USRDELIV,
+};

--- a/src/dpdk/lib/librte_pcapng/rte_pcapng.c
+++ b/src/dpdk/lib/librte_pcapng/rte_pcapng.c
@@ -1,0 +1,606 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2019 Microsoft Corporation
+ */
+
+#include <errno.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/uio.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <rte_common.h>
+#include <rte_cycles.h>
+#include <rte_dev.h>
+#include <rte_errno.h>
+#include <rte_ethdev.h>
+#include <rte_ether.h>
+#include <rte_mbuf.h>
+#include <rte_pcapng.h>
+#include <rte_time.h>
+
+#include "pcapng_proto.h"
+
+/* conversion from DPDK speed to PCAPNG */
+#define PCAPNG_MBPS_SPEED 1000000ull
+
+/* Format of the capture file handle */
+struct rte_pcapng {
+	int  outfd;		/* output file */
+	/* DPDK port id to interface index in file */
+	uint32_t port_index[RTE_MAX_ETHPORTS];
+};
+
+/* For converting TSC cycles to PCAPNG ns format */
+struct pcapng_time {
+	uint64_t ns;
+	uint64_t cycles;
+} pcapng_time;
+
+RTE_INIT(pcapng_init)
+{
+	struct timespec ts;
+
+	pcapng_time.cycles = rte_get_tsc_cycles();
+	clock_gettime(CLOCK_REALTIME, &ts);
+	pcapng_time.ns = rte_timespec_to_ns(&ts);
+}
+
+/* PCAPNG timestamps are in nanoseconds */
+static uint64_t pcapng_tsc_to_ns(uint64_t cycles)
+{
+	uint64_t delta;
+
+	delta = cycles - pcapng_time.cycles;
+	return pcapng_time.ns + (delta * NSEC_PER_SEC) / rte_get_tsc_hz();
+}
+
+/* length of option including padding */
+static uint16_t pcapng_optlen(uint16_t len)
+{
+	return RTE_ALIGN(sizeof(struct pcapng_option) + len,
+			 sizeof(uint32_t));
+}
+
+/* build TLV option and return location of next */
+static struct pcapng_option *
+pcapng_add_option(struct pcapng_option *popt, uint16_t code,
+		  const void *data, uint16_t len)
+{
+	popt->code = code;
+	popt->length = len;
+	memcpy(popt->data, data, len);
+
+	return (struct pcapng_option *)((uint8_t *)popt + pcapng_optlen(len));
+}
+
+/*
+ * Write required initial section header describing the capture
+ */
+static int
+pcapng_section_block(rte_pcapng_t *self,
+		    const char *os, const char *hw,
+		    const char *app, const char *comment)
+{
+	struct pcapng_section_header *hdr;
+	struct pcapng_option *opt;
+	void *buf;
+	uint32_t len;
+	ssize_t cc;
+
+	len = sizeof(*hdr);
+	if (hw)
+		len += pcapng_optlen(strlen(hw));
+	if (os)
+		len += pcapng_optlen(strlen(os));
+	if (app)
+		len += pcapng_optlen(strlen(app));
+	if (comment)
+		len += pcapng_optlen(strlen(comment));
+
+	/* reserve space for OPT_END */
+	len += pcapng_optlen(0);
+	len += sizeof(uint32_t);
+
+	buf = calloc(1, len);
+	if (!buf)
+		return -1;
+
+	hdr = (struct pcapng_section_header *)buf;
+	*hdr = (struct pcapng_section_header) {
+		.block_type = PCAPNG_SECTION_BLOCK,
+		.block_length = len,
+		.byte_order_magic = PCAPNG_BYTE_ORDER_MAGIC,
+		.major_version = PCAPNG_MAJOR_VERS,
+		.minor_version = PCAPNG_MINOR_VERS,
+		.section_length = UINT64_MAX,
+	};
+
+	/* After the section header insert variable length options. */
+	opt = (struct pcapng_option *)(hdr + 1);
+	if (comment)
+		opt = pcapng_add_option(opt, PCAPNG_OPT_COMMENT,
+					comment, strlen(comment));
+	if (hw)
+		opt = pcapng_add_option(opt, PCAPNG_SHB_HARDWARE,
+					hw, strlen(hw));
+	if (os)
+		opt = pcapng_add_option(opt, PCAPNG_SHB_OS,
+					os, strlen(os));
+	if (app)
+		opt = pcapng_add_option(opt, PCAPNG_SHB_USERAPPL,
+					app, strlen(app));
+
+	/* The standard requires last option to be OPT_END */
+	opt = pcapng_add_option(opt, PCAPNG_OPT_END, NULL, 0);
+
+	/* clone block_length after option */
+	memcpy(opt, &hdr->block_length, sizeof(uint32_t));
+
+	cc = write(self->outfd, buf, len);
+	free(buf);
+
+	return cc;
+}
+
+/* Write an interface block for a DPDK port */
+static int
+pcapng_add_interface(rte_pcapng_t *self, uint16_t port)
+{
+	struct pcapng_interface_block *hdr;
+	struct rte_eth_dev_info dev_info;
+	struct rte_ether_addr *ea, macaddr;
+	const struct rte_device *dev;
+	struct rte_eth_link link;
+	struct pcapng_option *opt;
+	const uint8_t tsresol = 9;	/* nanosecond resolution */
+	uint32_t len;
+	void *buf;
+	char ifname[IF_NAMESIZE];
+	char ifhw[256];
+	uint64_t speed = 0;
+
+	if (rte_eth_dev_info_get(port, &dev_info) < 0)
+		return -1;
+
+	/* make something like an interface name */
+	if (if_indextoname(dev_info.if_index, ifname) == NULL)
+		snprintf(ifname, IF_NAMESIZE, "dpdk:%u", port);
+
+	/* make a useful device hardware string */
+	dev = dev_info.device;
+	if (dev)
+		snprintf(ifhw, sizeof(ifhw),
+			 "%s-%s", dev->bus->name, dev->name);
+
+	/* DPDK reports in units of Mbps */
+	if (rte_eth_link_get(port, &link) == 0 &&
+	    link.link_status == RTE_ETH_LINK_UP)
+		speed = link.link_speed * PCAPNG_MBPS_SPEED;
+
+	if (rte_eth_macaddr_get(port, &macaddr) < 0)
+		ea = NULL;
+	else
+		ea = &macaddr;
+
+	/* Compute length of interface block options */
+	len = sizeof(*hdr);
+
+	len += pcapng_optlen(sizeof(tsresol));	/* timestamp */
+	len += pcapng_optlen(strlen(ifname));	/* ifname */
+
+	if (ea)
+		len += pcapng_optlen(RTE_ETHER_ADDR_LEN); /* macaddr */
+	if (speed != 0)
+		len += pcapng_optlen(sizeof(uint64_t));
+	if (dev)
+		len += pcapng_optlen(strlen(ifhw));
+
+	len += pcapng_optlen(0);
+	len += sizeof(uint32_t);
+
+	buf = alloca(len);
+	if (!buf)
+		return -1;
+
+	hdr = (struct pcapng_interface_block *)buf;
+	*hdr = (struct pcapng_interface_block) {
+		.block_type = PCAPNG_INTERFACE_BLOCK,
+		.link_type = 1,		/* DLT_EN10MB - Ethernet */
+		.block_length = len,
+	};
+
+	opt = (struct pcapng_option *)(hdr + 1);
+	opt = pcapng_add_option(opt, PCAPNG_IFB_TSRESOL,
+				&tsresol, sizeof(tsresol));
+	opt = pcapng_add_option(opt, PCAPNG_IFB_NAME,
+				ifname, strlen(ifname));
+	if (ea)
+		opt = pcapng_add_option(opt, PCAPNG_IFB_MACADDR,
+					ea, RTE_ETHER_ADDR_LEN);
+	if (speed != 0)
+		opt = pcapng_add_option(opt, PCAPNG_IFB_SPEED,
+					 &speed, sizeof(uint64_t));
+	if (dev)
+		opt = pcapng_add_option(opt, PCAPNG_IFB_HARDWARE,
+					 ifhw, strlen(ifhw));
+	opt = pcapng_add_option(opt, PCAPNG_OPT_END, NULL, 0);
+
+	/* clone block_length after optionsa */
+	memcpy(opt, &hdr->block_length, sizeof(uint32_t));
+
+	return write(self->outfd, buf, len);
+}
+
+/*
+ * Write the list of possible interfaces at the start
+ * of the file.
+ */
+static int
+pcapng_interfaces(rte_pcapng_t *self)
+{
+	uint16_t port_id;
+	uint16_t index = 0;
+
+	RTE_ETH_FOREACH_DEV(port_id) {
+		/* The list if ports in pcapng needs to be contiguous */
+		self->port_index[port_id] = index++;
+		if (pcapng_add_interface(self, port_id) < 0)
+			return -1;
+	}
+	return 0;
+}
+
+/*
+ * Write an Interface statistics block at the end of capture.
+ */
+ssize_t
+rte_pcapng_write_stats(rte_pcapng_t *self, uint16_t port_id,
+		       const char *comment,
+		       uint64_t start_time, uint64_t end_time,
+		       uint64_t ifrecv, uint64_t ifdrop)
+{
+	struct pcapng_statistics *hdr;
+	struct pcapng_option *opt;
+	uint32_t optlen, len;
+	uint8_t *buf;
+	uint64_t ns;
+
+	RTE_ETH_VALID_PORTID_OR_ERR_RET(port_id, -EINVAL);
+
+	optlen = 0;
+
+	if (ifrecv != UINT64_MAX)
+		optlen += pcapng_optlen(sizeof(ifrecv));
+	if (ifdrop != UINT64_MAX)
+		optlen += pcapng_optlen(sizeof(ifdrop));
+	if (start_time != 0)
+		optlen += pcapng_optlen(sizeof(start_time));
+	if (end_time != 0)
+		optlen += pcapng_optlen(sizeof(end_time));
+	if (comment)
+		optlen += pcapng_optlen(strlen(comment));
+	if (optlen != 0)
+		optlen += pcapng_optlen(0);
+
+	len = sizeof(*hdr) + optlen + sizeof(uint32_t);
+	buf = alloca(len);
+	if (buf == NULL)
+		return -1;
+
+	hdr = (struct pcapng_statistics *)buf;
+	opt = (struct pcapng_option *)(hdr + 1);
+
+	if (comment)
+		opt = pcapng_add_option(opt, PCAPNG_OPT_COMMENT,
+					comment, strlen(comment));
+	if (start_time != 0)
+		opt = pcapng_add_option(opt, PCAPNG_ISB_STARTTIME,
+					 &start_time, sizeof(start_time));
+	if (end_time != 0)
+		opt = pcapng_add_option(opt, PCAPNG_ISB_ENDTIME,
+					 &end_time, sizeof(end_time));
+	if (ifrecv != UINT64_MAX)
+		opt = pcapng_add_option(opt, PCAPNG_ISB_IFRECV,
+				&ifrecv, sizeof(ifrecv));
+	if (ifdrop != UINT64_MAX)
+		opt = pcapng_add_option(opt, PCAPNG_ISB_IFDROP,
+				&ifdrop, sizeof(ifdrop));
+	if (optlen != 0)
+		opt = pcapng_add_option(opt, PCAPNG_OPT_END, NULL, 0);
+
+	hdr->block_type = PCAPNG_INTERFACE_STATS_BLOCK;
+	hdr->block_length = len;
+	hdr->interface_id = self->port_index[port_id];
+
+	ns = pcapng_tsc_to_ns(rte_get_tsc_cycles());
+	hdr->timestamp_hi = ns >> 32;
+	hdr->timestamp_lo = (uint32_t)ns;
+
+	/* clone block_length after option */
+	memcpy(opt, &len, sizeof(uint32_t));
+
+	return write(self->outfd, buf, len);
+}
+
+uint32_t
+rte_pcapng_mbuf_size(uint32_t length)
+{
+	/* The VLAN and EPB header must fit in the mbuf headroom. */
+	RTE_ASSERT(sizeof(struct pcapng_enhance_packet_block) +
+		   sizeof(struct rte_vlan_hdr) <= RTE_PKTMBUF_HEADROOM);
+
+	/* The flags and queue information are added at the end. */
+	return sizeof(struct rte_mbuf)
+		+ RTE_ALIGN(length, sizeof(uint32_t))
+		+ pcapng_optlen(sizeof(uint32_t)) /* flag option */
+		+ pcapng_optlen(sizeof(uint32_t)) /* queue option */
+		+ sizeof(uint32_t);		  /*  length */
+}
+
+/* More generalized version rte_vlan_insert() */
+static int
+pcapng_vlan_insert(struct rte_mbuf *m, uint16_t ether_type, uint16_t tci)
+{
+	struct rte_ether_hdr *nh, *oh;
+	struct rte_vlan_hdr *vh;
+
+	if (!RTE_MBUF_DIRECT(m) || rte_mbuf_refcnt_read(m) > 1)
+		return -EINVAL;
+
+	if (rte_pktmbuf_data_len(m) < sizeof(*oh))
+		return -EINVAL;
+
+	oh = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
+	nh = (struct rte_ether_hdr *)
+		rte_pktmbuf_prepend(m, sizeof(struct rte_vlan_hdr));
+	if (nh == NULL)
+		return -ENOSPC;
+
+	memmove(nh, oh, 2 * RTE_ETHER_ADDR_LEN);
+	nh->ether_type = rte_cpu_to_be_16(ether_type);
+
+	vh = (struct rte_vlan_hdr *) (nh + 1);
+	vh->vlan_tci = rte_cpu_to_be_16(tci);
+
+	return 0;
+}
+
+/*
+ *   The mbufs created use the Pcapng standard enhanced packet  block.
+ *
+ *                         1                   2                   3
+ *     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  0 |                    Block Type = 0x00000006                    |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  4 |                      Block Total Length                       |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  8 |                         Interface ID                          |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * 12 |                        Timestamp (High)                       |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * 16 |                        Timestamp (Low)                        |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * 20 |                    Captured Packet Length                     |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * 24 |                    Original Packet Length                     |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * 28 /                                                               /
+ *    /                          Packet Data                          /
+ *    /              variable length, padded to 32 bits               /
+ *    /                                                               /
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |      Option Code = 0x0002     |     Option Length = 0x004     |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |              Flags (direction)                                |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |      Option Code = 0x0006     |     Option Length = 0x002     |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |              Queue id                                         |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                      Block Total Length                       |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+
+/* Make a copy of original mbuf with pcapng header and options */
+struct rte_mbuf *
+rte_pcapng_copy(uint16_t port_id, uint32_t queue,
+		const struct rte_mbuf *md,
+		struct rte_mempool *mp,
+		uint32_t length, uint64_t cycles,
+		enum rte_pcapng_direction direction)
+{
+	struct pcapng_enhance_packet_block *epb;
+	uint32_t orig_len, data_len, padding, flags;
+	struct pcapng_option *opt;
+	const uint16_t optlen = pcapng_optlen(sizeof(flags)) + pcapng_optlen(sizeof(queue));
+	struct rte_mbuf *mc;
+	uint64_t ns;
+
+#ifdef RTE_LIBRTE_ETHDEV_DEBUG
+	RTE_ETH_VALID_PORTID_OR_ERR_RET(port_id, NULL);
+#endif
+	ns = pcapng_tsc_to_ns(cycles);
+
+	orig_len = rte_pktmbuf_pkt_len(md);
+
+	/* Take snapshot of the data */
+	mc = rte_pktmbuf_copy(md, mp, 0, length);
+	if (unlikely(mc == NULL))
+		return NULL;
+
+	/* Expand any offloaded VLAN information */
+	if ((direction == RTE_PCAPNG_DIRECTION_IN &&
+	     (md->ol_flags & RTE_MBUF_F_RX_VLAN_STRIPPED)) ||
+	    (direction == RTE_PCAPNG_DIRECTION_OUT &&
+	     (md->ol_flags & RTE_MBUF_F_TX_VLAN))) {
+		if (pcapng_vlan_insert(mc, RTE_ETHER_TYPE_VLAN,
+				       md->vlan_tci) != 0)
+			goto fail;
+	}
+
+	if ((direction == RTE_PCAPNG_DIRECTION_IN &&
+	     (md->ol_flags & RTE_MBUF_F_RX_QINQ_STRIPPED)) ||
+	    (direction == RTE_PCAPNG_DIRECTION_OUT &&
+	     (md->ol_flags & RTE_MBUF_F_TX_QINQ))) {
+		if (pcapng_vlan_insert(mc, RTE_ETHER_TYPE_QINQ,
+				       md->vlan_tci_outer) != 0)
+			goto fail;
+	}
+
+	/* pad the packet to 32 bit boundary */
+	data_len = rte_pktmbuf_data_len(mc);
+	padding = RTE_ALIGN(data_len, sizeof(uint32_t)) - data_len;
+	if (padding > 0) {
+		void *tail = rte_pktmbuf_append(mc, padding);
+
+		if (tail == NULL)
+			goto fail;
+		memset(tail, 0, padding);
+	}
+
+	/* reserve trailing options and block length */
+	opt = (struct pcapng_option *)
+		rte_pktmbuf_append(mc, optlen + sizeof(uint32_t));
+	if (unlikely(opt == NULL))
+		goto fail;
+
+	switch (direction) {
+	case RTE_PCAPNG_DIRECTION_IN:
+		flags = PCAPNG_IFB_INBOUND;
+		break;
+	case RTE_PCAPNG_DIRECTION_OUT:
+		flags = PCAPNG_IFB_OUTBOUND;
+		break;
+	default:
+		flags = 0;
+	}
+
+	opt = pcapng_add_option(opt, PCAPNG_EPB_FLAGS,
+				&flags, sizeof(flags));
+
+	opt = pcapng_add_option(opt, PCAPNG_EPB_QUEUE,
+				&queue, sizeof(queue));
+
+	/* Note: END_OPT necessary here. Wireshark doesn't do it. */
+
+	/* Add PCAPNG packet header */
+	epb = (struct pcapng_enhance_packet_block *)
+		rte_pktmbuf_prepend(mc, sizeof(*epb));
+	if (unlikely(epb == NULL))
+		goto fail;
+
+	epb->block_type = PCAPNG_ENHANCED_PACKET_BLOCK;
+	epb->block_length = rte_pktmbuf_data_len(mc);
+
+	/* Interface index is filled in later during write */
+	mc->port = port_id;
+
+	epb->timestamp_hi = ns >> 32;
+	epb->timestamp_lo = (uint32_t)ns;
+	epb->capture_length = data_len;
+	epb->original_length = orig_len;
+
+	/* set trailer of block length */
+	*(uint32_t *)opt = epb->block_length;
+
+	return mc;
+
+fail:
+	rte_pktmbuf_free(mc);
+	return NULL;
+}
+
+/* Count how many segments are in this array of mbufs */
+static unsigned int
+mbuf_burst_segs(struct rte_mbuf *pkts[], unsigned int n)
+{
+	unsigned int i, iovcnt;
+
+	for (iovcnt = 0, i = 0; i < n; i++) {
+		const struct rte_mbuf *m = pkts[i];
+
+		__rte_mbuf_sanity_check(m, 1);
+
+		iovcnt += m->nb_segs;
+	}
+	return iovcnt;
+}
+
+/* Write pre-formatted packets to file. */
+ssize_t
+rte_pcapng_write_packets(rte_pcapng_t *self,
+			 struct rte_mbuf *pkts[], uint16_t nb_pkts)
+{
+	int iovcnt = mbuf_burst_segs(pkts, nb_pkts);
+	struct iovec iov[iovcnt];
+	unsigned int i, cnt;
+	ssize_t ret;
+
+	for (i = cnt = 0; i < nb_pkts; i++) {
+		struct rte_mbuf *m = pkts[i];
+		struct pcapng_enhance_packet_block *epb;
+
+		/* sanity check that is really a pcapng mbuf */
+		epb = rte_pktmbuf_mtod(m, struct pcapng_enhance_packet_block *);
+		if (unlikely(epb->block_type != PCAPNG_ENHANCED_PACKET_BLOCK ||
+			     epb->block_length != rte_pktmbuf_data_len(m))) {
+			rte_errno = EINVAL;
+			return -1;
+		}
+
+		/*
+		 * The DPDK port is recorded during pcapng_copy.
+		 * Map that to PCAPNG interface in file.
+		 */
+		epb->interface_id = self->port_index[m->port];
+		do {
+			iov[cnt].iov_base = rte_pktmbuf_mtod(m, void *);
+			iov[cnt].iov_len = rte_pktmbuf_data_len(m);
+			++cnt;
+		} while ((m = m->next));
+	}
+
+	ret = writev(self->outfd, iov, iovcnt);
+	if (unlikely(ret < 0))
+		rte_errno = errno;
+	return ret;
+}
+
+/* Create new pcapng writer handle */
+rte_pcapng_t *
+rte_pcapng_fdopen(int fd,
+		  const char *osname, const char *hardware,
+		  const char *appname, const char *comment)
+{
+	rte_pcapng_t *self;
+
+	self = malloc(sizeof(*self));
+	if (!self) {
+		rte_errno = ENOMEM;
+		return NULL;
+	}
+
+	self->outfd = fd;
+
+	if (pcapng_section_block(self, osname, hardware, appname, comment) < 0)
+		goto fail;
+
+	if (pcapng_interfaces(self) < 0)
+		goto fail;
+
+	return self;
+fail:
+	free(self);
+	return NULL;
+}
+
+void
+rte_pcapng_close(rte_pcapng_t *self)
+{
+	close(self->outfd);
+	free(self);
+}

--- a/src/dpdk/lib/librte_pcapng/rte_pcapng.h
+++ b/src/dpdk/lib/librte_pcapng/rte_pcapng.h
@@ -1,0 +1,193 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2019 Microsoft Corporation
+ */
+
+/**
+ * @file
+ * RTE pcapng
+ *
+ * @warning
+ * @b EXPERIMENTAL:
+ * All functions in this file may be changed or removed without prior notice.
+ *
+ * Pcapng is an evolution from the pcap format, created to address some of
+ * its deficiencies. Namely, the lack of extensibility and inability to store
+ * additional information.
+ *
+ * For details about the file format see RFC:
+ *   https://www.ietf.org/id/draft-tuexen-opsawg-pcapng-03.html
+ *  and
+ *    https://github.com/pcapng/pcapng/
+ */
+
+#ifndef _RTE_PCAPNG_H_
+#define _RTE_PCAPNG_H_
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <rte_compat.h>
+#include <rte_mempool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle used for functions in this library. */
+typedef struct rte_pcapng rte_pcapng_t;
+
+/**
+ * Write data to existing open file
+ *
+ * @param fd
+ *   file descriptor
+ * @param osname
+ *   Optional description of the operating system.
+ *   Examples: "Debian 11", "Windows Server 22"
+ * @param hardware
+ *   Optional description of the hardware used to create this file.
+ *   Examples: "x86 Virtual Machine"
+ * @param appname
+ *   Optional: application name recorded in the pcapng file.
+ *   Example: "dpdk-dumpcap 1.0 (DPDK 20.11)"
+ * @param comment
+ *   Optional comment to add to file header.
+ * @return
+ *   handle to library, or NULL in case of error (and rte_errno is set).
+ */
+__rte_experimental
+rte_pcapng_t *
+rte_pcapng_fdopen(int fd,
+		  const char *osname, const char *hardware,
+		  const char *appname, const char *comment);
+
+/**
+ * Close capture file
+ *
+ * @param self
+ *  handle to library
+ */
+__rte_experimental
+void
+rte_pcapng_close(rte_pcapng_t *self);
+
+/**
+ * Direction flag
+ * These should match Enhanced Packet Block flag bits
+ */
+enum rte_pcapng_direction {
+	RTE_PCAPNG_DIRECTION_UNKNOWN = 0,
+	RTE_PCAPNG_DIRECTION_IN  = 1,
+	RTE_PCAPNG_DIRECTION_OUT = 2,
+};
+
+/**
+ * Format an mbuf for writing to file.
+ *
+ * @param port_id
+ *   The Ethernet port on which packet was received
+ *   or is going to be transmitted.
+ * @param queue
+ *   The queue on the Ethernet port where packet was received
+ *   or is going to be transmitted.
+ * @param mp
+ *   The mempool from which the "clone" mbufs are allocated.
+ * @param m
+ *   The mbuf to copy
+ * @param length
+ *   The upper limit on bytes to copy.  Passing UINT32_MAX
+ *   means all data (after offset).
+ * @param timestamp
+ *   The timestamp in TSC cycles.
+ * @param direction
+ *   The direction of the packer: receive, transmit or unknown.
+ *
+ * @return
+ *   - The pointer to the new mbuf formatted for pcapng_write
+ *   - NULL if allocation fails.
+ *
+ */
+__rte_experimental
+struct rte_mbuf *
+rte_pcapng_copy(uint16_t port_id, uint32_t queue,
+		const struct rte_mbuf *m, struct rte_mempool *mp,
+		uint32_t length, uint64_t timestamp,
+		enum rte_pcapng_direction direction);
+
+
+/**
+ * Determine optimum mbuf data size.
+ *
+ * @param length
+ *   The largest packet that will be copied.
+ * @return
+ *   The minimum size of mbuf data to handle packet with length bytes.
+ *   Accounting for required header and trailer fields
+ */
+__rte_experimental
+uint32_t
+rte_pcapng_mbuf_size(uint32_t length);
+
+/**
+ * Write packets to the capture file.
+ *
+ * Packets to be captured are copied by rte_pcapng_copy()
+ * and then this function is called to write them to the file.
+ *
+ * @warning
+ * Do not pass original mbufs from transmit or receive
+ * or file will be invalid pcapng format.
+ *
+ * @param self
+ *  The handle to the packet capture file
+ * @param pkts
+ *  The address of an array of *nb_pkts* pointers to *rte_mbuf* structures
+ *  which contain the output packets
+ * @param nb_pkts
+ *  The number of packets to write to the file.
+ * @return
+ *  The number of bytes written to file, -1 on failure to write file.
+ *  The mbuf's in *pkts* are always freed.
+ */
+__rte_experimental
+ssize_t
+rte_pcapng_write_packets(rte_pcapng_t *self,
+			 struct rte_mbuf *pkts[], uint16_t nb_pkts);
+
+/**
+ * Write an Interface statistics block.
+ * For statistics, use 0 if don't know or care to report it.
+ * Should be called before closing capture to report results.
+ *
+ * @param self
+ *  The handle to the packet capture file
+ * @param port
+ *  The Ethernet port to report stats on.
+ * @param comment
+ *   Optional comment to add to statistics.
+ * @param start_time
+ *  The time when packet capture was started in nanoseconds.
+ *  Optional: can be zero if not known.
+ * @param end_time
+ *  The time when packet capture was stopped in nanoseconds.
+ *  Optional: can be zero if not finished;
+ * @param ifrecv
+ *  The number of packets received by capture.
+ *  Optional: use UINT64_MAX if not known.
+ * @param ifdrop
+ *  The number of packets missed by the capture process.
+ *  Optional: use UINT64_MAX if not known.
+ * @return
+ *  number of bytes written to file, -1 on failure to write file
+ */
+__rte_experimental
+ssize_t
+rte_pcapng_write_stats(rte_pcapng_t *self, uint16_t port,
+		       const char *comment,
+		       uint64_t start_time, uint64_t end_time,
+		       uint64_t ifrecv, uint64_t ifdrop);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _RTE_PCAPNG_H_ */

--- a/src/dpdk/lib/librte_pcapng/version.map
+++ b/src/dpdk/lib/librte_pcapng/version.map
@@ -1,0 +1,12 @@
+EXPERIMENTAL {
+	global:
+
+	rte_pcapng_close;
+	rte_pcapng_copy;
+	rte_pcapng_fdopen;
+	rte_pcapng_mbuf_size;
+	rte_pcapng_write_packets;
+	rte_pcapng_write_stats;
+
+	local: *;
+};

--- a/src/stx/common/trex_capture.cpp
+++ b/src/stx/common/trex_capture.cpp
@@ -21,6 +21,636 @@ limitations under the License.
 #include "trex_capture.h"
 #include "trex_exception.h"
 
+#ifndef TREX_SIM
+#define ENDPOINT_PCAPNG
+#endif
+
+#include <zmq.h>
+#ifdef ENDPOINT_PCAPNG
+#include <pcapng_proto.h>
+#endif
+
+#include <linux/limits.h>   // PATH_MAX
+#include <unistd.h>         // getcwd()
+#include <sys/stat.h>
+#include <thread>
+
+
+class FileWriter: public EndpointWriter {
+    FILE *m_file_handler;
+    std::string m_filepath_tmp;
+
+public:
+    virtual ~FileWriter() {
+        close();
+        if (!m_filepath_tmp.empty()) {
+            /* thread trick is to avoid watchdog during removing large size file */
+            std::thread([](std::string file){ remove(file.c_str()); }, m_filepath_tmp).detach();
+            m_filepath_tmp.clear();
+        }
+    }
+
+    virtual bool Create(std::string &endpoint, std::string &err) {
+        std::string prefix("file:///");
+        if (endpoint.substr(0, prefix.length()) != prefix) {
+            err = "file endpoint should start with " + prefix;
+            return false;
+        }
+
+        std::string filepath = endpoint.substr(prefix.length());
+        if (filepath.empty() || filepath[0] != '/') {
+            /* convert to absolute path */
+            char cpath[PATH_MAX];
+            getcwd(cpath, PATH_MAX);
+            filepath = std::string(cpath) + "/" + filepath;
+        }
+        if (filepath.substr(filepath.length()-1) == "/") {
+            /* generate internal temporary filename when it is not specified */
+            std::ostringstream filename;
+            filename << "endpoint_" << reinterpret_cast<intptr_t>(this);
+
+            filepath += filename.str();
+            /* save path to remove later automatically */
+            m_filepath_tmp = filepath;
+        }
+
+        struct stat buffer;
+        if (stat(filepath.c_str(), &buffer) == 0) {
+            err = "file '" + filepath + "' already exists.";
+            return false;
+        }
+
+        m_file_handler = fopen(filepath.c_str(), "wb");
+        if (!m_file_handler) {
+            err = "create file '" + filepath + "' faild - " + std::to_string(errno);
+            return false;
+        }
+        setbuf(m_file_handler, NULL);
+
+        /* update by generated endpoint file path for the later response */
+        endpoint = prefix + filepath;
+        return true;
+    }
+
+    virtual bool is_open() const {
+        return !!m_file_handler;
+    }
+
+    virtual void close() {
+        if (m_file_handler) {
+            /* this trick is to avoid watchdog during closing large size file */
+            std::thread([](FILE* fp){ fclose(fp); }, m_file_handler).detach();
+            m_file_handler = nullptr;
+        }
+    }
+
+    virtual int write(const void *buf, size_t nbyte) {
+        size_t size = fwrite(buf, nbyte, 1, m_file_handler);
+        if (size != 1 && ferror(m_file_handler)) {
+            clearerr(m_file_handler);
+            close();
+        }
+        return size * nbyte;
+    }
+};
+
+
+class ZmqWriter: public EndpointWriter {
+    void *m_zeromq_ctx;
+    void *m_zeromq_socket;
+
+public:
+    virtual ~ZmqWriter() {
+        close();
+    }
+
+    virtual bool Create(std::string &endpoint, std::string &err) {
+        std::string prefix("ipc://");
+        if (endpoint.substr(0, prefix.length()) == prefix) {
+            std::string path = endpoint.substr(prefix.length());
+            struct stat buffer;
+            if (stat(path.c_str(), &buffer) == -1) {
+                err = "ipc socket '" + path + "' does not exists.";
+                return false;
+            }
+        }
+
+        m_zeromq_ctx = zmq_ctx_new();
+        if ( !m_zeromq_ctx ) {
+            err = "Could not create ZMQ context";
+            return false;
+        }
+        m_zeromq_socket = zmq_socket(m_zeromq_ctx, ZMQ_PAIR);
+        if ( !m_zeromq_socket ) {
+            zmq_ctx_term(m_zeromq_ctx);
+            m_zeromq_ctx = nullptr;
+            err = "Could not create ZMQ socket";
+            return false;
+        }
+
+        int linger = 0;
+        zmq_setsockopt(m_zeromq_socket, ZMQ_LINGER, &linger, sizeof(linger));
+
+        if ( zmq_connect(m_zeromq_socket, endpoint.c_str()) != 0 ) {
+            zmq_close(m_zeromq_socket);
+            zmq_ctx_term(m_zeromq_ctx);
+            m_zeromq_socket = nullptr;
+            m_zeromq_ctx = nullptr;
+            err = "Could not connect to ZMQ socket";
+            return false;
+        }
+        return true;
+    }
+
+    virtual bool is_open() const {
+        return m_zeromq_ctx && m_zeromq_socket;
+    }
+
+    virtual void close() {
+        if ( m_zeromq_socket ) {
+            zmq_close(m_zeromq_socket);
+            m_zeromq_socket = nullptr;
+        }
+        if ( m_zeromq_ctx ) {
+            zmq_ctx_term(m_zeromq_ctx);
+            m_zeromq_ctx = nullptr;
+        }
+    }
+
+    virtual int write(const void *buf, size_t nbyte) {
+        int rc = zmq_send(m_zeromq_socket, buf, nbyte, ZMQ_DONTWAIT);
+        if (rc == -1 && errno != EAGAIN) {
+            close();
+        }
+        return rc;
+    }
+};
+
+
+#define ENDPOINT_BUFFER_SIZE    0x100000
+
+EndpointBuffer::EndpointBuffer() {
+    m_base = new uint8_t[ENDPOINT_BUFFER_SIZE];
+    m_size = 0;
+    m_reserved = 0;
+    m_count = 0;
+}
+
+EndpointBuffer::~EndpointBuffer() {
+    if (m_base) {
+        delete[] m_base;
+        m_base = nullptr;
+    }
+}
+
+uint32_t EndpointBuffer::available_size() const {
+    return ENDPOINT_BUFFER_SIZE - m_reserved;
+}
+
+uint8_t* EndpointBuffer::reserve_block(uint32_t size) {
+    uint8_t* block = nullptr;
+    if (size <= available_size()) {
+        block = m_base + m_reserved;
+        m_reserved += size;
+    }
+    return block;
+}
+
+void EndpointBuffer::consume_block(uint32_t size) {
+    m_size += size;
+    ++m_count;
+}
+
+
+#ifndef NSEC_PER_SEC
+#define NSEC_PER_SEC    1000000000L
+#endif
+#define USEC_PER_SEC    1000000L
+
+/**************************************
+ * Capture Endpoint
+ *
+ * An endpoint to save captured packets
+ *************************************/
+CaptureEndpoint::CaptureEndpoint(const std::string& endpoint, uint16_t snaplen): m_endpoint(endpoint) {
+    m_snaplen = snaplen;
+    m_writer = nullptr;
+    m_format = PCAP;
+
+    /* save start time as UTC nanoseconds */
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    m_timestamp_ns = ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec;
+    m_timestamp_cycles = os_get_hr_tick_64();
+    m_timestamp_last = m_timestamp_ns;
+
+    m_packet_limit = 0;
+    m_packet_count = 0;
+    m_packet_bytes = 0;
+}
+
+CaptureEndpoint::~CaptureEndpoint() {
+    if (m_writer) {
+        delete m_writer;
+        m_writer = nullptr;
+    }
+    for (auto buffer: m_buffers) {
+        delete buffer;
+    }
+}
+
+double CaptureEndpoint::get_start_ts() const {
+    return (m_timestamp_ns*1.0) / NSEC_PER_SEC;
+}
+
+uint64_t CaptureEndpoint::get_timestamp_ns() const {
+    uint64_t cycles = os_get_hr_tick_64() - m_timestamp_cycles;
+    return  m_timestamp_ns + (cycles*NSEC_PER_SEC)/os_get_hr_freq();
+}
+
+uint8_t *
+CaptureEndpoint::allocate_block(uint32_t size) {
+    std::unique_lock<std::mutex> ulock(m_lock);
+
+    if (m_buffers.empty() || size > m_buffers.back()->available_size()) {
+        m_buffers.push_back(new EndpointBuffer());
+    }
+
+    return m_buffers.back()->reserve_block(size);
+}
+
+void
+CaptureEndpoint::finalize_block(uint8_t* block, uint32_t size, uint32_t bytes) {
+    std::unique_lock<std::mutex> ulock(m_lock);
+
+    for(auto it = m_buffers.rbegin(); it != m_buffers.rend(); ++it) {
+        if ((*it)->has_reserved(block)) {
+            (*it)->consume_block(size);
+            break;
+        }
+    }
+    m_packet_count += 1;
+    m_packet_bytes += bytes;
+}
+
+bool
+CaptureEndpoint::Init(const CaptureFilter& filter, std::string &err) {
+    assert(!m_endpoint.empty());
+
+    size_t optpos = m_endpoint.find("?");
+    if (optpos != std::string::npos) {
+        std::string option = m_endpoint.substr(optpos+1);
+
+        if (option == "pcap") {
+            m_format = PCAP;
+        } else if (option == "pcapng") {
+            m_format = PCAPNG;
+        } else {
+            err = "upsuported format: " + option;
+            return false;
+        }
+        m_endpoint = m_endpoint.substr(0, optpos);
+    }
+
+    size_t pos = m_endpoint.find("://");
+    if (pos == std::string::npos) {
+        err = "no endpoint protocol specified: " + m_endpoint;
+        return false;
+    }
+    std::string proto = m_endpoint.substr(0, pos);
+    if (proto.compare("file") == 0) {
+        /* start with "file://" */
+        m_writer = new FileWriter();
+    } else {
+        /* start with "tcp://" or "ipc://" */
+        m_writer = new ZmqWriter();
+    }
+
+    /* to fill IDB for PCAPNG */
+    uint64_t ports_bit = filter.get_tx_active_map() | filter.get_rx_active_map();
+    for (int port_id = 0; ports_bit; ports_bit >>= 1, port_id++) {
+        if (ports_bit & 1) {
+            uint8_t index = (uint8_t) m_ports_map.size();
+            m_ports_map[port_id] = index;
+        }
+    }
+
+    bool done = m_writer->Create(m_endpoint, err);
+    if (done && !write_header()) {
+        if (done) {
+            err = "Failed writing header to " + m_endpoint;
+        }
+        done = false;
+    }
+
+    if (!done) {
+        delete m_writer;
+        m_writer = nullptr;
+    }
+    return writer_is_active();
+}
+
+#ifdef ENDPOINT_PCAPNG
+/* length of option including padding */
+static uint16_t pcapng_optlen(uint16_t len)
+{
+    return RTE_ALIGN(sizeof(struct pcapng_option) + len,
+                     sizeof(uint32_t));
+}
+
+/* build TLV option and return location of next */
+static struct pcapng_option *
+pcapng_add_option(struct pcapng_option *popt, uint16_t code,
+                  const void *data, uint16_t len)
+{
+    popt->code = code;
+    popt->length = len;
+    memcpy(popt->data, data, len);
+
+    return (struct pcapng_option *)((uint8_t *)popt + pcapng_optlen(len));
+}
+
+/* section header block */
+static uint32_t pcapng_shb_length() {
+    return sizeof(struct pcapng_section_header) + pcapng_optlen(0) + sizeof(uint32_t);
+}
+
+static uint32_t
+pcapng_shb(uint8_t *buf) {
+    uint32_t len = pcapng_shb_length();
+
+    struct pcapng_section_header* shb = (struct pcapng_section_header*) buf;
+    *shb = (struct pcapng_section_header) {
+            .block_type = PCAPNG_SECTION_BLOCK,
+            .block_length = len,
+            .byte_order_magic = PCAPNG_BYTE_ORDER_MAGIC,
+            .major_version = PCAPNG_MAJOR_VERS,
+            .minor_version = PCAPNG_MINOR_VERS,
+            .section_length = UINT64_MAX,
+    };
+    struct pcapng_option* opt = (struct pcapng_option *)(shb + 1);
+
+    /* The standard requires last option to be OPT_END */
+    opt = pcapng_add_option(opt, PCAPNG_OPT_END, NULL, 0);
+
+    /* clone block_length after option */
+    memcpy(opt, &shb->block_length, sizeof(uint32_t));
+
+    return len;
+}
+
+/* interface description block */
+static uint32_t pcapng_idb_length() {
+    return sizeof(struct pcapng_interface_block) + sizeof(uint32_t);
+}
+
+static uint32_t
+pcapng_idb(uint8_t* buf, uint32_t snaplen) {
+    uint32_t len = pcapng_idb_length();
+
+    struct pcapng_interface_block* idb = (struct pcapng_interface_block*) buf;
+    *idb = (struct pcapng_interface_block) {
+            .block_type = PCAPNG_INTERFACE_BLOCK,
+            .block_length = len,
+            .link_type = 1,         /* DLT_EN10MB - Ethernet */
+            .reserved = 0,
+            .snap_len = (uint32_t) (snaplen ? snaplen: 2000),
+    };
+
+    /* clone block_length */
+    memcpy(idb + 1, &idb->block_length, sizeof(uint32_t));
+
+    return len;
+}
+#endif /* ENDPOINT_PCAPNG */
+
+bool
+CaptureEndpoint::write_header() {
+    if (!writer_is_active()) {
+        return false;
+    }
+
+    if (m_format == PCAP) {
+        packet_file_header_t header;
+
+#define MAGIC_NUM_DONT_FLIP 0xa1b2c3d4  /* from common/pcap.cpp */
+        header.magic   = MAGIC_NUM_DONT_FLIP;
+        header.version_major  = 0x0002;
+        header.version_minor  = 0x0004;
+        header.thiszone       = 0;
+        header.sigfigs        = 0;
+        header.snaplen        = 2000;
+        header.linktype       = 1;
+
+        int rc = m_writer->write(&header, sizeof(header));
+        if (rc != sizeof(header)) {
+            return false;
+        }
+    }
+#ifdef ENDPOINT_PCAPNG
+    else if (m_format == PCAPNG) {
+        int idbcnt = m_ports_map.size();
+        uint32_t size = pcapng_shb_length() + idbcnt * pcapng_idb_length();
+        uint8_t buf[size];
+
+        uint32_t len = pcapng_shb(buf);
+
+        for (int i = 0; i < idbcnt; i++) {
+            len += pcapng_idb(buf + len, m_snaplen);
+        }
+        assert(size == len);
+
+        int rc = m_writer->write(buf, len);
+        if (rc != len) {
+            return false;
+        }
+    }
+#endif /* ENDPOINT_PCAPNG */
+
+    return true;
+}
+
+static int
+copy_packet_data(uint8_t *dest, const rte_mbuf_t *m, uint32_t caplen) {
+    int index = 0;
+
+    for (const rte_mbuf_t *it = m; it != NULL && (index < caplen); it = it->next) {
+        int copy_len = caplen - index;
+        copy_len = (copy_len > it->data_len) ? it->data_len: copy_len;
+
+        const uint8_t *src = rte_pktmbuf_mtod(it, const uint8_t *);
+        memcpy(dest + index, src, copy_len);
+
+        index += copy_len;
+    }
+
+    return index;
+}
+
+#ifdef ENDPOINT_PCAPNG
+static uint32_t
+pcapng_option_flags(TrexPkt::origin_e origin) {
+    uint32_t flags = 0;
+    if (origin == TrexPkt::ORIGIN_TX) {
+        flags = PCAPNG_IFB_OUTBOUND;
+    } else if (origin == TrexPkt::ORIGIN_RX) {
+        flags = PCAPNG_IFB_INBOUND;
+    }
+    return flags;
+}
+
+static uint32_t pcapng_packet_block_length(uint32_t datalen, uint16_t optlen) {
+    return RTE_ALIGN(sizeof(struct pcapng_enhance_packet_block) + datalen + optlen + sizeof(uint32_t),
+                     sizeof(uint32_t));
+}
+#endif /* ENDPOINT_PCAPNG */
+
+void
+CaptureEndpoint::write_packet(const rte_mbuf_t *m, int port, TrexPkt::origin_e origin, uint64_t index) {
+    if (!writer_is_active() || (m_packet_limit && index > m_packet_limit)) {
+        return;
+    }
+
+    uint64_t timestamp_ns = get_timestamp_ns();
+    uint64_t timestamp_us = timestamp_ns/1000;
+
+    uint32_t pktlen = m->pkt_len;
+    uint32_t caplen = (m_snaplen && m_snaplen < pktlen) ? m_snaplen: pktlen;
+
+    if (m_format == PCAP) {
+        uint8_t* block = allocate_block(sizeof(sf_pkthdr_t) + caplen);
+
+        sf_pkthdr_t* pkthdr = (sf_pkthdr_t*) block;
+        pkthdr->len = pktlen;
+        pkthdr->caplen = caplen;
+        pkthdr->ts.msec = timestamp_us % USEC_PER_SEC;
+        pkthdr->ts.sec  = timestamp_us / USEC_PER_SEC;
+
+        uint32_t len = sizeof(*pkthdr);
+
+        /* add packet data */
+        len += copy_packet_data(block + len, m, caplen);
+
+        finalize_block(block, len, pktlen);
+    }
+#ifdef ENDPOINT_PCAPNG
+    else if (m_format == PCAPNG) {
+        uint32_t flags = pcapng_option_flags(origin);
+        uint32_t optlen = flags ? pcapng_optlen(sizeof(flags)) : 0;
+        uint32_t size = pcapng_packet_block_length(caplen, optlen);
+
+        uint8_t* block = allocate_block(size);
+
+        /* fill header */
+        struct pcapng_enhance_packet_block* epb = (struct pcapng_enhance_packet_block*) block;
+        *epb = (struct pcapng_enhance_packet_block) {
+                .block_type = PCAPNG_ENHANCED_PACKET_BLOCK,
+                .block_length = size,
+                .interface_id = m_ports_map[port],
+                .timestamp_hi = (uint32_t)(timestamp_us >> 32),
+                .timestamp_lo = (uint32_t)timestamp_us,
+                .capture_length = caplen,
+                .original_length = pktlen,
+        };
+        uint32_t len = sizeof(*epb);
+
+        /* add packet data */
+        caplen = copy_packet_data(block + len, m, caplen);
+        len += RTE_ALIGN(caplen, sizeof(uint32_t));
+
+        /* add options */
+        if (flags) {
+            pcapng_option* opt = (struct pcapng_option*) (block + len);
+            pcapng_add_option(opt, PCAPNG_EPB_FLAGS, &flags, sizeof(flags));
+            len += optlen;
+        }
+
+        /* clone block_length */
+        memcpy(block + len, &epb->block_length, sizeof(uint32_t));
+        len += sizeof(uint32_t);
+
+        assert(len == size);
+        finalize_block(block, len, pktlen);
+    }
+#endif /* ENDPOINT_PCAPNG */
+
+    m_timestamp_last = timestamp_ns;
+}
+
+void
+CaptureEndpoint::stop() {
+    if (writer_is_active()) {
+        m_writer->close();
+    }
+}
+
+void
+CaptureEndpoint::to_json_status(Json::Value &output) const {
+    output["endpoint"] = get_name();
+
+    output["count"] = get_packet_count();   // total packets in endpoint and buffers
+    output["bytes"] = get_packet_bytes();   // total original bytes
+    output["limit"] = get_packet_limit();
+    output["snaplen"] = get_snaplen();
+
+    output["format"] = (m_format == PCAPNG) ? "pcapng": "pcap";
+}
+
+int
+CaptureEndpoint::flush_buffer(bool all) {
+    if (m_buffers.empty()) {
+        return 0;
+    }
+    /* last one is current working buffer */
+    if (m_buffers.size() == 1 && all == false &&
+        (get_timestamp_ns() - m_timestamp_last < NSEC_PER_SEC/2)) {
+        return 0;
+    }
+
+    std::unique_lock<std::mutex> ulock(m_lock);
+
+    EndpointBuffer* buffer = m_buffers[0];
+    if (buffer->in_use()) { /* TX core is filling data in the buffer */
+        return 0;
+    }
+
+    if (!writer_is_active() || buffer->get_count() == 0) {
+        /* to empty m_buffers gracefully */
+        delete buffer;
+        m_buffers.erase(m_buffers.begin());
+        return 0;
+    }
+
+    /* to prevent being used from allocate_block() */
+    buffer->reserve_block(buffer->available_size());
+
+    ulock.unlock();
+
+    int block_count = 0;
+    int rc = m_writer->write(buffer->get_base(), buffer->get_size());
+    if (rc == buffer->get_size()) {
+        block_count = buffer->get_count();
+        delete buffer;
+
+        ulock.lock();
+        m_buffers.erase(m_buffers.begin());
+    }
+
+    return block_count;
+}
+
+uint32_t
+CaptureEndpoint::get_element_count() const {
+    std::unique_lock<std::mutex> ulock(m_lock);
+
+    uint32_t count = 0;
+    for (auto buffer: m_buffers) {
+        count += buffer->get_count();
+    }
+    return count;
+}
+
+
 /**************************************
  * Capture
  *  
@@ -29,20 +659,32 @@ limitations under the License.
 TrexCapture::TrexCapture(capture_id_t id,
                          uint64_t limit,
                          const CaptureFilter &filter,
-                         TrexPktBuffer::mode_e mode) {
+                         TrexPktBuffer::mode_e mode,
+                         CaptureEndpoint *endpoint) {
     m_id         = id;
-    m_pkt_buffer = new TrexPktBuffer(limit, mode);
+    m_pkt_buffer = endpoint ? nullptr: new TrexPktBuffer(limit, mode);
     m_filter     = filter;
     m_state      = STATE_ACTIVE;
-    m_start_ts   = now_sec();
+    m_start_ts   = endpoint ? endpoint->get_start_ts(): now_sec();
     m_pkt_index  = 0;
-    
+    m_pkt_count  = 0;
+    m_endpoint   = endpoint;
+
     m_filter.compile();
+
+    if (m_endpoint) {
+        m_endpoint->set_packet_limit(limit);
+    }
 }
 
 TrexCapture::~TrexCapture() {
     if (m_pkt_buffer) {
         delete m_pkt_buffer;
+        m_pkt_buffer = nullptr;
+    }
+    if (m_endpoint) {
+        delete m_endpoint;
+        m_endpoint = nullptr;
     }
 }
 
@@ -57,8 +699,14 @@ TrexCapture::handle_pkt(const rte_mbuf_t *m, int port, TrexPkt::origin_e origin)
     if (!m_filter.match(port, origin, m)) {
         return;
     }
-    
-    m_pkt_buffer->push(m, port, origin, ++m_pkt_index);
+
+    ++m_pkt_index;
+
+    if (has_endpoint()) {
+        m_endpoint->write_packet(m, port, origin, m_pkt_index);
+    } else {
+        m_pkt_buffer->push(m, port, origin, m_pkt_index);
+    }
 }
 
 
@@ -68,6 +716,7 @@ TrexCapture::to_json() const {
 
     output["id"]       = Json::UInt64(m_id);
     output["matched"]  = Json::UInt64(m_pkt_index);
+    output["fetched"]  = Json::UInt64(m_pkt_count);
     output["filter"]   = m_filter.to_json();
     
     switch (m_state) {
@@ -82,12 +731,32 @@ TrexCapture::to_json() const {
     default:
         assert(0);
     }
-    
-    
+
     /* write the pkt buffer status */
-    m_pkt_buffer->to_json_status(output);
+    if (has_endpoint()) {
+        m_endpoint->to_json_status(output);
+    } else {
+        m_pkt_buffer->to_json_status(output);
+    }
     
     return output;
+}
+
+/**
+ * flush pkt buffer in endpoint
+ */
+int
+TrexCapture::flush_endpoint() {
+
+    int flush_cnt = m_endpoint->flush_buffer(!is_active());
+
+    m_pkt_count += flush_cnt;
+
+    if (!is_active() && m_endpoint->is_empty()) {
+        m_endpoint->stop();
+    }
+
+    return flush_cnt;
 }
 
 /**
@@ -102,13 +771,15 @@ TrexCapture::fetch(uint32_t pkt_limit, uint32_t &pending) {
         TrexPktBuffer *current = m_pkt_buffer;
         m_pkt_buffer = new TrexPktBuffer(m_pkt_buffer->get_capacity(), m_pkt_buffer->get_mode());
         pending = 0;
+        m_pkt_count += current->get_element_count();
         return current;
     }
     
     /* partial fetch - take a partial list */
     TrexPktBuffer *partial = m_pkt_buffer->pop_n(pkt_limit);
     pending  = m_pkt_buffer->get_element_count();
-    
+    m_pkt_count += partial->get_element_count();
+
     return partial;
 }
 
@@ -184,6 +855,8 @@ void
 TrexCaptureMngr::start(const CaptureFilter &filter,
                                 uint64_t limit,
                                 TrexPktBuffer::mode_e mode,
+                                uint16_t snaplen,
+                                const std::string& endpoint,
                                 TrexCaptureRCStart &rc) {
 
     /* check for maximum active captures */
@@ -191,11 +864,22 @@ TrexCaptureMngr::start(const CaptureFilter &filter,
         rc.set_err(TrexCaptureRC::RC_CAPTURE_LIMIT_REACHED);
         return;
     }
-    
+
+    /* create a new endpoint */
+    CaptureEndpoint *new_endpoint = nullptr;
+    if (!endpoint.empty()) {
+        new_endpoint = new CaptureEndpoint(endpoint, snaplen);
+        std::string err;
+        if (!new_endpoint->Init(filter, err)) {
+            delete new_endpoint;
+            rc.set_err(TrexCaptureRC::RC_CAPTURE_INVALID_ENDPOINT, err);
+            return;
+        }
+    }
+
     /* create a new capture*/
     int new_id = m_id_counter++;
-    TrexCapture *new_capture = new TrexCapture(new_id, limit, filter, mode);
-    
+    TrexCapture *new_capture = new TrexCapture(new_id, limit, filter, mode, new_endpoint);
     /**
      * add the new capture in a safe mode 
      * (TX might be active) 
@@ -229,7 +913,7 @@ TrexCaptureMngr::stop(capture_id_t capture_id, TrexCaptureRCStop &rc) {
     /* done with critical section */
     ulock.unlock();
     
-    rc.set_rc(capture->get_pkt_count());
+    rc.set_rc(capture->get_pkt_count(), capture->get_endpoint_name());
 }
 
 
@@ -242,11 +926,20 @@ TrexCaptureMngr::fetch(capture_id_t capture_id, uint32_t pkt_limit, TrexCaptureR
     }
     
     uint32_t pending = 0;
-    
-    /* take a lock before fetching all the packets */
-    std::unique_lock<std::mutex> ulock(m_lock);
-    TrexPktBuffer *pkt_buffer = capture->fetch(pkt_limit, pending);
-    ulock.unlock();
+    TrexPktBuffer *pkt_buffer;
+
+    if (capture->has_endpoint()) {
+        /* while endpoint is active, fetching from client would be stalled */
+        pkt_buffer = new TrexPktBuffer(0);
+        pending = capture->get_pkt_count();
+    } else {
+        /* take a lock before fetching all the packets */
+        std::unique_lock<std::mutex> ulock(m_lock);
+
+        pkt_buffer = capture->fetch(pkt_limit, pending);
+
+        ulock.unlock();
+    }
     
     rc.set_rc(pkt_buffer, pending, capture->get_start_ts());
 }
@@ -310,6 +1003,33 @@ TrexCaptureMngr::handle_pkt_slow_path(const rte_mbuf_t *m, int port, TrexPkt::or
     #endif
 }
 
+bool
+TrexCaptureMngr::tick() {
+    dsec_t now = now_sec();
+    if (m_tick_time_sec && now < m_tick_time_sec) {
+        return false;
+    }
+    m_tick_time_sec = now + 0.001;  /* on every 1 msec */
+
+    if (m_captures.empty()) {
+        return false;
+    }
+
+    /* Frequent locks will reduce TX core performance.
+     * Since TX cores are only reading m_captures,
+     * the locks is not required for reading m_captures in RX core.
+     * But each capture (endpoint) should have own locks for critical section.
+     */
+
+    uint64_t pkt_count = 0;
+    for (TrexCapture *capture : m_captures) {
+        if (capture->has_active_endpoint()) {
+            pkt_count += capture->flush_endpoint();
+        }
+    }
+
+    return !!pkt_count;
+}
 
 Json::Value
 TrexCaptureMngr::to_json() {

--- a/src/stx/common/trex_capture.cpp
+++ b/src/stx/common/trex_capture.cpp
@@ -21,6 +21,8 @@ limitations under the License.
 #include "trex_capture.h"
 #include "trex_exception.h"
 
+#include "trex_watchdog.h"
+
 #ifndef TREX_SIM
 #define ENDPOINT_PCAPNG
 #endif
@@ -251,6 +253,10 @@ CaptureEndpoint::CaptureEndpoint(const std::string& endpoint, uint16_t snaplen):
 
 CaptureEndpoint::~CaptureEndpoint() {
     if (m_writer) {
+        /* IO might take time, increse timeout of WD inside this function */
+        TrexWatchDog::IOFunction dummy;
+        (void)dummy;
+
         delete m_writer;
         m_writer = nullptr;
     }
@@ -334,6 +340,10 @@ CaptureEndpoint::Init(const CaptureFilter& filter, std::string &err) {
             m_ports_map[port_id] = index;
         }
     }
+
+    /* IO might take time, increse timeout of WD inside this function */
+    TrexWatchDog::IOFunction dummy;
+    (void)dummy;
 
     bool done = m_writer->Create(m_endpoint, err);
     if (done && !write_header()) {

--- a/src/stx/common/trex_capture_rc.h
+++ b/src/stx/common/trex_capture_rc.h
@@ -45,7 +45,8 @@ public:
         RC_OK = 1,
         RC_CAPTURE_NOT_FOUND,
         RC_CAPTURE_LIMIT_REACHED,
-        RC_CAPTURE_FETCH_UNDER_ACTIVE
+        RC_CAPTURE_FETCH_UNDER_ACTIVE,
+        RC_CAPTURE_INVALID_ENDPOINT
     };
 
     bool operator !() const {
@@ -55,6 +56,10 @@ public:
     std::string get_err() const {
         assert(m_rc != RC_INVALID);
         
+        if (!m_err.empty()) {
+            return m_err;
+        }
+
         switch (m_rc) {
         case RC_OK:
             return "";
@@ -64,6 +69,8 @@ public:
             return "capture ID not found";
         case RC_CAPTURE_FETCH_UNDER_ACTIVE:
             return "fetch command cannot be executed on an active capture";
+        case RC_CAPTURE_INVALID_ENDPOINT:
+            return "specified endpoint is unavailable";
         case RC_INVALID:
             /* should never be called under invalid */
             assert(0);
@@ -77,9 +84,14 @@ public:
         m_rc = rc;
     }
     
+    void set_err(rc_e rc, const std::string& err) {
+        m_rc = rc;
+        m_err = err;
+    }
     
 protected:
     rc_e m_rc;
+    std::string m_err;
 };
 
 /**
@@ -115,8 +127,9 @@ private:
 class TrexCaptureRCStop : public TrexCaptureRC {
 public:
     
-    void set_rc(uint32_t pkt_count) {
+    void set_rc(uint32_t pkt_count, const std::string &endpoint) {
         m_pkt_count = pkt_count;
+        m_endpoint  = endpoint;
         m_rc        = RC_OK;
     }
     
@@ -124,9 +137,15 @@ public:
         assert(m_rc == RC_OK);
         return m_pkt_count;
     }
+
+    std::string get_endpoint() const {
+        assert(m_rc == RC_OK);
+        return m_endpoint;
+    }
     
 private:
     uint32_t m_pkt_count;
+    std::string m_endpoint;
 };
 
 /**

--- a/src/stx/common/trex_messaging.cpp
+++ b/src/stx/common/trex_messaging.cpp
@@ -167,7 +167,7 @@ TrexRxCaptureStart::handle(CRxCore *rx_core) {
     
     TrexCaptureRCStart start_rc;
     
-    TrexCaptureMngr::getInstance().start(m_filter, m_limit, m_mode, start_rc);
+    TrexCaptureMngr::getInstance().start(m_filter, m_limit, m_mode, m_snaplen, m_endpoint, start_rc);
     
     /* mark as done */
     m_reply.set_reply(start_rc);

--- a/src/stx/common/trex_messaging.h
+++ b/src/stx/common/trex_messaging.h
@@ -401,11 +401,15 @@ public:
     TrexRxCaptureStart(const CaptureFilter& filter,
                                 uint64_t limit,
                                 TrexPktBuffer::mode_e mode,
+                                uint16_t snaplen,
+                                const std::string& endpoint,
                                 MsgReply<TrexCaptureRCStart> &reply) : m_reply(reply) {
         
         m_limit  = limit;
         m_filter = filter;
         m_mode   = mode;
+        m_snaplen   = snaplen;
+        m_endpoint  = endpoint;
     }
 
     virtual bool handle(CRxCore *rx_core);
@@ -415,6 +419,8 @@ private:
     uint64_t                         m_limit;
     CaptureFilter                    m_filter;
     TrexPktBuffer::mode_e            m_mode;
+    uint16_t                         m_snaplen;
+    std::string                      m_endpoint;
     MsgReply<TrexCaptureRCStart>    &m_reply;
 };
 

--- a/src/stx/common/trex_rx_core.cpp
+++ b/src/stx/common/trex_rx_core.cpp
@@ -439,7 +439,7 @@ bool CRxCore::work_tick() {
         }
 
         if (unlikely(m_working_tpg_threads != 0)) {
-            did_something = handle_tpg_threads();
+            did_something |= handle_tpg_threads();
         }
 
         m_sync_time_sec = now + m_sync_time_period;
@@ -449,6 +449,8 @@ bool CRxCore::work_tick() {
 
        */
     m_tx_queue.tick();
+
+    did_something |= TrexCaptureMngr::getInstance().tick();
 
     return did_something;
 }


### PR DESCRIPTION
Hi, this PR is the change for issue #822.

There are lots of changes but the original capture method is still functional.
This feature will be activated only by an 'endpoint' parameter in the 'capture' 'start' request.
I have met a traffic performance issue (about 2/3 degradation during capturing) with the original packet buffer.
So I introduce a new 'endpoint buffer' for bulk operation and get the performance improvement. (about 1/8 degradation during capturing with a small snaplen value)
Because the endpoint can be a file, the buffer will keep the packets in the PCAP/PCAPNG binary format.

@hhaim please check my code and give your feedback
