### PR TITLE
build and cleanup per-thread database at CP

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1261,6 +1261,14 @@ void CAstfDB::get_thread_ip_range(uint16_t thread_id, uint16_t max_threads, uint
 
 CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGeneratorSmart *g_gen,
                                               uint16_t thread_id, uint16_t max_threads, uint16_t dual_port_id) {
+    if (unlikely(m_rw_db.size() >= max_threads)) { // when CP already created all
+        for (auto rw_db: m_rw_db) {
+            if (rw_db && rw_db->get_thread_id() == thread_id) {
+                return rw_db;
+            }
+        }
+    }
+
     CAstfTemplatesRW *ret = new CAstfTemplatesRW();
     assert(ret);
     ret->Create(thread_id,max_threads);

--- a/src/bp_sim_tcp.cpp
+++ b/src/bp_sim_tcp.cpp
@@ -856,12 +856,12 @@ void CFlowGenListPerThread::unload_tcp_profile(profile_id_t profile_id, bool is_
 
     if (astf_db) {
         astf_db->clear_db_ro_rw(nullptr, m_thread_id);
-
-        m_c_tcp->set_template_ro(nullptr, profile_id);
-        m_c_tcp->set_template_rw(nullptr, profile_id);
-        m_s_tcp->set_template_ro(nullptr, profile_id);
-        m_s_tcp->set_template_rw(nullptr, profile_id);
     }
+
+    m_c_tcp->set_template_ro(nullptr, profile_id);
+    m_c_tcp->set_template_rw(nullptr, profile_id);
+    m_s_tcp->set_template_ro(nullptr, profile_id);
+    m_s_tcp->set_template_rw(nullptr, profile_id);
 
     if (is_last) {
         m_sched_accurate = false;

--- a/src/stx/astf/trex_astf.h
+++ b/src/stx/astf/trex_astf.h
@@ -175,6 +175,8 @@ private:
     std::vector<Json::Value> m_flows_info;
     uint64_t        m_flows_limit;
     uint64_t        m_flows_index;
+
+    bool            m_process_at_cp;    // temporary keep
 };
 
 


### PR DESCRIPTION
Hi, this PR will do more processing at CP when `process_at_cp` is enabled.

There was missed processing per-thread RW database when the `process_at_cp` has been added.
According to my investigation, all AstfDB instances can be initialized without the contexts from the DP cores.
So, parsing, building, and cleanup of AstfDB instance can be done safely and it will reduce DP core CPU consumption when multiple profiles are used dynamically.

@hhaim please review this change and give your feedback.