### PR TITLE
Prevent the send sockbuf from being emptied by TSO

### DIFF
--- a/src/44bsd/netinet/tcp_output.c
+++ b/src/44bsd/netinet/tcp_output.c
@@ -667,6 +667,12 @@ send:
                     sendalot = 1;
                 }
             }
+            /* TREX_FBSD: Prevent the send sockbuf from being emptied */
+            else {
+                moff = len % max_len;
+                len -= moff ? : max_len;
+                sendalot = 1;
+            }
 
             /*
              * In case there are too many small fragments


### PR DESCRIPTION
Hi, as discussed at #962, this change prevents TSO packets from adding the PUSH flag.
Since the PUSH flag is added when the send sockbuf is emptied, with this change, TSO left some data always and the PUSH flag will not be added to the packets.

@hhaim please review my change and give your feedback if any.