### PR TITLE
ena: use highest link speed

### DIFF
--- a/src/dpdk/drivers/net/ena/ena_ethdev.c
+++ b/src/dpdk/drivers/net/ena/ena_ethdev.c
@@ -926,7 +926,7 @@ static int ena_link_update(struct rte_eth_dev *dev,
 	struct ena_adapter *adapter = dev->data->dev_private;
 
 	link->link_status = adapter->link_status ? RTE_ETH_LINK_UP : RTE_ETH_LINK_DOWN;
-	link->link_speed = RTE_ETH_LINK_SPEED_50G;
+	link->link_speed = RTE_ETH_LINK_SPEED_100G;
 	link->link_duplex = RTE_ETH_LINK_FULL_DUPLEX;
 
 	return 0;


### PR DESCRIPTION
TRex needs valid speed which is 50G in ENA. However, the highest capability of ENA devices is 100G while the generating speed is limited to 50G. So change the link speed to 100G.

Signed-off-by: Xiaoyun Li <xiaoyun.li@intel.com>