### PR TITLE
change get_profile_list response for trex-java-sdk compatibility

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -863,13 +863,22 @@ class ASTFClient(STLClient):
                 raise TRexError(rc.err())
 
     @client_api('getter', True)
-    def get_profiles(self):
+    def get_profiles(self, profiles_in_ports = False):
         """
             Get profile list from Server.
 
+            :parameters:
+                profiles_in_ports: bool
+                    Get Stateless profiles also in all available ports
+                    Default is False
+
+            :returns:
+                List of profile names. When profiles_in_ports parameter is specified,
+                a dictionary for all available ports is included in the list.
         """
         params = {
             'handler': self.handler,
+            'profiles_in_ports': profiles_in_ports,
             }
         self.ctx.logger.pre_cmd('Getting profile list.')
         rc = self._transmit('get_profile_list', params = params)


### PR DESCRIPTION
Hi, this PR is to keep backward compatibility with trex-java-sdk behavior.

https://github.com/cisco-system-traffic-generator/trex-java-sdk/blob/c8032462c4be86720bc01f4e1c359c3d803d88e5/src/main/java/com/cisco/trex/stateful/TRexAstfClient.java#L383-L387

In this code, the result from the response should be an array of strings.
So, I added an optional parameter "profiles_in_ports" for backward compatibility.

@hhaim please review my changes and give your feedback quickly.
