### PR TITLE
Avoid exception when all packets are empty

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/cap_handling.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/cap_handling.py
@@ -59,9 +59,6 @@ class _CPcapReader_help(object):
         new_pkts = []
         new_dirs = []
         for pkt in self._pkts:
-            if pkt.is_empty():
-                continue
-
             if combined_data:
                 if combined_data.direction == pkt.direction:
                     combined_data += pkt


### PR DESCRIPTION
I'm not sure if this change makes sense in other scenarios. I wanted to make traffic with a TCP 3-way handshake pcap file, so the packets without payload resulted in an exception.

----

If a pcap file contains only packets that have no payload the loop would not assign any packet to `combined_data`. That would result in a thrown exception at `new_dirs.append(combined_data.direction)` because string `combined_data` has no attribute `direction`.