### PR TITLE
IPv6Header: fix FlowLabel field size

### DIFF
--- a/src/common/Network/Packet/IPv6Header.h
+++ b/src/common/Network/Packet/IPv6Header.h
@@ -205,13 +205,13 @@ IPv6Header::setTrafficClass(uint16_t argTrafficClass)
 //--------------------------------
 inline uint32_t IPv6Header::getFlowLabel()
 {
-    return  getMaskBit32(PKT_NTOHL(myVer_TrafficClass_FlowLabel), 12, 31);
+    return  getMaskBit32(PKT_NTOHL(myVer_TrafficClass_FlowLabel), 20, 31);
 }
 
 inline void  IPv6Header::setFlowLabel(uint32_t argFlowLabel)
 {
     uint32_t myFlowLabel = PKT_HTONL(myVer_TrafficClass_FlowLabel);
-    setMaskBit32(myFlowLabel, 12, 31, argFlowLabel);
+    setMaskBit32(myFlowLabel, 20, 31, argFlowLabel);
     myVer_TrafficClass_FlowLabel = PKT_NTOHL(myFlowLabel);
 }
 


### PR DESCRIPTION
following the RFC6437 [1] flow lable from IPv6 is a 20 bits field, this is setting the correct number of bits for both setter and getter in the ipv6 header

[1] https://www.rfc-editor.org/rfc/rfc6437

Signed-off-by: Raslan Darawsheh <rasland@nvidia.com>