### PR TITLE
enable net_iavf driver for E810 SRIO-VF support

### DIFF
--- a/src/dpdk/drivers/net/iavf/iavf_ethdev.c
+++ b/src/dpdk/drivers/net/iavf/iavf_ethdev.c
@@ -136,10 +136,12 @@ static int iavf_tm_ops_get(struct rte_eth_dev *dev __rte_unused, void *arg);
 
 static const struct rte_pci_id pci_id_iavf_map[] = {
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_ADAPTIVE_VF) },
+#ifndef TREX_PATCH  /* pci_id_i40evf_map */
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_VF) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_VF_HV) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_X722_VF) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_X722_A0_VF) },
+#endif
 	{ .vendor_id = 0, /* sentinel */ },
 };
 
@@ -2739,12 +2741,10 @@ static struct rte_pci_driver rte_iavf_pmd = {
 	.probe = eth_iavf_pci_probe,
 	.remove = eth_iavf_pci_remove,
 };
-#ifndef TREX_PATCH
 RTE_PMD_REGISTER_PCI(net_iavf, rte_iavf_pmd);
 RTE_PMD_REGISTER_PCI_TABLE(net_iavf, pci_id_iavf_map);
 RTE_PMD_REGISTER_KMOD_DEP(net_iavf, "* igb_uio | vfio-pci");
 RTE_PMD_REGISTER_PARAM_STRING(net_iavf, "cap=dcf");
-#endif
 RTE_LOG_REGISTER_SUFFIX(iavf_logtype_init, init, NOTICE);
 RTE_LOG_REGISTER_SUFFIX(iavf_logtype_driver, driver, NOTICE);
 #ifdef RTE_ETHDEV_DEBUG_RX

--- a/src/drivers/trex_driver_base.cpp
+++ b/src/drivers/trex_driver_base.cpp
@@ -149,7 +149,8 @@ CTRexExtendedDriverDb::CTRexExtendedDriverDb() {
     register_driver(std::string("net_vmxnet3"), CTRexExtendedDriverVmxnet3::create);
     register_driver(std::string("net_virtio"), CTRexExtendedDriverVirtio::create);
     register_driver(std::string("net_ena"),CTRexExtendedDriverVirtio::create);
-    register_driver(std::string("net_i40e_vf"), CTRexExtendedDriverI40evf::create);
+    register_driver(std::string("net_iavf"), CTRexExtendedDriverIavf::create);
+    register_driver(std::string("net_i40e_vf"), CTRexExtendedDriverIavf::create);
     register_driver(std::string("net_ixgbe_vf"), CTRexExtendedDriverIxgbevf::create);
     register_driver(std::string("net_netvsc"), CTRexExtendedDriverNetvsc::create);
     register_driver(std::string("net_bonding"), CTRexExtendedDriverBonding::create);

--- a/src/drivers/trex_driver_virtual.cpp
+++ b/src/drivers/trex_driver_virtual.cpp
@@ -33,7 +33,7 @@ TRexPortAttr* CTRexExtendedDriverVirtBase::create_port_attr(tvpid_t tvpid, repid
     return new DpdkTRexPortAttr(tvpid, repid, true, true, true, false, true);
 }
 
-TRexPortAttr* CTRexExtendedDriverI40evf::create_port_attr(tvpid_t tvpid, repid_t repid) {
+TRexPortAttr* CTRexExtendedDriverIavf::create_port_attr(tvpid_t tvpid, repid_t repid) {
     return new DpdkTRexPortAttr(tvpid, repid, true, true, false, false, true);
 }
 
@@ -202,11 +202,11 @@ void CTRexExtendedDriverMemif::update_configuration(port_cfg_t * cfg){
 
 ///////////////////////////////////////////////////////// VF
 
-CTRexExtendedDriverI40evf::CTRexExtendedDriverI40evf() {
+CTRexExtendedDriverIavf::CTRexExtendedDriverIavf() {
     m_cap = tdCAP_ONE_QUE | tdCAP_MULTI_QUE;
 }
 
-void CTRexExtendedDriverI40evf::update_configuration(port_cfg_t * cfg) {
+void CTRexExtendedDriverIavf::update_configuration(port_cfg_t * cfg) {
     CTRexExtendedDriverVirtBase::update_configuration(cfg);
     cfg->m_tx_conf.tx_thresh.pthresh = TX_PTHRESH;
     cfg->m_tx_conf.tx_thresh.hthresh = TX_HTHRESH;

--- a/src/drivers/trex_driver_virtual.h
+++ b/src/drivers/trex_driver_virtual.h
@@ -71,20 +71,20 @@ public:
 
 };
 
-class CTRexExtendedDriverI40evf : public CTRexExtendedDriverVirtBase {
+class CTRexExtendedDriverIavf : public CTRexExtendedDriverVirtBase {
 public:
-    CTRexExtendedDriverI40evf();
+    CTRexExtendedDriverIavf();
     virtual bool get_extended_stats(CPhyEthIF * _if, CPhyEthIFStats *stats) {
         return get_extended_stats_fixed(_if, stats, 4, 4);
     }
     virtual void update_configuration(port_cfg_t * cfg);
     static CTRexExtendedDriverBase * create() {
-        return ( new CTRexExtendedDriverI40evf() );
+        return ( new CTRexExtendedDriverIavf() );
     }
     virtual TRexPortAttr* create_port_attr(tvpid_t tvpid,repid_t repid);
 };
 
-class CTRexExtendedDriverIxgbevf : public CTRexExtendedDriverI40evf {
+class CTRexExtendedDriverIxgbevf : public CTRexExtendedDriverIavf {
 
 public:
     CTRexExtendedDriverIxgbevf();


### PR DESCRIPTION
Hi, this PR is to enable the IAVF driver for E810 SRIO-VF support as I suggested at #861.

@hhaim please review my change.