### PR TITLE
ASTF can generate a single flow on multiple cores

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -1578,7 +1578,7 @@ class ASTFTCPClientTemplate(_ASTFClientTemplate):
      """
 
     def __init__(self, ip_gen, cluster=ASTFCluster(), program=None,
-                 port=80, cps=1, glob_info=None,limit=None,cont=None):
+                 port=80, cps=1, glob_info=None,limit=None,cont=None,core_base=None):
         """
 
         :parameters:
@@ -1603,6 +1603,10 @@ class ASTFTCPClientTemplate(_ASTFClientTemplate):
                   cont     : bool
                         try to keep the number of flows up to limit.
 
+                  core_base : uint16_t
+                        preferred core base hint when limit value is less than the number of cores.
+                        default is pseudo random value.
+
                   glob_info : ASTFGlobalInfoPerTemplate see :class:`trex.astf.trex_astf_global_info.ASTFGlobalInfoPerTemplate`
         """
 
@@ -1611,6 +1615,7 @@ class ASTFTCPClientTemplate(_ASTFClientTemplate):
                      {"name": "cluster", 'arg': cluster, "t": ASTFCluster, "must": False},
                      {"name": "limit", 'arg': limit, "t": int, "must": False},
                      {"name": "cont", 'arg': cont, "t": bool, "must": False},
+                     {"name": "core_base", 'arg': core_base, "t": int, "must": False},
                      {"name": "glob_info", 'arg': glob_info, "t": ASTFGlobalInfoPerTemplate, "must": False},
                      {"name": "program", 'arg': program, "t": ASTFProgram}]
                     }
@@ -1625,6 +1630,8 @@ class ASTFTCPClientTemplate(_ASTFClientTemplate):
             self.fields['limit'] = limit
             if cont:
                 self.fields['cont'] = cont
+            if core_base:
+                self.fields['core_base'] = core_base
 
     def to_json(self):
         ret = super(ASTFTCPClientTemplate, self).to_json()

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -659,6 +659,7 @@ private:
     starting from tg_id = 1,2... . Remember that tg_id = 0 is unnamed */
 
     double m_factor; /* initial multiplier factor */
+    uint16_t m_core_base; /* preferred core base hint for the limited flow distribution */
 
     std::unordered_map<uint16_t,CTupleGeneratorSmart*> m_smart_gen;
 public:

--- a/src/utils/utl_split.h
+++ b/src/utils/utl_split.h
@@ -31,11 +31,8 @@ inline uint32_t utl_split_int(uint32_t val,
     assert(thread_id<num_threads);
     uint32_t s=val/num_threads;
     uint32_t m=val%num_threads;
-    if (thread_id==0) {
-        s+=m;
-    }
-    if (s==0) {
-        s=1;
+    if (thread_id<m) {
+        s+=1;
     }
     return(s);
 }


### PR DESCRIPTION
Hi, this change allows the generation of the limited flow on multiple cores in the ASTF profile.

In the current implementation, when the number of the limited flow is less than cores, core 0 will generate the given number of flows and other cores will also generate additional flows. It results in surplus flow generation.

This change will generate the exact number of limited flows. Some cores will not generate any flow for the template.
If the limit number is 2 with 4 cores, one of the cores will generate 1 flow and the other 3 cores will not generate any flow.
In addition, thanks to the source port distribution of the software RSS, there is no need to add dummy IPs over the limited number of flows. This change removes the restriction also.

When there are multiple profiles run simultaneously, the flow generations may be done at lower cores only. This change also varies the running core of profiles.

@hhaim please review my changes and give your feedback.