### PR TITLE
can separate queue start from device start

### DIFF
--- a/src/main_dpdk.h
+++ b/src/main_dpdk.h
@@ -89,6 +89,7 @@ class CPhyEthIF  {
         m_rx_queue=rx_queue;
     }
     virtual void conf_queues();
+    virtual void start_queues();
 
     virtual void configure(uint16_t nb_rx_queue,
                    uint16_t nb_tx_queue,
@@ -302,6 +303,7 @@ class CPhyEthIFDummy : public CPhyEthIF {
         m_is_dummy = true;
     }
     void conf_queues() {}
+    void start_queues() {}
     void configure(uint16_t, uint16_t, const struct rte_eth_conf *) {}
     int dump_fdir_global_stats(FILE *fd) { return 0; }
     int reset_hw_flow_stats() { return 0; }

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -466,6 +466,14 @@ public:
         return (btGetMaskBit32(m_flags1, 26, 26) ? true : false);
     }
 
+    void set_defer_start_queues(bool enable) {
+        btSetMaskBit32(m_flags1, 27, 27, (enable ? 1 : 0) );
+    }
+
+    bool get_defer_start_queues() {
+        return (btGetMaskBit32(m_flags1, 27, 27) ? true : false);
+    }
+
 public:
     void Dump(FILE *fd);
 


### PR DESCRIPTION
Hi, this change is to add the capability of deferring start queues.

Recently, my colleague experienced an issue similar to #861 and he resolved it by deferring queue start.
I think it can be another possible workaround for #861 also.
And I observed a similar issue with i40evf now, I need to apply it also.

I thought to make it default for i40evf and iavf drivers for the first time. But, since the behavior (queue started during device start) has been used, finally I thought making it optional could be better.
To my thought, after this PR has been merged, i40evf can be removed also.

@hhaim please check my changes and give me your opinion.