### PR TITLE
fix reass_maxqlen range limited by uint8_t.

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1063,7 +1063,7 @@ bool CAstfDB::read_tunables(CTcpTuneables *tune, Json::Value tune_json) {
                 tunable_min_max_u32("cc_algo",tune->m_tcp_cc_algo,0,1);
             }
 
-            if (read_tunable_uint8(tune,json,"reass_maxqlen",CTcpTuneables::tcp_reass_maxqlen,tune->m_tcp_reass_maxqlen)){
+            if (read_tunable_uint16(tune,json,"reass_maxqlen",CTcpTuneables::tcp_reass_maxqlen,tune->m_tcp_reass_maxqlen)){
                 tunable_min_max_u32("reass_maxqlen",tune->m_tcp_reass_maxqlen,0,1000);
             }
         }

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -172,7 +172,7 @@ class CTcpTuneables {
     uint8_t  m_tcp_do_sack;
     uint8_t  m_tcp_cc_algo;
 
-    uint8_t  m_tcp_reass_maxqlen;
+    uint16_t  m_tcp_reass_maxqlen;
 
  private:
     uint32_t m_bitfield;


### PR DESCRIPTION
Hi, this PR is to fix the `reass_maxqlen` range limited by uint8_t, 255.
It should be supported to 1000 as documented.
So, uint8_t is changed to uint16_t to cover the value of 1000.

@hhaim please review this change.