### PR TITLE
clear stats available in trex-console read-only mode

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -1194,7 +1194,7 @@ class ASTFClient(STLClient):
                     clear all the profiles sts
         """
         if clear_all:
-            self.traffic_stats.clear_dynamic_stats(clear_all)
+            self.traffic_stats.clear_dynamic_stats(clear_all = True)
         if pid_input:
             self.traffic_stats.clear_dynamic_stats(pid_input)
         return self.traffic_stats.clear_dynamic_stats(is_sum = True)

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -2932,8 +2932,8 @@ class TRexClient(object):
             A common method for STL/ASTF to clear stats
         """
 
-        # by default use all acquired ports
-        ports = ports if ports is not None else self.get_acquired_ports()
+        # by default use all ports
+        ports = ports if ports else self.get_all_ports()
 
         # validate
         ports = self.psv.validate('clear_stats', ports)


### PR DESCRIPTION
Hi, this PR is to improve trex-console behavior.

Until now, statistics cannot be cleared in trex-console read-only mode.
It's because the acquired ports are required for the default action.
But, since the clearing statistics does not change the T-Rex server, there is no need to acquire ports to do it.
So, I changed the acquired ports to all ports for clearing stats.

Also, I have found a bug that calls clear_dynamic_stats with an invalid argument and fixed it.

@hhaim please review my change.