### PR TITLE
Fix compiler warnings with gcc 13.2.1

### DIFF
--- a/external_libs/bpf/portability.h
+++ b/external_libs/bpf/portability.h
@@ -39,6 +39,7 @@
  * flavors of UN*X.
  */
 
+#include <string.h>
 #include "funcattrs.h"
 
 #ifdef __cplusplus

--- a/src/pkt_gen.h
+++ b/src/pkt_gen.h
@@ -22,6 +22,8 @@
 #ifndef __PKT_GEN_H__
 #define __PKT_GEN_H__
 
+#include <stdint.h>
+
 enum {
     D_PKT_TYPE_ICMP = 1,
     D_PKT_TYPE_UDP = 2,

--- a/src/rpc-server/trex_rpc_zip.h
+++ b/src/rpc-server/trex_rpc_zip.h
@@ -18,6 +18,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include <stdint.h>
 #include <string>
 
 class TrexRpcZip {

--- a/src/stx/astf/trex_astf_topo.h
+++ b/src/stx/astf/trex_astf_topo.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <mutex>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 namespace Json {
     class Value;

--- a/src/stx/common/trex_dp_port_events.cpp
+++ b/src/stx/common/trex_dp_port_events.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 #include "trex_stx.h"
 
 #include <sstream>
+#include <stdint.h>
 #include <os_time.h>
 
 

--- a/src/stx/common/trex_dp_port_events.h
+++ b/src/stx/common/trex_dp_port_events.h
@@ -21,6 +21,7 @@ limitations under the License.
 #ifndef __TREX_DP_PORT_EVENTS_H__
 #define __TREX_DP_PORT_EVENTS_H__
 
+#include <stdint.h>
 #include <unordered_map>
 #include <string>
 

--- a/src/stx/common/trex_owner.h
+++ b/src/stx/common/trex_owner.h
@@ -22,6 +22,7 @@ limitations under the License.
 #ifndef __TREX_OWNER_H__
 #define __TREX_OWNER_H__
 
+#include <stdint.h>
 #include <string>
 
 /**

--- a/src/utils/utl_dbl_human.h
+++ b/src/utils/utl_dbl_human.h
@@ -22,6 +22,7 @@ limitations under the License.
 */
 
 
+#include <stdint.h>
 #include <string>
 
 #define _1MB_DOUBLE ((double)(1024.0*1024.0))

--- a/src/utils/utl_ip.h
+++ b/src/utils/utl_ip.h
@@ -20,6 +20,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include <map>
+#include <stdint.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/utils/utl_ip.h
+++ b/src/utils/utl_ip.h
@@ -216,7 +216,7 @@ class COneIPv6Info : public COneIPInfo {
     virtual bool is_zero_ip();
 
  private:
-    virtual const void get_ip_str(char str[100]) {
+    virtual const void get_ip_str(char str[100]) const {
         ipv6_to_str((ipaddr_t *)m_ip, str);
     }
     uint16_t m_ip[8];

--- a/src/utils/utl_mbuf.cpp
+++ b/src/utils/utl_mbuf.cpp
@@ -319,7 +319,7 @@ int utl_rte_pktmbuf_verify(struct rte_mbuf *m){
             ret = -1;
         }
         pkt_len+=seg_len;
-        if (rte_pktmbuf_mtod(m, char *)==0){
+        if (!rte_pktmbuf_mtod(m, char *)){
             printf(" SEG has pointer zero \n");
             ret = -1;
         }


### PR DESCRIPTION
Hi!

gcc 13.2.1 complains about a few minor issues.
I addressed some of them here.

Still, I need to build with `-Wno-maybe-uninitialized` and a workaround for `-Wdangling-pointer`, but from a first glance, those seem to be false positives, so I did not include them in this PR.