### PR TITLE
Fix configure script check_ofed() to search for ofed version with more than one digit

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -671,9 +671,10 @@ def check_ofed(ctx):
     ctx.start_msg('Checking for OFED')
     ofed_info='/usr/bin/ofed_info'
 
-    ofed_ver_re = re.compile('.*[-](\d)[.](\d)[-].*')
+    ofed_ver_re = re.compile('.*[-](\d+)[.](\d+)[-].*')
 
-    ofed_ver= 42
+    ofed_major_ver = 4
+    ofed_minor_ver = 2
     ofed_ver_show= '4.2'
 
     if not os.path.isfile(ofed_info):
@@ -692,8 +693,12 @@ def check_ofed(ctx):
 
     m= ofed_ver_re.match(str(lines[0]))
     if m:
-        ver=int(m.group(1))*10+int(m.group(2))
-        if ver < ofed_ver:
+        is_version_okay = False
+        if int(m.group(1)) > ofed_major_ver:
+            is_version_okay = True
+        elif int(m.group(1)) == ofed_major_ver and int(m.group(2)) >= ofed_minor_ver:
+            is_version_okay = True
+        if not is_version_okay:
           ctx.end_msg("installed OFED version is '%s' should be at least '%s' and up - try with ./b configure --no-mlx flag" % (lines[0],ofed_ver_show),'YELLOW')
           return False
     else:


### PR DESCRIPTION
Good day,

ws_main.py script contains check for mlx5 OFED driver installation by searching output from /usr/bin/ofed_info using regular expression:
`re.compile('.*[-](\d)[.](\d)[-].*')`
This expression matches for strings that contain ofed version which has only 1 digit in major and minor versions, e.g. 

> MLNX_OFED_LINUX-4.2-1.1.3.0 (OFED-4.2-1.1.3)

But fails to match string of newer OFED versions, e.g.

> MLNX_OFED_LINUX-23.04-1.1.3.0 (OFED-23.04-1.1.3)

The impact is failing to find required OFED version, default auto configuration of mlx5 driver compilation settings instead of checking available capabilities. This might lead to building of mlx5 driver that won't work in the current environment. (We've encountered crashes in rte_memzone_reserve calls during t-rex-64 server startup)

The patch fixes string matching and further improves minimum version requirements check

