### PR TITLE
SLRO merges PSH pkt to saved mbuf and pushes it

### DIFF
--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -1166,6 +1166,14 @@ HOT_FUNC bool CTcpRxOffload::append_buf(CTcpFlow* flow,
         if (do_lro && buf->reassemble_mbuf(mbuf, lpTcp, ftuple)) {
             lro_done = true;
         } else {
+            uint8_t flags = lpTcp->getFlags();
+            if ((flags & TCPHeader::Flag::PSH) && (ftuple.m_l7_total_len > 0)) {
+                if (buf->reassemble_mbuf(mbuf, lpTcp, ftuple)) {
+                    buf->m_lpTcp->setFlag(flags);
+                    lro_done = true;
+                }
+            }
+
             /* nullptr ctx prevents unexpected flow closing */
             m_cb(nullptr, flow, buf->m_mbuf, buf->m_lpTcp, buf->m_ftuple);
             buf->clear_flow();


### PR DESCRIPTION
Hi, this change will merge a PSH packet to the previously merged packet by SLRO.
With this change, more packets can be merged and fewer ACK packets can be shown.
```
ACK ACK ACK PSH ACK PSH --(SLRO)--> ACK PSH ACK PSH
=>
ACK ACK ACK PSH ACK PSH --(SLRO)--> PSH PSH
```
PSH means the packet has PSH and ACK flags, and ACK means the packet has only the ACK flag.

@hhaim please review this change and give your feedback.