### PR TITLE
set device mtu by port_mtu in trex_cfg.yaml

### DIFF
--- a/src/dpdk/drivers/net/bonding/rte_eth_bond_pmd.c
+++ b/src/dpdk/drivers/net/bonding/rte_eth_bond_pmd.c
@@ -1761,8 +1761,8 @@ slave_configure(struct rte_eth_dev *bonded_eth_dev,
 	errval = rte_eth_dev_set_mtu(slave_eth_dev->data->port_id,
 				     bonded_eth_dev->data->mtu);
 	if (errval != 0 && errval != -ENOTSUP) {
-		RTE_BOND_LOG(ERR, "rte_eth_dev_set_mtu: port %u, err (%d)",
-				slave_eth_dev->data->port_id, errval);
+		RTE_BOND_LOG(ERR, "rte_eth_dev_set_mtu: port %u, mtu %u, err (%d)",
+				slave_eth_dev->data->port_id, bonded_eth_dev->data->mtu, errval);
 		return errval;
 	}
 	return 0;

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -4319,9 +4319,14 @@ COLD_FUNC int  CGlobalTRex::device_prob_init(void){
         }
     }
 
+    uint32_t port_mtu = global_platform_cfg_info.m_port_mtu;
+
+    if (!port_mtu) {
+        port_mtu = dev_info.max_rx_pktlen - trex_dev_get_overhead_len(dev_info.max_rx_pktlen, dev_info.max_mtu);
+    }
+
     /*update mtu based on the dev info*/
-    m_port_cfg.m_port_conf.rxmode.mtu = dev_info.max_rx_pktlen - trex_dev_get_overhead_len(dev_info.max_rx_pktlen, 
-                                                                                      dev_info.max_mtu);
+    m_port_cfg.m_port_conf.rxmode.mtu = port_mtu;
     m_port_cfg.update_var();
 
     if (m_port_cfg.m_port_conf.rxmode.mtu > dev_info.max_rx_pktlen ) {


### PR DESCRIPTION
Hi, this change overrides the device's MTU size by port_mtu in trex_cfg.yaml.

My colleague found the bonding driver had failed to set the MTU size when the slave device is the MLX5.
Since the MLX5 DPDK driver returns 65536 for max_rx_pktlen and T-Rex calculates the RX MTU size from the max_rx_pktlen, the bonding driver tries to set the large RX MTU size and failed.
https://github.com/cisco-system-traffic-generator/trex-core/blob/7216782dc312333a7c66fd10644f07eed32edb17/src/dpdk/drivers/net/mlx5/mlx5_ethdev.c#L321-L324
I tried to set RTE_ETHER_MAX_JUMBO_FRAME_LEN but it was failed also. So, I decided to set it from the already defined configuration value, port_mtu.

@hhaim, please review my change and give your opinion.