### PR TITLE
Use ie40evf instead of iavf driver

### DIFF
--- a/src/dpdk/drivers/net/iavf/iavf_ethdev.c
+++ b/src/dpdk/drivers/net/iavf/iavf_ethdev.c
@@ -142,10 +142,12 @@ static int iavf_tm_ops_get(struct rte_eth_dev *dev __rte_unused, void *arg);
 
 static const struct rte_pci_id pci_id_iavf_map[] = {
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_ADAPTIVE_VF) },
+#ifndef TREX_PATCH  /* pci_id_i40evf_map */
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_VF) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_VF_HV) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_X722_VF) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_X722_A0_VF) },
+#endif
 	{ .vendor_id = 0, /* sentinel */ },
 };
 


### PR DESCRIPTION
Hi, this PR fixes IOMMU fault when the IAVF driver is used together with other DPDK applications. This is done by using the i40evf driver instead of IAVF if TREX_PATCH is set.

This is related to the following issue:
Cannot Rx after DPDK 22.03 version with iavf(XL710 VF) #861