### PR TITLE
update missing trex patch for i40e_ethdev_vf.c

### DIFF
--- a/src/dpdk/drivers/net/i40e/i40e_ethdev_vf.c
+++ b/src/dpdk/drivers/net/i40e/i40e_ethdev_vf.c
@@ -47,7 +47,11 @@
 #define I40EVF_BUSY_WAIT_COUNT 50
 #define MAX_RESET_WAIT_CNT     20
 
+#ifndef TREX_PATCH
 #define I40EVF_ALARM_INTERVAL 50000 /* us */
+#else
+#define I40EVF_ALARM_INTERVAL 50000 /* same as ASQ_DELAY_MS */
+#endif
 
 struct i40evf_arq_msg_info {
 	enum virtchnl_ops ops;
@@ -317,7 +321,11 @@ _atomic_set_cmd(struct i40e_vf *vf, enum virtchnl_ops ops)
 	return !ret;
 }
 
+#ifdef TREX_PATCH
+#define MAX_TRY_TIMES 20
+#else
 #define MAX_TRY_TIMES 200
+#endif
 #define ASQ_DELAY_MS  10
 
 static int
@@ -398,7 +406,15 @@ _i40evf_execute_vf_cmd(struct rte_eth_dev *dev, struct vf_cmd_info *args)
 				err = 0;
 				break;
 			}
+            #ifdef TREX_PATCH
+                /* imarom: response from the PF drive will be handled by the interrupt process
+                           this requires us to relinquish the thread as both are pinned to the same
+                           core - busy wait might hold us back
+                */
+                usleep(ASQ_DELAY_MS * 1000);
+            #else
 			rte_delay_ms(ASQ_DELAY_MS);
+            #endif
 			/* If don't read msg or read sys event, continue */
 		} while (i++ < MAX_TRY_TIMES);
 		/* If there's no response is received, clear command */
@@ -2442,8 +2458,10 @@ i40evf_dev_stats_get(struct rte_eth_dev *dev, struct rte_eth_stats *stats)
 		stats->ibytes = pstats->rx_bytes;
 		stats->ibytes -= stats->ipackets * RTE_ETHER_CRC_LEN;
 		stats->obytes = pstats->tx_bytes;
+#ifndef TREX_PATCH
 	} else {
 		PMD_DRV_LOG(ERR, "Get statistics failed");
+#endif
 	}
 	return ret;
 }


### PR DESCRIPTION
Hi, this change is to update the missing TREX_PATCH from https://github.com/cisco-system-traffic-generator/trex-core/commit/9e3b836bd10b7367cb770cd8f2e980315f7da4e4

I observed that the `get_pgid_stats` takes a longer time than before.
And I found that there was TREX_PATCH in i40e_ethdev_vf.c which reduces the retry counter.

@hhaim @syaakov please review my change.
