### PR TITLE
remove irrelevant sync_threads_stats() call

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -7412,7 +7412,6 @@ COLD_FUNC int TrexDpdkPlatformApi::get_mbuf_util(Json::Value &mbuf_pool) const {
 }
 
 COLD_FUNC int TrexDpdkPlatformApi::get_pgid_stats(Json::Value &json, std::vector<uint32_t> pgids) const {
-    g_trex.sync_threads_stats();
     CFlowStatRuleMgr::instance()->dump_json(json, pgids);
     return 0;
 }


### PR DESCRIPTION
Hi, this is the change from the suggestion at #885.

I think this change will improve the response time of the `get_pgid_stats` request.

@hhaim please check this change and give your feedback.