### PR TITLE
add description of stateless profile support on ASTF mode

### DIFF
--- a/doc/trex_astf.asciidoc
+++ b/doc/trex_astf.asciidoc
@@ -230,6 +230,18 @@ The client side of TRex server is responsible to the encapsulation/decapsulation
 * Loopback mode - from version v2.93 TRex supports loopback mode for testing without DUT - the server side is aware to the GTPU mode and decapsulates the client packets, and learns the tunnel context. When transmitting, the server encapsulates the packets with the same tunnel context. +
 * More than 2 ports support - from version v2.93 TRex supports more than 2 ports in GTPU mode.
 
+==== Stateless profile support
+
+The stateless profile can be used on ASTF mode with the following limitations.
+
+* TCP header packet is not supported.
+* The UDP flow in stateless profile should not be handled by ASTF. When the received UDP packet is matched to ASTF UDP flow, it will not be handled by the stateless profile.
+* HW flow statistics is not supported due to the conflits with ASTF HW RSS.
+* The performance will be less than original stateless mode.
+* TPG is not supported yet.
+
+* start/update/stop cannot be used for the stateless profile. Instead, start_stl/update_stl/stop_stl should be used.
+
 
 
 === ASTF package folders 

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -2230,20 +2230,20 @@ class ASTFClient(STLClient):
     @console_api('start_stl', 'STL', True)
     def start_stl_line(self, line):
         '''Start traffic command'''
-        self.start_line(line)
+        STLClient.start_line(self, line)
 
     @console_api('stop_stl', 'STL', True)
     def stop_stl_line(self, line):
         '''stop traffic command'''
-        self.stop_line(line)
+        STLClient.stop_line(self, line)
 
     @console_api('update_stl', 'STL', True)
     def update_stl_line(self, line):
         '''update traffic command'''
-        self.update_line(line)
+        STLClient.update_line(self, line)
 
     @console_api('stats_stl', 'STL', True)
     def stats_stl_line(self, line):
         '''stats traffic command'''
-        self.show_stats_line(line)
+        STLClient.show_stats_line(self, line)
 


### PR DESCRIPTION
Hi, this PR describes the feature and limitations of previous PR #936.

In addition, I found the `start_stl` command didn't work with the last merge and fixed it.

@hhaim please review this PR and give your feedback.