### PR TITLE
get TCP flow information per profile

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -773,6 +773,15 @@ class OPTIONS_DB_ARGS:
          'default': 0.0,
          'help': "Set time limit waiting for all the flow to terminate gracefully."})
 
+    DUMP_INTERVAL = ArgumentPack(
+        ['--dump_interval'],
+        {'action': "store",
+         'metavar': 'TIME',
+         'dest': 'dump_interval',
+         'type': match_time_unit,
+         'default': 0.0,
+         'help': "Set interval time for dumping TCP flow information"})
+
     TIMEOUT = ArgumentPack(
         ['-t'],
         {'action': "store",

--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -397,8 +397,9 @@ bool CFlowTable::update_new_template(CTcpPerThreadCtx * ctx,
     assert(!flow->is_activated());
     if (flow->m_template_info) {
         flow->update_new_template_assoc_info();
-        flow->m_app.start(false);
         assert(flow->is_activated()); /* flow is now activated */
+        flow->m_pctx->set_flow_info(flow);
+        flow->m_app.start(false);
     } else {    /* no matched template found, now mbuf should be freed */
         CPerProfileCtx* pctx = FALLBACK_PROFILE_CTX(ctx);
         uint8_t mask = 3;
@@ -559,6 +560,7 @@ HOT_FUNC void CFlowTable::free_flow(CFlowBase * flow){
         delete udp_flow;
     }else{
         CTcpFlow * tcp_flow=(CTcpFlow *)flow;
+        flow->m_pctx->clear_flow_info(tcp_flow);
         tcp_flow->Delete();
         delete tcp_flow;
     }
@@ -993,6 +995,7 @@ bool CFlowTable::rx_handle_packet_tcp_no_flow(CTcpPerThreadCtx * ctx,
     if (unlikely(temp->has_payload_params())) {
         lptflow->start_identifying_template(pctx, payload_info);
     } else {
+        lptflow->m_pctx->set_flow_info(lptflow);
         app->start(true); /* start the application */
     }
 

--- a/src/44bsd/netinet/tcp_var.h
+++ b/src/44bsd/netinet/tcp_var.h
@@ -217,6 +217,7 @@ struct tcpcb {
     struct sackhint	sackhint;	/* SACK scoreboard hint */
     int	t_rttlow;		/* smallest observerved RTT */
     int	t_sndrexmitpack;	/* retransmit packets sent */
+    int	t_rcvoopack;		/* out-of-order packets received */
     struct cc_algo	*cc_algo;	/* congestion control algorithm */
     struct cc_var	*ccv;		/* congestion control specific vars */
     int	t_bytes_acked;		/* # bytes acked during current RTT */

--- a/src/44bsd/tcp_input.cpp
+++ b/src/44bsd/tcp_input.cpp
@@ -248,6 +248,7 @@ int CTcpReass::pre_tcp_reass(CPerProfileCtx * pctx,
     uint16_t tg_id = tp->m_flow->m_tg_id;
     INC_STAT(pctx, tg_id, tcps_rcvoopack);
     INC_STAT_CNT(pctx, tg_id, tcps_rcvoobyte, ti->ti_len);
+    tp->t_rcvoopack++;
 
     CTcpReassBlock cur{ti->ti_seq, ti->ti_len, !!(ti->ti_flags & TH_FIN)};
     CTcpSeqKey cur_seq{cur.m_seq};

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -577,6 +577,7 @@ void CFlowGenListPerThread::generate_flow(bool &done, CPerProfileCtx * pctx){
         tcp_flow->set_c_tcp_info(cur, template_id);
 
         /* start connect */
+        tcp_flow->m_pctx->set_flow_info(tcp_flow);
         app_c->start(true);
         tcp_connect(&tcp_flow->m_tcp);
     }

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -112,6 +112,7 @@ public:
     void dp_core_error(const std::string &err);
 
     void add_dp_profile_ctx(CPerProfileCtx* client, CPerProfileCtx* server);
+    void add_flow_info(Json::Value& flows);
 
     /*
      * publish event for each profile
@@ -136,6 +137,9 @@ public:
     void    set_establish_timeout(double timeout) { m_establish_timeout = timeout; }
     void    set_terminate_duration(double duration) { m_terminate_duration = duration; }
     void    set_factor(double mult) { m_factor = mult; }
+
+    void get_flow_info(Json::Value& flows, uint64_t index);
+    void init_flow_info(double interval);
 
     /*
      * clear statistics counter
@@ -163,6 +167,12 @@ private:
 
     CSTTCp*         m_stt_cp;
     TrexAstf*       m_astf_obj;
+
+    double          m_dump_interval;
+
+    std::vector<Json::Value> m_flows_info;
+    uint64_t        m_flows_limit;
+    uint64_t        m_flows_index;
 };
 
 
@@ -459,6 +469,8 @@ public:
     void insert_ignored_ip_addresses(std::vector<uint32_t>& ip_addresses);
     void get_ignored_ip_addresses(std::vector<uint32_t>& ip_addresses);
     int get_ignored_ips_size();
+
+    void add_flows_info(profile_id_t dp_profile_id, Json::Value& flows);
 
 protected:
     void change_state(state_e new_state);

--- a/src/stx/astf/trex_astf_defs.h
+++ b/src/stx/astf/trex_astf_defs.h
@@ -32,6 +32,7 @@ typedef struct {
     uint32_t    client_mask;
     double      e_duration;
     double      t_duration;
+    double      dump_interval;
 } start_params_t;
 
 

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -37,6 +37,7 @@ struct profile_param {
     bool            m_nc_flow_close;
     double          m_establish_timeout;
     double          m_terminate_duration;
+    double          m_dump_interval;
 };
 
 class TrexAstfDpCore : public TrexDpCore {
@@ -61,7 +62,7 @@ public:
      */
     virtual bool is_port_active(uint8_t port_id);
 
-    void start_transmit(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration);
+    void start_transmit(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration, double dump_interval);
     void stop_transmit(profile_id_t profile_id, uint32_t stop_id, bool set_nc);
     void stop_transmit(profile_id_t profile_id, bool set_nc);
     void update_rate(profile_id_t profile_id, double ratio);
@@ -80,6 +81,7 @@ public:
     void insert_ignored_mac_addresses(std::vector<uint64_t>& mac_addresses);
     void insert_ignored_ip_addresses(std::vector<uint32_t>& ip_addresses);
     void update_tunnel_for_client(CAstfDB* astf_db, std::vector<client_tunnel_data_t> msg_data);
+    void dump_profile_flows(profile_id_t profile_id);
 
 protected:
     virtual bool rx_for_idle();
@@ -98,7 +100,7 @@ protected:
     void set_profile_stop_id(profile_id_t profile_id, uint32_t stop_id);
 
     void get_scheduler_options(profile_id_t profile_id, bool& disable_client, double& d_time_flow, double& d_phase);
-    void start_profile_ctx(profile_id_t profile_id, double duration, bool nc, double establish_timeout = 0.0, double terminate_duration = 0.0);
+    void start_profile_ctx(profile_id_t profile_id, double duration, bool nc, double establish_timeout = 0.0, double terminate_duration = 0.0, double dump_interval = 0.0);
     void stop_profile_ctx(profile_id_t profile_id, uint32_t stop_id);
 
     std::vector<struct profile_param> m_sched_param;

--- a/src/stx/astf/trex_astf_messaging.cpp
+++ b/src/stx/astf/trex_astf_messaging.cpp
@@ -35,22 +35,23 @@ TrexAstfDpCore* astf_core(TrexDpCore *dp_core) {
 /*************************
   start traffic message
  ************************/
-TrexAstfDpStart::TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration) {
+TrexAstfDpStart::TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration, double dump_interval) {
     m_profile_id = profile_id;
     m_duration = duration;
     m_nc_flow_close = nc;
     m_establish_timeout = establish_timeout;
     m_terminate_duration = terminate_duration;
+    m_dump_interval = dump_interval;
 }
 
 
 bool TrexAstfDpStart::handle(TrexDpCore *dp_core) {
-    astf_core(dp_core)->start_transmit(m_profile_id, m_duration, m_nc_flow_close, m_establish_timeout, m_terminate_duration);
+    astf_core(dp_core)->start_transmit(m_profile_id, m_duration, m_nc_flow_close, m_establish_timeout, m_terminate_duration, m_dump_interval);
     return true;
 }
 
 TrexCpToDpMsgBase* TrexAstfDpStart::clone() {
-    return new TrexAstfDpStart(m_profile_id, m_duration, m_nc_flow_close, m_establish_timeout, m_terminate_duration);
+    return new TrexAstfDpStart(m_profile_id, m_duration, m_nc_flow_close, m_establish_timeout, m_terminate_duration, m_dump_interval);
 }
 
 /*************************
@@ -307,4 +308,13 @@ bool TrexAstfDpInitTunnelHandler::handle(TrexDpCore *dp_core) {
 
 TrexCpToDpMsgBase* TrexAstfDpInitTunnelHandler::clone() {
     return new TrexAstfDpInitTunnelHandler(m_activate, m_tunnel_type, m_loopback_mode, m_reply);
+}
+
+/*************************
++  Report flows per profile
++ ************************/
+
+bool TrexAstfDpFlowInfo::handle(void) {
+    ((TrexAstf*)get_stx())->add_flows_info(m_dp_profile_id, m_flows);
+    return true;
 }

--- a/src/stx/astf/trex_astf_messaging.h
+++ b/src/stx/astf/trex_astf_messaging.h
@@ -57,7 +57,7 @@ private:
  */
 class TrexAstfDpStart : public TrexCpToDpMsgBase {
 public:
-    TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration);
+    TrexAstfDpStart(profile_id_t profile_id, double duration, bool nc, double establish_timeout, double terminate_duration, double dump_interval);
     virtual TrexCpToDpMsgBase* clone();
     virtual bool handle(TrexDpCore *dp_core);
 private:
@@ -66,6 +66,7 @@ private:
     bool m_nc_flow_close;
     double m_establish_timeout;
     double m_terminate_duration;
+    double m_dump_interval;
 };
 
 /**
@@ -277,6 +278,24 @@ private:
     uint8_t m_tunnel_type;
     bool m_loopback_mode;
     MsgReply<std::pair<uint64_t*, uint64_t*>> &m_reply;
+};
+
+/**
+ * a message for sending the clients sts from dp to cp
+ */
+class TrexAstfDpFlowInfo : public TrexDpToCpMsgBase {
+public:
+
+    TrexAstfDpFlowInfo(profile_id_t profile_id, Json::Value& flows) {
+        m_dp_profile_id = profile_id;
+        m_flows = flows;
+    }
+
+    virtual bool handle(void);
+
+private:
+    profile_id_t m_dp_profile_id;
+    Json::Value m_flows;
 };
 
 #endif /* __TREX_STL_MESSAGING_H__ */

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -115,6 +115,7 @@ TREX_RPC_CMD(TrexRpcCmdAstfDynamicCountersValues, "get_dynamic_counter_values");
 TREX_RPC_CMD(TrexRpcCmdAstfTotalDynamicCountersValues, "get_total_dynamic_counter_values");
 TREX_RPC_CMD(TrexRpcCmdAstfGetTGNames, "get_tg_names");
 TREX_RPC_CMD(TrexRpcCmdAstfGetTGStats, "get_tg_id_stats");
+TREX_RPC_CMD(TrexRpcCmdAstfGetFlowInfo, "get_flow_info");
 TREX_RPC_CMD(TrexRpcCmdAstfGetLatencyStats, "get_latency_stats");
 TREX_RPC_CMD(TrexRpcCmdAstfGetTrafficDist, "get_traffic_dist");
 
@@ -290,6 +291,7 @@ TrexRpcCmdAstfStart::_run(const Json::Value &params, Json::Value &result) {
     args.client_mask = parse_uint32(params, "client_mask", result);
     args.e_duration = parse_double(params, "e_duration", result, 0.0);
     args.t_duration = parse_double(params, "t_duration", result, 0.0);
+    args.dump_interval = parse_double(params, "dump_interval", result, 0.0);
 
     try {
         get_astf_object()->start_transmit(profile_id, args);
@@ -759,6 +761,21 @@ TrexRpcCmdAstfGetTGStats::_run(const Json::Value &params, Json::Value &result) {
 }
 
 trex_rpc_cmd_rc_e
+TrexRpcCmdAstfGetFlowInfo::_run(const Json::Value &params, Json::Value &result) {
+    string profile_id = parse_profile(params, result);
+    uint64_t index = parse_uint64(params, "index", result, 0);
+    TrexAstf *astf = get_astf_object();
+    if (!astf->is_valid_profile(profile_id)) {
+        generate_execute_err(result, "Invalid profile : " + profile_id);
+    }
+
+    result["result"] = Json::arrayValue;
+    astf->get_profile(profile_id)->get_flow_info(result["result"], index);
+
+    return (TREX_RPC_CMD_OK);
+}
+
+trex_rpc_cmd_rc_e
 TrexRpcCmdAstfTopoGet::_run(const Json::Value &params, Json::Value &result) {
     try {
         get_astf_object()->topo_get(result["result"]);
@@ -1183,6 +1200,7 @@ TrexRpcCmdsASTF::TrexRpcCmdsASTF() : TrexRpcComponent("ASTF") {
     m_cmds.push_back(new TrexRpcCmdAstfTotalCountersValues(this));
     m_cmds.push_back(new TrexRpcCmdAstfGetTGNames(this));
     m_cmds.push_back(new TrexRpcCmdAstfGetTGStats(this));
+    m_cmds.push_back(new TrexRpcCmdAstfGetFlowInfo(this));
     m_cmds.push_back(new TrexRpcCmdAstfTopoGet(this));
     m_cmds.push_back(new TrexRpcCmdAstfTopoFragment(this));
     m_cmds.push_back(new TrexRpcCmdAstfTopoClear(this));


### PR DESCRIPTION
Hi, this is the change for my suggestion in #834.

The user can get the information about a TCP flow per given tg_id.
It includes almost all the FreeBSD `struct tcp_info` information.

@hhaim please review my change and give your feedback.