### PR TITLE
Fix Scapy ctypes usage with Python 3.9

### DIFF
--- a/scripts/external_libs/scapy-2.4.3/scapy/arch/bpf/core.py
+++ b/scripts/external_libs/scapy-2.4.3/scapy/arch/bpf/core.py
@@ -28,7 +28,7 @@ from scapy.modules.six.moves import range
 
 # ctypes definitions
 
-LIBC = cdll.LoadLibrary(find_library("libc"))
+LIBC = cdll.LoadLibrary(find_library("c"))
 LIBC.ioctl.argtypes = [c_int, c_ulong, c_char_p]
 LIBC.ioctl.restype = c_int
 


### PR DESCRIPTION
The embedded version of Scapy is using `find_library("libc")` which is incorrect. This does not work anymore with Python 3.9. This should use `find_library("c")` instead (which also works for older versions). See https://github.com/secdev/scapy/pull/3000 for more details.

Anoher option would be to upgrade Scapy to 2.4.5, where this bug is fixed.

Signed-off-by: Vincent Bernat <vincent@bernat.ch>