### PR TITLE
ASTF profile parsing at CP core by user control

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -386,6 +386,10 @@ def decode_tunables (tunable_str):
         val = m.group(2)           # string
         if val.startswith(("'", '"')) and val.endswith(("'", '"')) and len(val) > 1: # need to remove the quotes from value
             val = val[1:-1]
+        elif val.lower() in ('true', 'on', 'yes'): # bool(True)
+            val = True
+        elif val.lower() in ('false', 'off', 'no'): # bool(False)
+            val = False
         elif val.startswith('0x'): # hex
             val = int(val, 16)
         else:

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -1734,9 +1734,11 @@ TrexRpcCmdCancelAsyncTask::_run(const Json::Value &params, Json::Value &result) 
  */
 trex_rpc_cmd_rc_e
 TrexRpcCmdSetGlobalCfg::_run(const Json::Value &params, Json::Value &result) {
-    double max_stretch = parse_double(params, "sched_max_stretch", result, -1.0);
-    if (max_stretch >= 0.0) {
-        CGlobalInfo::m_burst_offset_dtime = max_stretch;
+    if (params["sched_max_stretch"] != Json::Value::null) {
+        CGlobalInfo::m_burst_offset_dtime = parse_double(params, "sched_max_stretch", result);
+    }
+    if (params["process_at_cp"] != Json::Value::null) {
+        CGlobalInfo::m_process_at_cp = parse_bool(params, "process_at_cp", result);
     }
     return (TREX_RPC_CMD_OK);
 }
@@ -1746,6 +1748,7 @@ TrexRpcCmdGetGlobalCfg::_run(const Json::Value &params, Json::Value &result) {
     Json::Value &section = result["result"];
 
     section["sched_max_stretch"] = CGlobalInfo::m_burst_offset_dtime;
+    section["process_at_cp"] = CGlobalInfo::m_process_at_cp;
 
     return (TREX_RPC_CMD_OK);
 }

--- a/src/trex_global.cpp
+++ b/src/trex_global.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 CRteMemPool         CGlobalInfo::m_mem_pool[MAX_SOCKETS_SUPPORTED];
 uint32_t            CGlobalInfo::m_nodes_pool_size = 10*1024;
 double              CGlobalInfo::m_burst_offset_dtime;
+bool                CGlobalInfo::m_process_at_cp = false;
 CParserOption       CGlobalInfo::m_options;
 CGlobalMemory       CGlobalInfo::m_memory_cfg;
 CPlatformSocketInfo CGlobalInfo::m_socket;

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -1075,6 +1075,7 @@ public:
     static CRteMemPool       m_mem_pool[MAX_SOCKETS_SUPPORTED];
     static uint32_t              m_nodes_pool_size;
     static double                m_burst_offset_dtime;
+    static bool                  m_process_at_cp;
     static CParserOption         m_options;
     static CGlobalMemory         m_memory_cfg;
     static CPlatformSocketInfo   m_socket;


### PR DESCRIPTION
Hi, this change is to implement the discussion result from #901.

I added `process_at_cp` in `global_cfg` for this feature activation to keep backward compatibility of profile scaling.

@hhaim, please review my changes and give your feedback.