### PR TITLE
fix active flow generation from inactive templates

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1321,7 +1321,8 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
 
     ret->set_tuneables(c_tune, s_tune);
 
-    std::vector<double>  dist;
+    std::vector<double>  dist_cps;
+    std::vector<astf_t_id_t> dist_tids;
 
     ret->set_flow_limited(true);
 
@@ -1343,7 +1344,8 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
         double cps = cps_factor (c_temp["cps"].asDouble() / max_threads);
         template_ro.m_k_cps = cps;
         if (cps) {
-            dist.push_back(cps);
+            dist_cps.push_back(cps);
+            dist_tids.push_back(index);
         }
         template_ro.m_destination_port = c_temp["port"].asInt();
         template_ro.m_stream = get_emul_stream(c_temp["program_index"].asInt());
@@ -1390,7 +1392,7 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
     }
 
     /* init scheduler */
-    ret->init_scheduler(dist);
+    ret->init_scheduler(dist_cps, dist_tids);
 
     m_rw_db.push_back(ret);
 

--- a/src/astf/astf_template_db.cpp
+++ b/src/astf/astf_template_db.cpp
@@ -90,8 +90,9 @@ void CAstfTemplatesRW::Dump(FILE *fd) {
 }
 
 
-void CAstfTemplatesRW::init_scheduler(std::vector<double> & dist){
-    m_nru =new KxuNuRand(dist,&m_rnd);
+void CAstfTemplatesRW::init_scheduler(std::vector<double> & cps, std::vector<astf_t_id_t> & tids){
+    m_nru =new KxuNuRand(cps,&m_rnd);
+    m_dist_tids = tids;
 }
 
 void CAstfTemplatesRW::add_tg_id_dist(uint16_t tg_id, astf_t_id_t tid){
@@ -109,7 +110,7 @@ uint16_t CAstfTemplatesRW::do_schedule_template(uint16_t tg_id){
         auto& tids = m_tg_ids[tg_id-1];
         return tids[m_rnd.getRandom() % tids.size()];
     }
-    return ((uint16_t)m_nru->getRandom());
+    return m_dist_tids[(uint16_t)m_nru->getRandom()];
 }
 
 

--- a/src/astf/astf_template_db.h
+++ b/src/astf/astf_template_db.h
@@ -146,7 +146,7 @@ public:
     void Dump(FILE *fd);
     void add_template(CAstfPerTemplateRW *temp_rw) {m_cap_gen.push_back(temp_rw);}
     uint16_t get_num_templates() {return m_cap_gen.size();}
-    void init_scheduler(std::vector<double> & dist);
+    void init_scheduler(std::vector<double> & cps, std::vector<astf_t_id_t> & tids);
     uint16_t do_schedule_template(uint16_t tg_id);
     CTcpTuneables *get_c_tuneables() {return m_c_tuneables;}
     CTcpTuneables *get_s_tuneables() {return m_s_tuneables;}
@@ -180,6 +180,7 @@ private:
     CTcpTuneables *                   m_c_tuneables;
     bool                              m_flow_limited;
     std::vector<std::vector<astf_t_id_t>>   m_tg_ids;
+    std::vector<astf_t_id_t>          m_dist_tids;
 } ;
 
 


### PR DESCRIPTION
Hi, this PR is to remove the flow generation possibility from inactive templates in generate_flow().
When an inactive template is placed before active templates, generate_flow() will generate new flows from the inactive template.
And last active template won't generate new flows. This change will fix this issue.

@hhaim please review this change and give your feedback.
