### PR TITLE
Add build support for gcc-11, gcc-12 and gcc-13

### DIFF
--- a/linux/ws_main.py
+++ b/linux/ws_main.py
@@ -530,7 +530,6 @@ cxxflags_base =['-DWIN_UCODE_SIM',
                 '-Wno-deprecated-declarations',
                 '-Wno-dangling-pointer', # Disabled since unrecognized before gcc-12
                 '-Wno-error=maybe-uninitialized', # Additional warnings in gcc-11
-                '-Wno-error=overloaded-virtual', # Additional warnings in gcc-13
                 '-Wno-error=uninitialized',
                 '-std=c++0x',
                 '-Wno-sign-compare',

--- a/linux/ws_main.py
+++ b/linux/ws_main.py
@@ -528,6 +528,9 @@ cxxflags_base =['-DWIN_UCODE_SIM',
                 #'-DGLIBCXX_USE_CXX11_ABI=0',
                 '-g',
                 '-Wno-deprecated-declarations',
+                '-Wno-dangling-pointer', # Disabled since unrecognized before gcc-12
+                '-Wno-error=maybe-uninitialized', # Additional warnings in gcc-11
+                '-Wno-error=overloaded-virtual', # Additional warnings in gcc-13
                 '-Wno-error=uninitialized',
                 '-std=c++0x',
                 '-Wno-sign-compare',

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -57,6 +57,8 @@ clang_flags = ['-Wno-null-conversion',
 
 gcc_flags = ['-Wall',
              '-Werror',
+             '-Wno-error=maybe-uninitialized', # Additional warnings in gcc-11
+             '-Wno-dangling-pointer', # Disabled since unrecognized before gcc-12
              '-Wno-literal-suffix',
              '-Wno-sign-compare',
              '-Wno-strict-aliasing',

--- a/src/publisher/trex_publisher.h
+++ b/src/publisher/trex_publisher.h
@@ -137,7 +137,8 @@ private:
     bool   m_is_interactive;
 
     std::vector<TrexPublisherCtx*> m_ctxs;
-    
+
+protected:
     static const int MSG_COMPRESS_THRESHOLD = 256;
 };
 

--- a/src/sim/trex_sim_stateless.cpp
+++ b/src/sim/trex_sim_stateless.cpp
@@ -107,15 +107,14 @@ class SimPublisher : public TrexPublisher {
 public:
 
     /* override create */
-    bool Create(uint16_t port, bool disable) {
+    bool Create(uint16_t port, bool disable) override {
         return true;
     }
 
-    void Delete() {
-
+    void Delete(int timeout_sec = 0) override {
     }
 
-    void publish_json(const std::string &s) {
+    void publish_json(const std::string &s, uint32_t zip_threshold = TrexPublisher::MSG_COMPRESS_THRESHOLD) override {
     }
 
     virtual ~SimPublisher() {


### PR DESCRIPTION
Handle build-warning errors by disabling some warnings found by the new compiler versions.
Additionally fix a new `overloaded-virtual` warning found by `gcc-13`.

The issues can be found in logs on local CI-runs:
gcc-11 maybe-uninitialized warning:
https://github.com/Nordix/trex-core/actions/runs/7259509593/job/19776795795

gcc-12 dangling pointer warning:
https://github.com/Nordix/trex-core/actions/runs/7259509593/job/19776796061

Run with similar corrections, which are ok:
https://github.com/Nordix/trex-core/actions/runs/7267842399