### PR TITLE
silence maybe-uninitialized warning in get_plugin_id()

### DIFF
--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -1962,20 +1962,6 @@ bool CCapFileFlowInfo::Create(){
 }
 
 
-void CCapFileFlowInfo::dump_pkt_sizes(void){
-    int i;
-    for (i=0; i<(int)Size(); i++) {
-        flow_pkt_info_t lp=GetPacket((uint32_t)i);
-        CGenNode node;
-        node.m_dest_ip  = 0x10000110;
-        node.m_src_ip   = 0x20000110;
-        node.m_src_port = 12;
-        rte_mbuf_t * buf=lp->generate_new_mbuf(&node);
-        //rte_pktmbuf_dump(buf, buf->pkt_len);
-        rte_pktmbuf_free(buf);
-    }
-}
-
 void CCapFileFlowInfo::RemoveAll(){
     int i;
     clear();
@@ -4761,16 +4747,6 @@ void CFlowGenList::Dump(FILE *fd){
     for (i=0; i<(int)m_cap_gen.size(); i++) {
         CFlowGeneratorRec * lp=m_cap_gen[i];
         lp->Dump(fd);
-    }
-}
-
-
-void CFlowGenList::DumpPktSize(){
-
-    int i;
-    for (i=0; i<(int)m_cap_gen.size(); i++) {
-        CFlowGeneratorRec * lp=m_cap_gen[i];
-        lp->m_flow_info.dump_pkt_sizes();
     }
 }
 

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -765,6 +765,7 @@ public:
 
     inline void reset_pkt_in_flow(void);
     inline uint8_t get_plugin_id(void){
+        assert(m_template_info);
         return ( m_template_info->m_plugin_id);
     }
 
@@ -2871,7 +2872,6 @@ public:
     inline CFlowPktInfo * GetPacket(uint32_t index);
     void Append(CPacketIndication * pkt_indication);
     void RemoveAll();
-    void dump_pkt_sizes(void);
     enum load_cap_file_err load_cap_file(std::string cap_file, uint16_t _id, uint8_t plugin_id);
     enum load_cap_file_err load_cap_file(std::string cap_file, uint16_t _id, CFlowYamlInfo &flow_info);
 
@@ -3425,7 +3425,6 @@ public:
 public:
     void Dump(FILE *fd);
     void DumpCsv(FILE *fd);
-    void DumpPktSize();
     void UpdateFast();
     double GetCpuUtil();
     double GetCpuUtilRaw();

--- a/src/sim/trex_sim_stateful.cpp
+++ b/src/sim/trex_sim_stateful.cpp
@@ -77,7 +77,6 @@ void test_load_list_of_cap_files_linux(CParserOption * op){
     fl.Create();
 
     fl.load_from_yaml(op->cfg_file,cores);
-    fl.DumpPktSize();
 
     
     fl.generate_p_thread_info(cores);
@@ -138,7 +137,6 @@ void test_load_list_of_cap_files(CParserOption * op){
     #define NUM 1
 
     fl.load_from_yaml(op->cfg_file,NUM);
-    fl.DumpPktSize();
     
     
     fl.generate_p_thread_info(NUM);


### PR DESCRIPTION
Hi,

This is just to silence the warning when building with distrib default on debian-11.
gcc is `gcc (Debian 10.2.1-6) 10.2.1 20210110`

Best regards
 