### PR TITLE
Some debian bookworm compilation fixes

### DIFF
--- a/src/bp_gtest.cpp
+++ b/src/bp_gtest.cpp
@@ -2223,7 +2223,7 @@ class CRxCheck1 : public CRxCheckCallbackBase {
 public:
 
     virtual void handle_packet(rte_mbuf_t  * m){
-        rte_pktmbuf_mtod(m, char*);
+        (void) rte_pktmbuf_mtod(m, char*);
         CRx_check_header * rx_p;
         rte_mbuf_t  * m2 = m->next;
         rx_p=(CRx_check_header *)rte_pktmbuf_mtod(m2, char*);

--- a/src/stx/astf/trex_astf_dp_core.cpp
+++ b/src/stx/astf/trex_astf_dp_core.cpp
@@ -20,6 +20,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <array>
+
 #include "astf/astf_db.h"
 #include "bp_sim.h"
 #include "stt_cp.h"

--- a/src/stx/common/trex_owner.cpp
+++ b/src/stx/common/trex_owner.cpp
@@ -19,6 +19,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <ctime>
+
 #include "trex_owner.h"
 #include "common/basic_utils.h"
 

--- a/src/utils/utl_counter.h
+++ b/src/utils/utl_counter.h
@@ -389,9 +389,8 @@ private:
 
 class CTblGCounters {
 public:
-    CTblGCounters() : m_epoch(m_internal_epoch) {
+    CTblGCounters() : m_internal_epoch(0), m_epoch(m_internal_epoch) {
         m_free_objects = false;
-        m_internal_epoch = 0;
     }
 
     ~CTblGCounters();
@@ -435,8 +434,8 @@ private:
 
 
 private:
-    std::reference_wrapper<uint64_t>    m_epoch;
     uint64_t                            m_internal_epoch;
+    std::reference_wrapper<uint64_t>    m_epoch;
     bool                                m_free_objects;
     std::vector<CGTblClmCounters*>      m_counters;
 };


### PR DESCRIPTION
Hi,

These are some small fixes for warnings that I encountered after upgrading to debian bookworm which uses gcc/g++ (Debian 12.2.0-14) 12.2.0.

They are mostly trivial and I do not expect they will cause trouble in any other env.
It's not all of them: I still see some dangling-pointer or maybe-uninitialized warnings that I will try to address when I can.
EDIT: removed https://github.com/GabrielGanne/trex-core/commit/ff6c225dae0f6e2a1353e78771f889f9cabb4f40 from the initial PR after CI failure: it seems there are some assertions I missed.

Best regards