### PR TITLE
fix build bug during process_at_cp

### DIFF
--- a/src/stx/astf/trex_astf.cpp
+++ b/src/stx/astf/trex_astf.cpp
@@ -1154,12 +1154,12 @@ void TrexAstfPerProfile::build() {
             astf_db->set_factor(m_factor);
             for (auto flow_gen : get_platform_api().get_fl()->m_threads_info) {
                 auto dual_port_id = flow_gen->getDualPortId();
+                auto socket_id = flow_gen->get_memory_socket_id();
 
-                if (!astf_db->get_db_ro(dual_port_id)) {
+                if (!astf_db->get_db_ro(socket_id)) {
                     throw TrexException("Could not create RO template database at CP");
                 }
 
-                auto socket_id = flow_gen->get_memory_socket_id();
                 auto thread_id = flow_gen->m_thread_id;
                 auto max_threads = flow_gen->m_max_threads;
 


### PR DESCRIPTION
Hi, this PR is to fix the build bug during process_at_cp.

My previous PR #1033 made a bug that calls get_db_ro with dual_port_id.
It causes a crash when NUMA 1 memory is used. It should be called with socket_id.
I'm sorry for my previous fault.

@hhaim, please take a look at this change and give your feedback as soon as possible.