### PR TITLE
fix l7_map buffer invalid issue with do_mbuf_cache

### DIFF
--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -1160,7 +1160,7 @@ int utl_mbuf_buffer_create_and_copy(uint8_t socket,
         uint32_t alloc_size = bsd_umin(blk_size,size);
         auto copy_size = bsd_umin(d_size, alloc_size);
         rte_mbuf_t* m;
-        if (mbuf_fill && (alloc_size == blk_size)) {
+        if (!copy_size && mbuf_fill && (alloc_size == blk_size)) {
             m = mbuf_fill;
             rte_mbuf_refcnt_update(m, 1);
         } else {


### PR DESCRIPTION
Hi, this PR is to fix #981.

After #981 is merged, when `do_mbuf_cache` is enabled, the l7_map buffer will be generated by cached mbuf only without containing l7_map data. It causes l7_map mapping to fail. This change will fix this bug.

@hhaim please review this change.