### PR TITLE
apply XL710 workaround for #508 to bonding

### DIFF
--- a/src/drivers/trex_driver_base.h
+++ b/src/drivers/trex_driver_base.h
@@ -219,6 +219,8 @@ public:
 
     void create_dummy();
 
+    CTRexExtendedDriverBase * create_driver(std::string name);
+
     CTRexExtendedDriverBase* get_drv();
 
 public:
@@ -226,8 +228,6 @@ public:
     static CTRexExtendedDriverDb * Ins();
 
 private:
-    CTRexExtendedDriverBase * create_driver(std::string name);
-
     CTRexExtendedDriverDb();
     void register_driver(std::string name, create_object_t func);
     static CTRexExtendedDriverDb * m_ins;

--- a/src/drivers/trex_driver_virtual.h
+++ b/src/drivers/trex_driver_virtual.h
@@ -187,6 +187,13 @@ public:
     virtual void update_configuration(port_cfg_t * cfg);
     virtual int wait_for_stable_link();
     virtual void wait_after_link_up();
+    virtual bool extra_tx_queues_requires(tvpid_t tvpid);
+    virtual int verify_fw_ver(tvpid_t tvpid);
+
+private:
+    CTRexExtendedDriverBase *m_slave_drv; // slave device driver
+
+    void set_slave_driver(tvpid_t tvpid);
 };
 
 

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -7183,6 +7183,17 @@ COLD_FUNC void reorder_dpdk_ports() {
         if ( isVerbose(0) ){
            printf(" size of interfaces_vdevs %d \n",(int)cg->m_if_list_vdevs.size());
         }
+        if ( CGlobalInfo::m_options.m_pdevs_in_vdev.size() ) {
+            /* mapping virtual tvpid for bonding device driver usage.
+             * real tvpid will be updated by next m_if_list_vdevs loop. */
+            int tvpid = cg->m_if_list_vdevs.size();
+            uint8_t cnt = rte_eth_dev_count_avail();
+            for (int repid = 0; repid < cnt; repid++) {
+                lp->set_map(tvpid,repid);
+                lp->set_rmap(repid,tvpid);
+                tvpid++;
+            }
+        }
         int if_index = 0;
         for (std::string &opts : cg->m_if_list_vdevs) {
             if ( CTVPort(if_index).is_dummy() ) {
@@ -7204,6 +7215,7 @@ COLD_FUNC void reorder_dpdk_ports() {
                 printf(" ===>>>found %s %d \n",opts.c_str(),port_id);
             }
             lp->set_map(if_index,port_id);
+            lp->set_rmap(port_id,if_index);
             if_index++;
         }
         return;
@@ -7216,6 +7228,7 @@ COLD_FUNC void reorder_dpdk_ports() {
                     continue;
                 }
                 lp->set_map(i, if_index);
+                lp->set_rmap(if_index, i);
                 if_index++;
             }
             return;


### PR DESCRIPTION
Hi, this PR is to apply the old XL710 workaround for the #508 issue to the bonding device driver.

Recently, my user observed performance degradation when the bonding device uses Intel 25G NIC with F/W 6.8 as slaves.
I found that a similar issue #508 was already solved by adding an extra queue.
But the workaround was not applied when the device is used for bonding device slaves.

To apply the workaround, I added `m_slave_drv` to the bonding driver and made a proper call for `extra_tx_queues_requires`.

@hhaim please review my change and give your feedback. Any suggestions are welcome.