### PR TITLE
fix invalid timestamp in captured packets by endpoint

### DIFF
--- a/src/stx/common/trex_capture.cpp
+++ b/src/stx/common/trex_capture.cpp
@@ -271,7 +271,9 @@ double CaptureEndpoint::get_start_ts() const {
 
 uint64_t CaptureEndpoint::get_timestamp_ns() const {
     uint64_t cycles = os_get_hr_tick_64() - m_timestamp_cycles;
-    return  m_timestamp_ns + (cycles*NSEC_PER_SEC)/os_get_hr_freq();
+    uint64_t sec = cycles/os_get_hr_freq();
+    cycles = cycles - sec*os_get_hr_freq();
+    return  m_timestamp_ns + sec*NSEC_PER_SEC + (cycles*NSEC_PER_SEC)/os_get_hr_freq();
 }
 
 uint8_t *


### PR DESCRIPTION
Hi, my colleague found that the timestamp in the captured packets is not always going forward.
```
11:12:43.291971 IP 2.2.2.2.1000 > 1.1.11.4.41668: Flags [.], seq 763877:765223, ack 12, win 32768, options [nop,nop
,TS val 1001976765 ecr 1253344017], length 1346
11:12:43.291972 IP 2.2.2.2.1000 > 1.1.11.4.41668: Flags [.], seq 765223:766569, ack 12, win 32768, options [nop,nop
,TS val 1001976765 ecr 1253344017], length 1346
11:12:35.685578 IP 1.1.11.4.41668 > 2.2.2.2.1000: Flags [.], ack 766569, win 32768, options [nop,nop,TS val 1253344117 ecr 1001976765], length 0
11:12:35.685717 IP 1.1.11.4.41668 > 2.2.2.2.1000: Flags [.], ack 766569, win 32768, options [nop,nop,TS val 1253344117 ecr 1001976765], length 0
```
I analyzed it and found I had fault on `CaptureEndpoint::get_timestamp_us()`.
I didn't consider the overflow possibility properly.
Now, with this change, it will be freed from the overflow possibility.

@hhaim, please give your feedback.