### PR TITLE
stx/stl: Fix comment typo on get_max_stream_id function

### DIFF
--- a/src/stx/stl/trex_stl_port.h
+++ b/src/stx/stl/trex_stl_port.h
@@ -194,7 +194,7 @@ public:
     bool has_flow_stats();
 
     /**
-     * the the max stream id currently assigned
+     * the max stream id currently assigned
      *
      */
     int get_max_stream_id() const;
@@ -464,7 +464,7 @@ public:
     bool has_flow_stats(string profile_id);
 
     /**
-     * the the max stream id currently assigned
+     * the max stream id currently assigned
      *
      */
     int get_max_stream_id(string profile_id);


### PR DESCRIPTION
The comment of get_max_stream_id function have a typo.
"the the" is not a valid sentence in a comment.

Signed-off-by: ali <alirezaarzehgar82@gmail.com>