### PR TITLE
fix ASTF profile clear issue in multiple cores

### DIFF
--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -107,6 +107,7 @@ public:
     void build();
     void transmit();
     void cleanup();
+    void remove();
     void all_dp_cores_finished(bool partial=false);
     void dp_core_finished();
     void dp_core_finished_partial();

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -427,8 +427,6 @@ void TrexAstfDpCore::remove_astf_json(profile_id_t profile_id, CAstfDB* astf_db)
         report_error(profile_id, "Cannot delete ASTF DB on existing profile: state " + std::to_string(get_profile_state(profile_id)));
         return;
     }
-    // try removing the profile_ctx which contains statistics.
-    m_flow_gen->remove_tcp_profile(profile_id);
 
     if (astf_db) {
         astf_db->Delete();


### PR DESCRIPTION
Hi, recently my colleague found an issue that the profile statistics are left in DP cores.
According to my investigation, there is no request to remove them except for DP core 0.
In this PR, `profile_clear` will request them before removing profile DB finally.

`profile_clear` --> [STATE_DELETE] --> `TrexAstfDeleteDB` to DP core 0
=>
`profile_clear` --> [STATE_DELETE] --> **`TrexAstfDpDeleteTcp`** to all DP cores --> `TrexAstfDeleteDB` to DP core 0

@hhaim please review my changes and give your feedback.