### PR TITLE
ASTF extends STL feature

### DIFF
--- a/doc/trex_astf.asciidoc
+++ b/doc/trex_astf.asciidoc
@@ -230,6 +230,18 @@ The client side of TRex server is responsible to the encapsulation/decapsulation
 * Loopback mode - from version v2.93 TRex supports loopback mode for testing without DUT - the server side is aware to the GTPU mode and decapsulates the client packets, and learns the tunnel context. When transmitting, the server encapsulates the packets with the same tunnel context. +
 * More than 2 ports support - from version v2.93 TRex supports more than 2 ports in GTPU mode.
 
+==== Stateless profile support
+
+The stateless profile can be used on ASTF mode with the following limitations.
+
+* TCP header packet is not supported.
+* The UDP flow in stateless profile should not be handled by ASTF. When the received UDP packet is matched to ASTF UDP flow, it will not be handled by the stateless profile.
+* HW flow statistics is not supported due to the conflits with ASTF HW RSS.
+* The performance will be less than original stateless mode.
+* TPG is not supported yet.
+
+* start/update/stop cannot be used for the stateless profile. Instead, start_stl/update_stl/stop_stl should be used.
+
 
 
 === ASTF package folders 

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -17,6 +17,8 @@ from ..common.trex_exceptions import TRexError, TRexTimeoutError
 from ..common.trex_types import *
 from ..common.trex_types import DEFAULT_PROFILE_ID, ALL_PROFILE_ID
 
+from ..stl.trex_stl_client import STLClient
+
 from .trex_astf_port import ASTFPort
 from .trex_astf_profile import ASTFProfile
 from .topo import ASTFTopologyManager
@@ -44,7 +46,7 @@ class Tunnel:
         self.teid     = teid
         self.version  = version
 
-class ASTFClient(TRexClient):
+class ASTFClient(STLClient):
     port_states = [getattr(ASTFPort, state, 0) for state in astf_states]
 
     def __init__(self,
@@ -122,6 +124,8 @@ class ASTFClient(TRexClient):
         self.astf_profile_state = {'_': 0}
         self.profile_state_change = {}
 
+        STLClient.init(self)
+
     def get_mode(self):
         return "ASTF"
 
@@ -156,6 +160,7 @@ class ASTFClient(TRexClient):
         with self.ctx.logger.suppress(verbose = "warning"):
             self.clear_stats(ports = self.get_all_ports(), clear_xstats = False, clear_traffic = False)
             self.clear_dynamic_traffic_stats()
+            self.clear_pgid_stats(clear_flow_stats=True, clear_latency_stats=True)
         return RC_OK()
 
     def _on_astf_state_chg(self, ctx_state, error, epoch):
@@ -421,6 +426,11 @@ class ASTFClient(TRexClient):
             with self.ctx.logger.suppress():
             # force take the port and ignore any streams on it
                 self.acquire(force = True)
+
+                # clear STL first
+                self.clear_stl_profiles(ports)
+                self.clear_pgid_stats(clear_flow_stats=True, clear_latency_stats=True)
+
                 self.stop(False, pid_input=ALL_PROFILE_ID)
                 self.check_states(ok_states=[self.STATE_ASTF_LOADED, self.STATE_IDLE])
                 self.stop_latency()
@@ -941,6 +951,8 @@ class ASTFClient(TRexClient):
             TRexClient.wait_on_traffic(self, ports, timeout)
         else:
             self.wait_for_profile_state(profile_id, self.STATE_ASTF_LOADED, timeout)
+
+    wait_on_traffic_stl = client_api('commnad', True)(STLClient.wait_on_traffic)
 
     # get stats
     @client_api('getter', True)
@@ -1986,6 +1998,9 @@ class ASTFClient(TRexClient):
         elif opts.stats == 'latency_counters':
             self._show_latency_counters()
 
+        elif opts.stats == 'streams': # STLClient
+            self._show_streams_stats()
+
         else:
             raise TRexError('Unhandled stat: %s' % opts.stats)
 
@@ -2087,6 +2102,8 @@ class ASTFClient(TRexClient):
             self.logger.info(format_text("No profiles found with desired filter.\n", "bold", "magenta"))
 
         text_tables.print_table_with_header(table, header = 'Profile states')
+
+        STLClient.profiles_line(self, line)
 
 
     @console_api('update_tunnel', 'ASTF', True)
@@ -2205,3 +2222,9 @@ class ASTFClient(TRexClient):
 
         else:
             raise TRexError('Unhandled command %s' % opts.command)
+
+    # rename STL console commands
+    start_stl_line = console_api('start_stl', 'STL', True)(STLClient.start_line)
+    stop_stl_line = console_api('stop_stl', 'STL', True)(STLClient.stop_line)
+    update_stl_line = console_api('update_stl', 'STL', True)(STLClient.update_line)
+    stats_stl_line = console_api('stats_stl', 'STL', True)(STLClient.show_stats_line)

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_port.py
@@ -1,10 +1,11 @@
 
 from .topo import ASTFTopology
 from ..common.trex_port import Port
+from ..stl.trex_stl_port import STLPort
 
-class ASTFPort(Port):
+class ASTFPort(STLPort):
     def __init__(self, *a, **k):
-        Port.__init__(self, *a, **k)
+        STLPort.__init__(self, *a, **k)
         self.topo = ASTFTopology()
         self.service_mode          = False
         self.service_mode_filtered = False

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_port.py
@@ -31,7 +31,7 @@ class STLPort(Port):
 
     MASK_ALL = ((1 << 64) - 1)
 
-    def __init__ (self, ctx, port_id, rpc, info, dynamic):
+    def __init__ (self, ctx, port_id, rpc, info, dynamic = True):
         Port.__init__(self, ctx, port_id, rpc, info)
 
         self.has_rx_streams = False

--- a/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/parsing_opts.py
@@ -2005,6 +2005,7 @@ class OPTIONS_DB_GROUPS:
             EXTENDED_INC_ZERO_STATS,
             ASTF_STATS,
             ASTF_INC_ZERO_STATS,
+            STREAMS_STATS,
         ],
         {})
 

--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -152,6 +152,7 @@ void CFlowTable::parse_packet(struct rte_mbuf * mbuf,
          (parser.m_protocol != IPHeader::Protocol::UDP) ){
         FT_INC_SCNT(m_err_no_tcp_udp);
         action=tREDIRECT_RX_CORE;
+        parser.m_protocol = 0;
         return;
     }
     /* TCP/UDP, only supported right now */
@@ -651,6 +652,19 @@ bool CFlowTable::ignore_packet(CTcpPerThreadCtx * ctx,
     return false;
 }
 
+bool CFlowTable::rx_handle_stateless_packet(CTcpPerThreadCtx * ctx,
+                                            struct rte_mbuf * mbuf){
+    TrexStatelessDpCore* dp_core = (TrexStatelessDpCore*)ctx->m_thread->get_dp_core();
+    if (!dp_core->is_feature_set(TrexStatelessDpCore::LATENCY))
+        return false;
+
+    RXLatency* fs_latency = dp_core->get_fs_latency_object_ptr(!m_client_side);
+
+    fs_latency->handle_pkt(mbuf, 0);
+
+    return true;
+}
+
 bool CFlowTable::rx_handle_packet_udp_no_flow(CTcpPerThreadCtx * ctx,
                                               struct rte_mbuf * mbuf,
                                               flow_hash_ent_t * lpflow,
@@ -667,6 +681,7 @@ bool CFlowTable::rx_handle_packet_udp_no_flow(CTcpPerThreadCtx * ctx,
 
     /* not found in flowtable , we are generating the flows*/
     if ( m_client_side ){
+        rx_handle_stateless_packet(ctx, mbuf);
         FT_INC_SCNT(m_err_client_pkt_without_flow);
         rte_pktmbuf_free(mbuf);
         return(false);
@@ -696,6 +711,7 @@ bool CFlowTable::rx_handle_packet_udp_no_flow(CTcpPerThreadCtx * ctx,
     uint16_t dst_port = lpUDP->getDestPort();
 
     if (!ctx->is_any_profile()) {
+        rx_handle_stateless_packet(ctx, mbuf);
         rte_pktmbuf_free(mbuf);
         FT_INC_SCNT(m_err_no_template);
         return(false);
@@ -711,6 +727,9 @@ bool CFlowTable::rx_handle_packet_udp_no_flow(CTcpPerThreadCtx * ctx,
     CTcpServerInfo *server_info = temp ? temp->get_server_info(): nullptr;
 
     if (!server_info || !pctx->is_open_flow_allowed()){
+        if (!server_info) {
+            rx_handle_stateless_packet(ctx, mbuf);
+        }
         rte_pktmbuf_free(mbuf);
         FT_INC_SCNT(m_err_no_template);
         return(false);
@@ -1226,6 +1245,9 @@ HOT_FUNC bool CFlowTable::rx_handle_packet(CTcpPerThreadCtx * ctx,
     }
 
     if ( action != tPROCESS ) {
+        if (action != tDROP && !parser.m_protocol) {
+            rx_handle_stateless_packet(ctx, mbuf);
+        }
         rx_non_process_packet(action, ctx, mbuf);
         return false;
     }

--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -325,7 +325,8 @@ public:
                                         );
 
       bool rx_handle_stateless_packet(CTcpPerThreadCtx * ctx,
-                                      struct rte_mbuf * mbuf);
+                                      struct rte_mbuf * mbuf,
+                                      tvpid_t port_id);
 
       bool rx_handle_packet(CTcpPerThreadCtx * ctx,
                             struct rte_mbuf * mbuf,

--- a/src/44bsd/flow_table.h
+++ b/src/44bsd/flow_table.h
@@ -324,6 +324,9 @@ public:
                                         tvpid_t port_id
                                         );
 
+      bool rx_handle_stateless_packet(CTcpPerThreadCtx * ctx,
+                                      struct rte_mbuf * mbuf);
+
       bool rx_handle_packet(CTcpPerThreadCtx * ctx,
                             struct rte_mbuf * mbuf,
                             bool is_idle,

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -545,13 +545,6 @@ class CCapFileFlowInfo ;
    we are optimizing the allocation dealocation !!!
  */
 
-struct CNodeTcp {
-     double       sim_time;
-     rte_mbuf_t * mbuf;
-     uint8_t      dir;
-};
-
-
 struct CGenNodeBase  {
 public:
 
@@ -652,6 +645,13 @@ public:
             return (false);
         }
     }
+};
+
+
+struct CNodeTcp: public CGenNodeBase {
+     double       sim_time;
+     rte_mbuf_t * mbuf;
+     uint8_t      dir;
 };
 
 

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -105,6 +105,7 @@ int CTcpIOCb::on_tx(CTcpPerThreadCtx *ctx,
                       struct CTcpCb * tp,
                       rte_mbuf_t *m){
     CNodeTcp node_tcp;
+    node_tcp.m_type = 0xFF;
     node_tcp.dir  = m_dir;
     node_tcp.mbuf = m;
 #ifdef TREX_SIM

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,7 @@ const char *get_exe_name() {
     return g_exe_name;
 }
 
-static void set_sw_mode(){
+void set_sw_mode(){
     get_mode()->choose_mode(tdCAP_ONE_QUE);
     get_mode()->force_software_mode(true);
 }
@@ -423,6 +423,8 @@ int main(int argc , char * argv[]){
     case OPT_TYPE_GTEST:
         {
             SimGtest test;
+            set_op_mode(OP_MODE_STL);
+            set_sw_mode();
             return test.run(argc, argv);
         }
 

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4090,6 +4090,8 @@ COLD_FUNC void CGlobalTRex::init_astf() {
     rx_interactive_conf();
     m_stx = new TrexAstf(get_stx_cfg());
     start_master_astf();
+
+    init_stl_stats();
 }
 
 

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4059,7 +4059,7 @@ COLD_FUNC void CGlobalTRex::init_stl() {
 }
 
 COLD_FUNC void CGlobalTRex::init_stl_stats() {
-    if (get_dpdk_mode()->dp_rx_queues()) {
+    if (get_dpdk_mode()->dp_rx_queues() || get_is_tcp_mode()) {
         std::vector<TrexStatelessDpCore*> dp_core_ptrs;
         for (int thread_id = 0; thread_id < (int)m_fl.m_threads_info.size(); thread_id++) {
             TrexStatelessDpCore* stl_dp_core = (TrexStatelessDpCore*)m_fl.m_threads_info[thread_id]->get_dp_core();

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -1783,7 +1783,7 @@ public:
     uint16_t     m_rx_queue_id[CS_NUM]; 
 };
 
-class CCoreEthIFTcp : public CCoreEthIF {
+class CCoreEthIFTcp : public CCoreEthIFStateless {
 public:
     CCoreEthIFTcp() {
         m_rx_queue_id[CLIENT_SIDE]=0xffff;
@@ -1800,6 +1800,7 @@ public:
 
     void set_rx_queue_id(uint16_t client_qid,
                          uint16_t server_qid){
+        CCoreEthIFStateless::set_rx_queue_id(client_qid, server_qid);
         m_rx_queue_id[CLIENT_SIDE]=client_qid;
         m_rx_queue_id[SERVER_SIDE]=server_qid;
     }
@@ -2126,6 +2127,9 @@ HOT_FUNC uint16_t CCoreEthIFTcp::rx_burst(pkt_dir_t dir,
 
 
 HOT_FUNC int CCoreEthIFTcp::send_node(CGenNode *node){
+    if (unlikely(node->m_type == CGenNode::STATELESS_PKT)) {
+        return CCoreEthIFStateless::send_node_service_mode(node);
+    }
     CNodeTcp * node_tcp = (CNodeTcp *) node;
     uint8_t dir=node_tcp->dir;
     CCorePerPort *lp_port = &m_ports[dir];

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -5779,6 +5779,11 @@ COLD_FUNC void CPhyEthIF::configure_rss(){
         configure_rss_astf(false,
                            dpdk_p.get_total_rx_queues(),
                            MAIN_DPDK_RX_Q);
+
+        /* disable HW flow statistics on ASTF mode due to conflicts with STL flow stats. */
+        if (get_is_interactive() && !get_is_stateless()) {
+            CGlobalInfo::m_options.preview.set_disable_hw_flow_stat(true);
+        }
     }
 }
 

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #include "trex_astf_messaging.h"
 #include "trex_astf_port.h"
 #include "trex_astf_rpc_cmds.h"
+#include "stl/trex_stl_rpc_cmds.h"
 #include "trex_astf_rx_core.h"
 #include "trex_astf_topo.h"
 
@@ -43,7 +44,7 @@ using namespace std;
 /***********************************************************
  * TrexAstf
  ***********************************************************/
-TrexAstf::TrexAstf(const TrexSTXCfg &cfg) : TrexSTX(cfg) {
+TrexAstf::TrexAstf(const TrexSTXCfg &cfg) : TrexStateless(cfg, true) {
     /* API core version */
     const int API_VER_MAJOR = 2;
     const int API_VER_MINOR = 3;
@@ -111,6 +112,7 @@ TrexAstf::~TrexAstf() {
     for (auto &port_pair : m_ports) {
         delete port_pair.second;
     }
+    m_ports.clear();
 
     delete m_rx;
     delete m_cp_sts_infra;

--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -60,6 +60,7 @@ TrexAstf::TrexAstf(const TrexSTXCfg &cfg) : TrexStateless(cfg, true) {
 
     /* load the RPC components for ASTF */
     rpc_table.load_component(new TrexRpcCmdsCommon());
+    rpc_table.load_component(new TrexRpcCmdsSTL());
     rpc_table.load_component(new TrexRpcCmdsASTF());
     const TrexPlatformApi &api = get_platform_api();
     m_opts = &CGlobalInfo::m_options;

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "common/trex_stx.h"
 #include "trex_astf_defs.h"
 #include "stt_cp.h"
+#include "stl/trex_stl.h"
 
 #include "tunnels/tunnel_factory.h"
 
@@ -229,7 +230,7 @@ private:
 /***********************************************************
  * TRex adavanced stateful interactive object
  ***********************************************************/
-class TrexAstf : public TrexAstfProfile, public TrexSTX {
+class TrexAstf : public TrexAstfProfile, public TrexStateless {
 public:
     enum state_latency_e {
         STATE_L_IDLE,

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -36,7 +36,7 @@ limitations under the License.
 using namespace std;
 
 TrexAstfDpCore::TrexAstfDpCore(uint8_t thread_id, CFlowGenListPerThread *core) :
-                TrexDpCore(thread_id, core, STATE_IDLE) {
+                TrexStatelessDpCore(thread_id, core) {
     CSyncBarrier *sync_barrier = get_astf_object()->get_barrier();
     m_flow_gen = m_core;
     m_flow_gen->set_sync_barrier(sync_barrier);

--- a/src/stx/astf/trex_astf_dp_core.h
+++ b/src/stx/astf/trex_astf_dp_core.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <algorithm>
 #include "trex_astf_mbuf_redirect.h"
 #include "trex_dp_core.h"
+#include "stl/trex_stl_dp_core.h"
 #include "trex_messaging.h"
 #include "tunnels/tunnel_handler.h"
 
@@ -40,7 +41,7 @@ struct profile_param {
     double          m_dump_interval;
 };
 
-class TrexAstfDpCore : public TrexDpCore {
+class TrexAstfDpCore : public TrexStatelessDpCore {
 
 public:
 

--- a/src/stx/astf/trex_astf_port.cpp
+++ b/src/stx/astf/trex_astf_port.cpp
@@ -27,7 +27,7 @@ limitations under the License.
 
 using namespace std;
 
-TrexAstfPort::TrexAstfPort(uint8_t port_id) : TrexPort(port_id) {
+TrexAstfPort::TrexAstfPort(uint8_t port_id) : TrexStatelessPort(port_id) {
     m_is_service_mode_on          = false;
     m_is_service_filtered_mode_on = false;
     m_service_filtered_mask       = 0;

--- a/src/stx/astf/trex_astf_port.cpp
+++ b/src/stx/astf/trex_astf_port.cpp
@@ -37,7 +37,10 @@ TrexAstfPort::~TrexAstfPort() {
 }
 
 void TrexAstfPort::change_state(port_state_e state) {
-    m_port_state = state;
+    if (m_port_state != state) {
+        m_port_state = state;
+        get_astf_object()->publish_astf_state();
+    }
 }
 
 void TrexAstfPort::set_service_mode(bool enabled, bool filtered, uint8_t mask) {

--- a/src/stx/astf/trex_astf_port.h
+++ b/src/stx/astf/trex_astf_port.h
@@ -23,6 +23,7 @@ limitations under the License.
 
 
 #include "trex_port.h"
+#include "stl/trex_stl_port.h"
 
 class CSyncBarrier;
 
@@ -30,7 +31,7 @@ class CSyncBarrier;
  * describes an ASTF port
  *
  */
-class TrexAstfPort : public TrexPort {
+class TrexAstfPort : public TrexStatelessPort {
 
 public:
 

--- a/src/stx/astf/trex_astf_rpc_cmds.cpp
+++ b/src/stx/astf/trex_astf_rpc_cmds.cpp
@@ -337,6 +337,27 @@ TrexRpcCmdAstfProfileList::_run(const Json::Value &params, Json::Value &result) 
         json_profile_list.append(profile_id);
     }
 
+    uint8_t port_cnt = get_astf_object()->get_port_count();
+    for (uint8_t port_id = 0; port_id < port_cnt; port_id++) {
+        TrexStatelessPort *port = get_stateless_obj()->get_port_by_id(port_id);
+        profile_list.clear();
+
+        port->get_profile_id_list(profile_list);
+        Json::Value json_list = Json::arrayValue;
+
+        for (auto &profile_id : profile_list) {
+            json_list.append(profile_id);
+        }
+
+        if (json_list.size()) {
+            Json::Value json_port = Json::objectValue;
+            std::stringstream ss;
+            ss << port_id;
+            json_port[ss.str()] = json_list;
+            json_profile_list.append(json_port);
+        }
+    }
+
     result["result"] = json_profile_list;
 
     return (TREX_RPC_CMD_OK);

--- a/src/stx/common/trex_messaging.cpp
+++ b/src/stx/common/trex_messaging.cpp
@@ -96,7 +96,7 @@ bool
 TrexDpPortEventMsg::handle() {
     TrexPort *port = get_stx()->get_port_by_id(m_port_id);
 
-    if ( get_is_stateless() ) {
+    if ( get_is_interactive() ) {
         TrexStatelessPort *stl_port = (TrexStatelessPort*) port;
         stl_port->get_dp_events(m_profile_id).on_core_reporting_in(m_event_id, m_thread_id, get_status());
     } else {

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -282,7 +282,7 @@ TrexRpcCmdGetPortStatus::_run(const Json::Value &params, Json::Value &result) {
     res["state"]     = port->get_state_as_string();
 
     string profile_id = parse_profile(params, result, "");
-    if ( get_is_stateless() && (profile_id != "") ) {
+    if ( get_is_interactive() && (profile_id != "") ) {
         TrexStatelessPort *stl_port = (TrexStatelessPort*) port;
         Json::Value state_profile =  Json::objectValue;
         stl_port->get_state_as_string(profile_id, state_profile);
@@ -291,7 +291,7 @@ TrexRpcCmdGetPortStatus::_run(const Json::Value &params, Json::Value &result) {
 
     res["service"]       = port->is_service_mode_on();
     res["service_filtered"] = port->is_service_filtered_mode_on();
-    if ( get_is_stateless() ) {
+    if ( get_is_interactive() ) {
         TrexStatelessPort *stl_port = (TrexStatelessPort*) port;
         result["result"]["profile_count"] = stl_port->get_profile_count();
         result["result"]["max_stream_id"] = stl_port->get_max_stream_id();

--- a/src/stx/stl/trex_stl.cpp
+++ b/src/stx/stl/trex_stl.cpp
@@ -188,6 +188,11 @@ TrexStateless::TrexStateless(const TrexSTXCfg &cfg) : TrexSTX(cfg) {
     m_stats = nullptr;
 }
 
+TrexStateless::TrexStateless(const TrexSTXCfg &cfg, bool base) : TrexSTX(cfg) {
+    assert(base);
+    m_stats = nullptr;
+}
+
 
 /** 
  * release all memory

--- a/src/stx/stl/trex_stl.cpp
+++ b/src/stx/stl/trex_stl.cpp
@@ -202,6 +202,7 @@ TrexStateless::TrexStateless(const TrexSTXCfg &cfg, bool base) : TrexSTX(cfg) {
 TrexStateless::~TrexStateless() {
 
     /* release memory for ports */
+    m_dp_core_count = 0;
     for (auto &port : m_ports) {
         delete port.second;
     }
@@ -272,7 +273,7 @@ TrexStateless::publish_async_data() {
 
 void
 TrexStateless::init_stats_multiqueue(const vector<TrexStatelessDpCore*> & dp_core_ptrs) {
-    assert(get_dpdk_mode()->dp_rx_queues());
+    assert(get_dpdk_mode()->dp_rx_queues() || get_is_tcp_mode());
     m_stats = new TrexStatelessMulticoreSoftwareFSLatencyStats(this, dp_core_ptrs);
 }
 

--- a/src/stx/stl/trex_stl.h
+++ b/src/stx/stl/trex_stl.h
@@ -86,6 +86,7 @@ public:
      * create stateless object 
      */
     TrexStateless(const TrexSTXCfg &cfg);
+    TrexStateless(const TrexSTXCfg &cfg, bool base);
     virtual ~TrexStateless();
 
     

--- a/src/stx/stl/trex_stl_dp_core.cpp
+++ b/src/stx/stl/trex_stl_dp_core.cpp
@@ -1732,7 +1732,11 @@ void TrexStatelessDpCore::push_pcap(uint8_t port_id,
         add_port_duration(duration, port_id, 0, event_id);
     }
 
-     m_state = TrexStatelessDpCore::STATE_PCAP_TX;
+    /* TrexAstfDpCore may cause problem when STATE_PCAP_TX replaces STATE_TRANSMITTING.
+     * No impact on TrexStatelessDpCore because the state is not STATE_TRANSMITTING here. */
+    if (m_state != TrexStatelessDpCore::STATE_TRANSMITTING) {
+        m_state = TrexStatelessDpCore::STATE_PCAP_TX;
+    }
 }
 
 void TrexStatelessDpCore::update_traffic(uint8_t port_id, uint32_t profile_id, double factor) {

--- a/src/stx/stl/trex_stl_fs.cpp
+++ b/src/stx/stl/trex_stl_fs.cpp
@@ -982,7 +982,7 @@ int CFlowStatRuleMgr::start_stream(TrexStream * stream) {
 
     if (m_num_started_streams == 0) {
 
-        if (get_dpdk_mode()->dp_rx_queues()) {
+        if (get_dpdk_mode()->dp_rx_queues() || get_is_tcp_mode()) {
             get_stateless_obj()->set_latency_feature();
         } else {
             send_start_stop_msg_to_rx(true); // First transmitting stream. Rx core should start reading packets;
@@ -1101,7 +1101,7 @@ int CFlowStatRuleMgr::internal_stop_stream(TrexStream * stream) {
     assert (m_num_started_streams >= 0);
     if (m_num_started_streams == 0) {
         DEBUG_PRINT("  Sending stop message to rx\n");
-        if (get_dpdk_mode()->dp_rx_queues()) {
+        if (get_dpdk_mode()->dp_rx_queues() || get_is_tcp_mode()) {
             get_stateless_obj()->unset_latency_feature();
         } else {
             send_start_stop_msg_to_rx(false); // No more transmitting streams. Rx core should get into idle loop.

--- a/src/stx/stl/trex_stl_rpc_cmds.cpp
+++ b/src/stx/stl/trex_stl_rpc_cmds.cpp
@@ -2272,16 +2272,21 @@ TrexRpcCmdClearTaggedPktGroupUnknownTags::_run(const Json::Value& params, Json::
  */
 TrexRpcCmdsSTL::TrexRpcCmdsSTL() : TrexRpcComponent("STL") {
 
-    /* ownership */
-    m_cmds.push_back(new TrexRpcCmdAcquire(this));
-    m_cmds.push_back(new TrexRpcCmdRelease(this));
+    if (get_is_stateless()) {
+        /* ownership */
+        m_cmds.push_back(new TrexRpcCmdAcquire(this));
+        m_cmds.push_back(new TrexRpcCmdRelease(this));
+
+        /* service mode */
+        m_cmds.push_back(new TrexRpcCmdSetServiceMode(this));
+
+        /* profiles */
+        m_cmds.push_back(new TrexRpcCmdGetProfileList(this));
+    }
 
     /* PG IDs */
     m_cmds.push_back(new TrexRpcCmdGetActivePGIds(this));
     m_cmds.push_back(new TrexRpcCmdGetPGIdsStats(this));
-
-    /* profiles */
-    m_cmds.push_back(new TrexRpcCmdGetProfileList(this));
 
     /* streams */
     m_cmds.push_back(new TrexRpcCmdGetStreamList(this));
@@ -2302,9 +2307,6 @@ TrexRpcCmdsSTL::TrexRpcCmdsSTL() : TrexRpcComponent("STL") {
     m_cmds.push_back(new TrexRpcCmdUpdateStreams(this));
     m_cmds.push_back(new TrexRpcCmdValidate(this));
     m_cmds.push_back(new TrexRpcCmdRemoveRXFilters(this));
-
-    /* service mode */
-    m_cmds.push_back(new TrexRpcCmdSetServiceMode(this));
 
     /* pcap */
     m_cmds.push_back(new TrexRpcCmdPushRemote(this));


### PR DESCRIPTION
Hi, this change is to run a typical stateless profile on ASTF mode.

On this change, there are some restrictions.
- TCP packet is not supported.
- UDP packets should not be handled by ASTF.
- TPG is not supported yet.
- Performance will be low.

```
trex>start_stl -f stl/flow_stats.py

Removing all streams from port(s) [0._, 1._]:                [SUCCESS]


Attaching 1 streams to port(s) [0._]:                        [SUCCESS]


Attaching 1 streams to port(s) [1._]:                        [SUCCESS]


Starting traffic on port(s) [0._, 1._]:                      [SUCCESS]

21.64 [ms]

trex>stats -g
Global Statistics

connection   : localhost, Port 4521                       total_tx_L2  : 1.52 Kbps                      
version      : ASTF @ v3.00                               total_tx_L1  : 1.82 Kbps                      
cpu_util.    : 0.45% @ 1 cores (1 per dual port)          total_rx     : 1.46 Kbps                      
rx_cpu_util. : 0.0% / 0 pps                               total_pps    : 1.88 pps                       
async_util.  : 0% / 1.84 bps                              drop_rate    : 0 bps                          
total_cps.   : 0 cps                                      queue_full   : 0 pkts                         

trex>stats -s
Streams Statistics

  PG ID    |         1         
-----------+------------------
Tx pps     |             0 pps 
Tx bps L2  |             0 bps 
Tx bps L1  |             0 bps 
---        |                   
Rx pps     |             0 pps 
Rx bps     |             0 bps 
----       |                   
opackets   |                48 
ipackets   |                48 
obytes     |              4848 
ibytes     |              4848 
-----      |                   
opackets   |           48 pkts 
ipackets   |           48 pkts 
obytes     |           4.85 KB 
ibytes     |           4.85 KB 
```

@hhaim please review my change and give your opinion.