### PR TITLE
cache filled mbuf to reduce 2K mbuf usage

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -1993,7 +1993,9 @@ class TRexClient(object):
             :parameters:
                 params: dictionary
                     dictionary of global configuration parameters. Available parameters:
-                    "sched_max_stretch", type = double, default =0.0, units = usec, scheduler's maximum time for stretch in case it is a high value there won't be a scheduler compensation on burst and time will not be stretch. 0.0 means use the default internal value (~100usec). value could not be lower than 100usec will be considered as 100usec.
+                    "sched_max_stretch", type = double, default = 0.0, units = usec, scheduler's maximum time for stretch in case it is a high value there won't be a scheduler compensation on burst and time will not be stretch. 0.0 means use the default internal value (~100usec). value could not be lower than 100usec will be considered as 100usec. The change cannot be applied to the current epoch.
+                    "process_at_cp", type = bool, default = False, ASTF profile needs to prepare for traffic generation. By default, it is performed at DP cores. But when you run multiple profiles, since it consumes DP processing power, it may affect the traffic generation. This parameter can remove the process from DP cores and perform it at CP core.
+                    "do_mbuf_cache", type = bool, default = False, ASTF profile's buffer can be filled with specific pattern. This parameter enables the cached mbuf for the same patterns. It will save 2K mbuf consumption when you run lots of profiles with the same patterns. But, since a pattern consumes a 2K mbuf permanently, please enable this parameter only the patterns are limited.
 
             :raises:
                 + :exc:`TRexError`
@@ -2012,6 +2014,14 @@ class TRexClient(object):
 
     @client_api('command', True)
     def get_global_cfg (self):
+        """
+            Get global configuration parameter values. See `set_global_cfg` for the parameters.
+
+            :raises:
+                + :exc:`TRexError`
+
+        """
+
         rc = self._transmit("get_global_cfg")
         if not rc:
             raise TRexError(rc)

--- a/src/44bsd/tcp_socket.h
+++ b/src/44bsd/tcp_socket.h
@@ -1023,8 +1023,7 @@ int utl_mbuf_buffer_create_and_copy(uint8_t socket,
                                     uint8_t *d,
                                     uint32_t d_size,
                                     uint32_t size,
-                                    uint8_t *f,
-                                    uint32_t f_size,
+                                    std::string& fill_string,
                                     bool mbuf_const=false);
 
 

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1629,7 +1629,7 @@ bool CAstfDB::convert_bufs(uint8_t socket_id) {
             if (buf_obj["fill"] != Json::nullValue) {
                 fill_data = base64_decode(buf_obj["fill"].asString());
             }
-            utl_mbuf_buffer_create_and_copy(socket_id, tcp_buf, 2048, (uint8_t *)(temp_str.c_str()), temp_str.size(),buf_len,(uint8_t*)(fill_data.c_str()),fill_data.size(),true);
+            utl_mbuf_buffer_create_and_copy(socket_id, tcp_buf, 2048, (uint8_t *)(temp_str.c_str()), temp_str.size(),buf_len,fill_data,true);
         } else {
             json_buf = m_val["buf_list"][buf_index].asString();
             temp_str = base64_decode(json_buf);

--- a/src/stx/common/trex_rpc_cmds_common.cpp
+++ b/src/stx/common/trex_rpc_cmds_common.cpp
@@ -1740,6 +1740,9 @@ TrexRpcCmdSetGlobalCfg::_run(const Json::Value &params, Json::Value &result) {
     if (params["process_at_cp"] != Json::Value::null) {
         CGlobalInfo::m_process_at_cp = parse_bool(params, "process_at_cp", result);
     }
+    if (params["do_mbuf_cache"] != Json::Value::null) {
+        CGlobalInfo::m_do_mbuf_cache = parse_bool(params, "do_mbuf_cache", result);
+    }
     return (TREX_RPC_CMD_OK);
 }
 
@@ -1749,6 +1752,7 @@ TrexRpcCmdGetGlobalCfg::_run(const Json::Value &params, Json::Value &result) {
 
     section["sched_max_stretch"] = CGlobalInfo::m_burst_offset_dtime;
     section["process_at_cp"] = CGlobalInfo::m_process_at_cp;
+    section["do_mbuf_cache"] = CGlobalInfo::m_do_mbuf_cache;
 
     return (TREX_RPC_CMD_OK);
 }

--- a/src/trex_global.cpp
+++ b/src/trex_global.cpp
@@ -28,6 +28,7 @@ CRteMemPool         CGlobalInfo::m_mem_pool[MAX_SOCKETS_SUPPORTED];
 uint32_t            CGlobalInfo::m_nodes_pool_size = 10*1024;
 double              CGlobalInfo::m_burst_offset_dtime;
 bool                CGlobalInfo::m_process_at_cp = false;
+bool                CGlobalInfo::m_do_mbuf_cache = false;
 CParserOption       CGlobalInfo::m_options;
 CGlobalMemory       CGlobalInfo::m_memory_cfg;
 CPlatformSocketInfo CGlobalInfo::m_socket;

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -1100,6 +1100,7 @@ public:
     static uint32_t              m_nodes_pool_size;
     static double                m_burst_offset_dtime;
     static bool                  m_process_at_cp;
+    static bool                  m_do_mbuf_cache;
     static CParserOption         m_options;
     static CGlobalMemory         m_memory_cfg;
     static CPlatformSocketInfo   m_socket;


### PR DESCRIPTION
Hi, this change reduces 2K mbuf usage when lots of profiles and buffers are loaded.
Until now, a buffer in a profile shares a mbuf filled by pattern. The shared mbuf is dedicated to one buffer only.
From now on, the shared mbuf will be cached globally and can be used by other buffers even though in other profiles.

I implemented the cache using `const-mbuf` due to the possibility of refcnt overflow.
As discussed at #979, `const-mbuf` will not be freed from the cache.
I think there is no issue because the number of cached mbufs will be small.

@hhaim, please review this change and give your feedback.