### PR TITLE
limit the number of saved event log messages

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_events.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_events.py
@@ -8,6 +8,8 @@ from .trex_types import listify
 from .trex_exceptions import TRexError
 from ..utils.text_opts import format_text
 
+from collections import deque
+
 
 # an event
 class Event(object):
@@ -37,7 +39,7 @@ class EventsHandler(object):
 
     def __init__ (self):
 
-        self.events = []
+        self.events = deque([], 1000)
 
         # events are disabled by default until explicitly enabled
         self.enabled = False
@@ -65,12 +67,10 @@ class EventsHandler(object):
 
     def pop_event (self):
         """
-            returns a event from the head of 
-
-            'ev_type_filter' - 'info', 'warning' or a list of them
+            returns a event from the head and remove it.
         """
         if not self.empty ():
-           return self.events.pop(0)
+           return self.events.popleft()
         else:
            return None
 
@@ -91,7 +91,7 @@ class EventsHandler(object):
         """
             clears all the current events
         """
-        self.events = []
+        self.events.clear()
 
 
     def register_event_handler (self, event_name, on_event_cb):
@@ -123,3 +123,4 @@ class EventsHandler(object):
         event = self.events_handlers[event_name](*args, **kwargs)
         if event:
             self.events.append(event)
+


### PR DESCRIPTION
Hi, this PR is to solve issue #853.

The number of saved event log messages is limited to 1000.
`Queue` is not appropriate to save the event log messages. It does not provide the contents in the middle of the queue.
Instead, `deque` is suitable for it and better than `list`.

@hhaim, @bdollma, please review my change and give your feedback.