### PR TITLE
dpdk: fix build on avx512 platforms

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -1947,7 +1947,7 @@ common_flags = ['-DWIN_UCODE_SIM',
 if march == 'x86_64':
     common_flags_new = common_flags + [
                     '-march=native',
-                    '-mssse3', '-msse4.1', '-mpclmul', 
+                    '-mssse3', '-msse4.1', '-mpclmul', '-mno-avx2',
                     '-DRTE_MACHINE_CPUFLAG_SSE',
                     '-DRTE_MACHINE_CPUFLAG_SSE2',
                     '-DRTE_MACHINE_CPUFLAG_SSE3',


### PR DESCRIPTION
Fix the following build error:

```
src/dpdk/drivers/net/ice/ice_rxtx_vec_sse.c.4.o: In function `_ice_tx_queue_release_mbufs_vec':
src/dpdk/drivers/net/ice/ice_rxtx_vec_common.h:200: undefined reference to `ice_xmit_pkts_vec_avx512'
src/dpdk/drivers/net/ice/ice_rxtx_vec_common.h:200: undefined reference to `ice_xmit_pkts_vec_avx512_offload'
```

The `ice_rxtx_vec_avx2.c` and `ice_rxtx_vec_avx512.c` files are not compiled. However, other parts of the code expects them to since the CPU supports avx512 instructions. Disable AVX2 and AVX512 explicitly.