### PR TITLE
enable ECN packet handling

### DIFF
--- a/doc/trex_astf.asciidoc
+++ b/doc/trex_astf.asciidoc
@@ -3881,6 +3881,7 @@ link:cp_astf_docs/index.html[python index]
 |   tcp.do_rfc1323  | bool   |1|-|+| enable timestamp rfc 1323. 
 |   tcp.do_sack     | bool   |1|-|+| enable SACK.
 |   tcp.cc_algo     | 0,1    |0|-|+| select congestion control algorithm (0 - newreno, 1 - cubic).
+|   tcp.do_ecn      | 0,1,2  |0|-|+| enable ECN (1 - active, 2 - passive). limitation can't be used with hardware filter on some NICs.
 |   tcp.reass_maxqlen | 0,1000 |100|-|+| maximum number of TCP segments per reassembly queue.
 |   tcp.keepinit    |2-65533|5|-|+| value in second for TCP keepalive.
 |   tcp.keepidle    |2-65533|5|-|+| value in second for TCP keepidle

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_global_info.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_global_info.py
@@ -123,6 +123,7 @@ class ASTFGlobalInfo(ASTFGlobalInfoBase):
                 {"name": "no_delay", "type": [int]},
                 {"name": "no_delay_counter", "type": [int]},
                 {"name": "do_sack", "type": [int]},
+                {"name": "do_ecn", "type": [int]},
                 {"name": "cc_algo", "type": [int]},
                 {"name": "reass_maxqlen", "type": [int]},
             ],

--- a/src/44bsd/flow_table.cpp
+++ b/src/44bsd/flow_table.cpp
@@ -425,7 +425,14 @@ static inline void tcp_flow_input(CTcpFlow *  flow,
                                   TCPHeader    * lpTcp,
                                   CFlowKeyFullTuple &ftuple){
 
-    tcp_int_input(&flow->m_tcp, (struct mbuf*)mbuf, (struct tcphdr*)lpTcp, ftuple.m_l7_offset, ftuple.m_l7_total_len, 0);
+    uint8_t iptos;
+    if (ftuple.m_ipv4) {
+        iptos = (rte_pktmbuf_mtod_offset(mbuf, IPHeader*, ftuple.m_l3_offset))->getTOS();
+    } else {
+        iptos = (rte_pktmbuf_mtod_offset(mbuf, IPv6Header*, ftuple.m_l3_offset))->getTrafficClass();
+    }
+
+    tcp_int_input(&flow->m_tcp, (struct mbuf*)mbuf, (struct tcphdr*)lpTcp, ftuple.m_l7_offset, ftuple.m_l7_total_len, iptos);
 
     flow->check_defer_function();
 }

--- a/src/44bsd/netinet/tcp_var.h
+++ b/src/44bsd/netinet/tcp_var.h
@@ -506,6 +506,7 @@ struct	tcpstat {
 struct tcp_tune {
     int tcp_do_rfc1323;     /* (1) Enable rfc1323 (high performance TCP) extensions */
     int tcp_do_sack;        /* (1) Enable/Disable TCP SACK support */
+    int tcp_do_ecn;         /* (0) Enable/Disable TCP ECN support */
     int tcp_mssdflt;        /* (TCP_MSS) Default TCP Maximum Segment Size */
     //int tcp_v6mssdflt;      /* (TCP6_MSS) Default TCP Maximum Segment Size for IPv6 */
     int tcp_initcwnd_segments;  /* (10) Slow-start flight size (initial congestion window) in number of segments (10) */
@@ -539,7 +540,7 @@ struct tcp_tune {
 #define V_tcp_do_rfc3390            1
 #define V_tcp_do_rfc3042            1
 
-#define V_tcp_do_ecn                2
+#define V_tcp_do_ecn                TCP_TUNE(tcp_do_ecn)
 #define V_tcp_ecn_maxretries        1
 
 #define V_tcp_minmss                216

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1063,6 +1063,14 @@ bool CAstfDB::read_tunables(CTcpTuneables *tune, Json::Value tune_json) {
                 tunable_min_max_u32("cc_algo",tune->m_tcp_cc_algo,0,1);
             }
 
+            if (read_tunable_uint8(tune,json,"do_ecn",CTcpTuneables::tcp_do_ecn,tune->m_tcp_do_ecn)){
+                tunable_min_max_u32("do_ecn",tune->m_tcp_do_ecn,0,2);
+                if (tune->m_tcp_do_ecn > 0 && get_dpdk_mode()->is_hardware_filter_needed()) {
+                    Json::Value result;
+                    generate_parse_err(result,"do_ecn does not support with hardware filter. use --software.");
+                }
+            }
+
             if (read_tunable_uint16(tune,json,"reass_maxqlen",CTcpTuneables::tcp_reass_maxqlen,tune->m_tcp_reass_maxqlen)){
                 tunable_min_max_u32("reass_maxqlen",tune->m_tcp_reass_maxqlen,0,1000);
             }

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -85,8 +85,9 @@ class CTcpTuneables {
 
         tcp_do_sack     = 0x200000,
         tcp_cc_algo     = 0x400000,
+        tcp_do_ecn      = 0x800000,
 
-        tcp_reass_maxqlen = 0x800000,
+        tcp_reass_maxqlen = 0x1000000,
     };
     enum {
         no_delay_mask_nagle = 0x1,
@@ -120,6 +121,7 @@ class CTcpTuneables {
 
         m_tcp_do_sack=1;
         m_tcp_cc_algo=0;
+        m_tcp_do_ecn=0;
 
         m_tcp_reass_maxqlen=0;
 
@@ -170,6 +172,7 @@ class CTcpTuneables {
     uint8_t  m_dont_use_inbound_mac;
 
     uint8_t  m_tcp_do_sack;
+    uint8_t  m_tcp_do_ecn;
     uint8_t  m_tcp_cc_algo;
 
     uint16_t  m_tcp_reass_maxqlen;

--- a/src/stt_cp.cpp
+++ b/src/stt_cp.cpp
@@ -534,6 +534,13 @@ void CSTTCpPerTGIDPerDir::create_clm_counters(){
     TCP_S_ADD_CNT_E(tcps_sack_send_blocks,"SACK blocks (options) sent");
     TCP_S_ADD_CNT_E(tcps_sack_sboverflow,"times scoreboard overflowed");
 
+    /* TREX_FBSD: ECN counters */
+    TCP_S_ADD_CNT(tcps_ecn_ce,"ECN Congestion Experienced");
+    TCP_S_ADD_CNT(tcps_ecn_ect0,"ECN Capable Transport");
+    TCP_S_ADD_CNT(tcps_ecn_ect1,"ECN Capable Transport");
+    TCP_S_ADD_CNT(tcps_ecn_shs,"ECN successful handshakes");
+    TCP_S_ADD_CNT(tcps_ecn_rcwnd,"times ECN reduced the cwnd");
+
     create_bar(&m_clm,"-");
     create_bar(&m_clm,"UDP");
     create_bar(&m_clm,"-");


### PR DESCRIPTION
Hi, this PR is to enable ECN packet handling in the integrated TCP stack.

When I integrated FreeBSD 13.0 TCP stack, the ECN packet handling was left over. Recently it needs to be enabled. This change delivers ECN bits in the received IP packet header to the TCP stack.

@hhaim please review and give your feedback.
