### PR TITLE
improve STL flow latency error counters

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -224,6 +224,7 @@ enum {
        OPT_HDRH,
        OPT_BNXT_SO,
        OPT_DISABLE_IEEE_1588,
+       OPT_LATENCY_DIAG,
 
        /* no more pass this */
        OPT_MAX
@@ -322,6 +323,7 @@ static CSimpleOpt::SOption parser_options[] =
         { OPT_SLEEPY_SCHEDULER,       "--sleeps",          SO_NONE},
         { OPT_BNXT_SO,                "--bnxt-so",         SO_NONE},
         { OPT_DISABLE_IEEE_1588,      "--disable-ieee-1588", SO_NONE},
+        { OPT_LATENCY_DIAG,           "--latency-diag", SO_NONE},
 
         SO_END_OF_OPTIONS
     };
@@ -426,6 +428,8 @@ static int COLD_FUNC  usage() {
     printf(" --disable-ieee-1588        : Enable Latency Measurement using HW timestamping and DPDK APIs. Currently works only for Stateless mode. \n");
     printf("                              Need to Enable COMPILE time DPDK config RTE_LIBRTE_IEEE1588 inorder to use this feature \n");
     printf("                              Uses PTP (IEEE 1588v2) Protocol to have the packets timestamped at NIC \n");
+    printf(" --latency-diag             : STL flow latency counts all duplicated packets with more CPU load consumption.\n");
+    printf("                              To see the duplicated packets, please use -v 7.\n");
 
     printf("\n");
     printf(" Examples: ");
@@ -960,6 +964,9 @@ COLD_FUNC static int parse_options(int argc, char *argv[], bool first_time ) {
                 break;
             case OPT_DISABLE_IEEE_1588:
                 po->preview.setLatencyIEEE1588Disable(true);
+                break;
+            case OPT_LATENCY_DIAG:
+                po->preview.set_latency_diag(true);
                 break;
 
             default:

--- a/src/stx/common/trex_latency_counters.h
+++ b/src/stx/common/trex_latency_counters.h
@@ -68,6 +68,7 @@ class CRFC2544Info {
         bool empty() const { return size() == 0 || size() == m_seq_cnt; }
         bool includes(uint32_t seq) const { return seq >= m_begin && seq <= m_end; }
         bool has_map() const { return !m_seq_map.empty(); }
+        int dropped_cnt() const { return has_map() ? size() - m_seq_cnt: size(); }
 
         bool is_border(uint32_t seq) const { return seq == m_begin || seq == m_end; }
         bool is_split(uint32_t seq) const { return !has_map() && !is_border(seq); }
@@ -78,8 +79,11 @@ class CRFC2544Info {
         bool set_seq(uint32_t seq);
     };
 
+#define MAX_SEQBLKS     10000
     std::map<uint32_t,SeqBlk> m_seqblks;
     uint32_t m_seqblk_base;
+    uint32_t m_drop_refseq;
+    uint32_t m_drop_refcnt;
 
 #define CHECK_BLK_SIZE  0x1000000
     void prune_old_seqblks(uint32_t cur_seq);

--- a/src/stx/common/trex_latency_counters.h
+++ b/src/stx/common/trex_latency_counters.h
@@ -36,6 +36,10 @@ class CRFC2544Info {
     CRFC2544Info operator+= (const CRFC2544Info& in);
     friend std::ostream& operator<<(std::ostream& os, const CRFC2544Info& in);
 
+    void add_seqblk(uint32_t begin, uint32_t end);
+    bool set_seqblk_seq(uint32_t seq);
+    void check_seqblks();
+
  private:
     uint32_t m_seq; // expected next seq num
     CTimeHistogram  m_latency; // latency info
@@ -48,6 +52,37 @@ class CRFC2544Info {
     uint16_t m_exp_flow_seq; // flow sequence number we should see in latency header
     // flow sequence number previously used with this id. We use this to catch packets arriving late from an old flow
     uint16_t m_prev_flow_seq;
+
+    // to check duplicated packet exactly
+    class SeqBlk {
+        uint32_t m_begin;
+        uint32_t m_end;
+        std::vector<bool> m_seq_map;
+        int m_seq_cnt;
+
+    public:
+        SeqBlk(uint32_t begin, uint32_t end): m_begin(begin), m_end(end), m_seq_cnt(0) {
+            assert(begin <= end);
+        }
+        int size() const { return m_end - m_begin + 1; }
+        bool empty() const { return size() == 0 || size() == m_seq_cnt; }
+        bool includes(uint32_t seq) const { return seq >= m_begin && seq <= m_end; }
+        bool has_map() const { return !m_seq_map.empty(); }
+
+        bool is_border(uint32_t seq) const { return seq == m_begin || seq == m_end; }
+        bool is_split(uint32_t seq) const { return !has_map() && !is_border(seq); }
+        uint32_t get_end() const { return m_end; }
+        void set_end(uint32_t end) { assert(!has_map()); m_end = end; }
+
+        bool set_map(uint32_t seq);
+        bool set_seq(uint32_t seq);
+    };
+
+    std::map<uint32_t,SeqBlk> m_seqblks;
+    uint32_t m_seqblk_base;
+
+#define CHECK_BLK_SIZE  0x1000000
+    void prune_old_seqblks(uint32_t cur_seq);
 };
 
 std::ostream& operator<<(std::ostream& os, const CRFC2544Info& in);
@@ -197,6 +232,9 @@ public:
     bool                  m_dump_err_pkts;
     const rte_mbuf_t     *m_dump_pkt;
     struct flow_stat_payload_header *m_dump_fsp_head;
+
+    // to be aware of interleaved duplicated packets
+    bool                  m_diag_dup_pkts;
 };
 
 std::ostream& operator<<(std::ostream& os, const RXLatency& in);

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -455,6 +455,14 @@ public:
         return (btGetMaskBit32(m_flags1, 25, 25) ? true : false);
     }
 
+    void set_latency_diag(bool enable) {
+        btSetMaskBit32(m_flags1, 26, 26, (enable ? 1 : 0) );
+    }
+
+    bool get_latency_diag() {
+        return (btGetMaskBit32(m_flags1, 26, 26) ? true : false);
+    }
+
 public:
     void Dump(FILE *fd);
 


### PR DESCRIPTION
Hi, this change is to count accurately duplicated packets with the STL flow latency feature.
Until now, when the packet drops and duplications happen in the same flow, the error counters cannot show correct values.
It's because the interleaved duplicated packet reduces the drop counter.
With this change, the counters will show accurate values and the users will know the issue more precisely, drop or duplication problem.
But this feature is quite complicated and consumes more CPU and memory even though there is no duplicated packet.
So, I make it optional which can be activated by `--latency-diag` command line argument.
Users can use this feature when some duplicated packets are suspected on DUT.

@hhaim please review this change and give me your feedback.
