### PR TITLE
append index parameter to get_flow_info

### DIFF
--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -3591,10 +3591,10 @@ inline int CNodeGenerator::flush_file_realtime(dsec_t max_time,
     m_scheduler_offset = offset;
     dsec_t burst_size = BURST_OFFSET_DTIME;
     if (CGlobalInfo::m_burst_offset_dtime > BURST_OFFSET_DTIME) {
+        burst_size = CGlobalInfo::m_burst_offset_dtime;
         if (CGlobalInfo::m_options.preview.getVMode() > 3) {
             std::cout << "burst_size = " << burst_size << std::endl;
         }
-        burst_size = CGlobalInfo::m_burst_offset_dtime;
     }
 
     thread->m_cpu_dp_u.start_work1();


### PR DESCRIPTION
Hi, this change is to improve ASTFClient's get_flow_info API.

Since non-blocking requests with duration 0 may contain duplicated entries, the user should compare the duplicated ones and remove them. It's quite an annoying job. So, I added the index parameter for the users of non-blocking requests.

@hhaim please review my changes and give your opinion.