### PR TITLE
Fixed typos of "does not exits"

### DIFF
--- a/scripts/automation/regression/stateful_tests/trex_general_test.py
+++ b/scripts/automation/regression/stateful_tests/trex_general_test.py
@@ -331,7 +331,7 @@ class CTRexGeneral_Test(unittest.TestCase):
     def check_general_scenario_results (self, trex_res, check_latency = True, skip_expected = False):
         """ 
 
-           skip expected is for case of TCP that those value does not exits because we can't predict them 
+           skip expected is for case of TCP that those value does not exist because we can't predict them 
 
         """
 

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -1,7 +1,7 @@
 #ifndef BP_SIM_H
 #define BP_SIM_H
 /*
- Hanoh Haim
+ Hanoch Haim
  Cisco Systems, Inc.
 */
 
@@ -1875,7 +1875,7 @@ public:
     uint16_t            m_payload_offset;
     uint8_t             m_rw_mbuf_size;    /* first R/W mbuf size 64/128/256 */
     uint8_t             m_pad1;
-    uint16_t            m_ro_mbuf_size;    /* the size of the const mbuf, zero if does not exits */
+    uint16_t            m_ro_mbuf_size;    /* the size of the const mbuf, zero if does not exist */
 
 public:
 

--- a/src/common/captureFile.cpp
+++ b/src/common/captureFile.cpp
@@ -194,7 +194,7 @@ bool CErfCmp::compare(std::string f1, std::string f2 ){
     CCapReaderBase * lp1=CCapReaderFactory::CreateReader((char *)f1.c_str(),0);
     if (lp1 == 0) {
         if ( dump ){
-            printf(" ERROR file %s does not exits or not supported \n",(char *)f1.c_str());
+            printf(" ERROR file %s does not exist or not supported \n",(char *)f1.c_str());
         }
         return (false);
     }
@@ -203,7 +203,7 @@ bool CErfCmp::compare(std::string f1, std::string f2 ){
     if (lp2 == 0) {
         delete lp1;
         if ( dump ){
-            printf(" ERROR file %s does not exits or not supported \n",(char *)f2.c_str());
+            printf(" ERROR file %s does not exist or not supported \n",(char *)f2.c_str());
         }
         return (false);
     }

--- a/src/stx/common/trex_stack_linux_based.cpp
+++ b/src/stx/common/trex_stack_linux_based.cpp
@@ -492,7 +492,7 @@ CNamespacedIfNode * CStackLinuxBased::get_node_rpc(const std::string &mac){
     CNamespacedIfNode * lp=get_node_by_mac(mac);
     if (!lp) {
         stringstream ss;
-        ss << "node " << mac << " does not exits " ;
+        ss << "node " << mac << " does not exist " ;
         throw (TrexRpcCommandException(TREX_RPC_CMD_PARSE_ERR,ss.str()));
     }
     return (lp);

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -406,7 +406,7 @@ public:
         m_flags= ( m_flags & ~SL_NODE_CONST_MBUF );
     }
 
-    /* prefix header exits only in non cache mode size is 64/128/512  other are not possible right now */
+    /* prefix header exist only in non cache mode size is 64/128/512  other are not possible right now */
     inline void alloc_prefix_header(uint16_t size){
          set_prefix_header_size(size);
          m_original_packet_data_prefix = (uint8_t *)malloc(size);


### PR DESCRIPTION
I just saw an error running one of my scripts in BIRD Stateless API. So I searched through the hole repo to find out if there are any more typos like that. 

Wherever I saw "does not exits", I modified it to "does not exist"!
