### PR TITLE
Fix sanitizer errors in testcases

### DIFF
--- a/src/bp_gtest.cpp
+++ b/src/bp_gtest.cpp
@@ -2884,6 +2884,7 @@ TEST_F(gt_ring, ring1) {
         uint32_t *p;
         assert(my.Dequeue(p)==0);
         EXPECT_EQ_UINT32(*p, i);
+        delete p;
     }
     uint32_t *p;
     assert(my.Dequeue(p)!=0);

--- a/src/gtest/bp_tunnel_gtest.cpp
+++ b/src/gtest/bp_tunnel_gtest.cpp
@@ -43,6 +43,7 @@ void prepend_ipv4_and_compare(char *buf, uint16_t len, uint32_t teid, uint16_t s
     CGtpuMan gtpu(TUNNEL_MODE_TX);
     gtpu.on_tx(0, m);
     create_pcap_and_compare(m, pcap_file);
+    rte_pktmbuf_free(m);
 }
 
 
@@ -56,6 +57,7 @@ void prepend_ipv6_and_compare(char *buf, uint16_t len, uint32_t teid, uint16_t s
     CGtpuMan gtpu(TUNNEL_MODE_TX);
     gtpu.on_tx(0, m);
     create_pcap_and_compare(m, pcap_file);
+    rte_pktmbuf_free(m);
 }
 
 
@@ -64,6 +66,7 @@ void adjust_and_compare(char *buf, uint16_t len, std::string pcap_file) {
     CGtpuMan gtpu(TUNNEL_MODE_RX);
     gtpu.on_rx(0, m);
     create_pcap_and_compare(m, pcap_file);
+    rte_pktmbuf_free(m);
 }
 
 

--- a/src/gtest/trex_stateless_gtest.cpp
+++ b/src/gtest/trex_stateless_gtest.cpp
@@ -6524,7 +6524,7 @@ public:
         bcopy(test_pkt, p1, sizeof(test_pkt));
         EXPECT_EQ(m1->pkt_len, sizeof(test_pkt));
 
-        uint8_t tmp_buf[sizeof(struct flow_stat_payload_header)];
+        uint8_t tmp_buf[sizeof(struct tpg_payload_header)];
         struct tpg_payload_header* tpg_header = (tpg_payload_header*)
             utl_rte_pktmbuf_get_last_bytes(m1, sizeof(struct tpg_payload_header), tmp_buf);
 
@@ -6532,8 +6532,6 @@ public:
         EXPECT_EQ(tpg_header->seq, 3);
 
         rx_tpg_port->handle_pkt(m1);
-
-        rte_pktmbuf_free(m1);
 
         Json::Value stats;
         rx_tpg_port->get_tpg_stats(stats, tpg_header->tpgid, 0, 1, false, false);
@@ -6554,6 +6552,7 @@ public:
         }
         VALIDATE_STATS_JSON(tag_stats, &exp);
 
+        rte_pktmbuf_free(m1);
         delete rx_tpg_port;
         free(port_cntr);
         delete tag_mgr;
@@ -6603,7 +6602,7 @@ public:
         bcopy(test_pkt, p1, sizeof(test_pkt));
         EXPECT_EQ(m1->pkt_len, sizeof(test_pkt));
 
-        uint8_t tmp_buf[sizeof(struct flow_stat_payload_header)];
+        uint8_t tmp_buf[sizeof(struct tpg_payload_header)];
         struct tpg_payload_header* tpg_header = (tpg_payload_header*)
             utl_rte_pktmbuf_get_last_bytes(m1, sizeof(struct tpg_payload_header), tmp_buf);
 
@@ -6611,8 +6610,6 @@ public:
         EXPECT_EQ(tpg_header->seq, 3);
 
         rx_tpg_port->handle_pkt(m1);
-
-        rte_pktmbuf_free(m1);
 
         // let's see the stats are successfully parsed
 
@@ -6628,6 +6625,7 @@ public:
         exp.set_cntrs(1, sizeof(test_pkt) + 4, 0, 0, 0, 0, 0);
         VALIDATE_STATS_JSON(unknown_stats, &exp);
 
+        rte_pktmbuf_free(m1);
         delete rx_tpg_port;
         free(port_cntr);
         delete tag_mgr;
@@ -6674,7 +6672,7 @@ public:
         bcopy(test_pkt, p1, sizeof(test_pkt));
         EXPECT_EQ(m1->pkt_len, sizeof(test_pkt));
 
-        uint8_t tmp_buf[sizeof(struct flow_stat_payload_header)];
+        uint8_t tmp_buf[sizeof(struct tpg_payload_header)];
         struct tpg_payload_header* tpg_header = (tpg_payload_header*)
             utl_rte_pktmbuf_get_last_bytes(m1, sizeof(struct tpg_payload_header), tmp_buf);
 
@@ -6682,8 +6680,6 @@ public:
         EXPECT_EQ(tpg_header->seq, 3);
 
         rx_tpg_port->handle_pkt(m1);
-
-        rte_pktmbuf_free(m1);
 
         Json::Value stats;
         rx_tpg_port->get_tpg_stats(stats, tpg_header->tpgid, 0, 1, true, true);
@@ -6705,6 +6701,7 @@ public:
 
         VALIDATE_STATS_JSON(untagged, &exp);
 
+        rte_pktmbuf_free(m1);
         delete rx_tpg_port;
         free(port_cntr);
         delete tag_mgr;

--- a/src/gtest/trex_stateless_gtest.cpp
+++ b/src/gtest/trex_stateless_gtest.cpp
@@ -6382,6 +6382,7 @@ public:
 
         delete rx_tpg_port;
         free(port_cntr);
+        delete tag_mgr;
     }
 
     void TestWithSomeErrors() {
@@ -6429,6 +6430,7 @@ public:
 
         delete rx_tpg_port;
         free(port_cntr);
+        delete tag_mgr;
     }
 
     void TestUntagged() {
@@ -6474,6 +6476,7 @@ public:
 
         delete rx_tpg_port;
         free(port_cntr);
+        delete tag_mgr;
     }
 
     void TestRxHandleValidTag(bool multicast) {
@@ -6553,6 +6556,7 @@ public:
         VALIDATE_STATS_JSON(tag_stats, &exp);
 
         rte_pktmbuf_free(m1);
+        utl_rte_mempool_delete(mp1);
         delete rx_tpg_port;
         free(port_cntr);
         delete tag_mgr;
@@ -6626,6 +6630,7 @@ public:
         VALIDATE_STATS_JSON(unknown_stats, &exp);
 
         rte_pktmbuf_free(m1);
+        utl_rte_mempool_delete(mp1);
         delete rx_tpg_port;
         free(port_cntr);
         delete tag_mgr;
@@ -6702,6 +6707,7 @@ public:
         VALIDATE_STATS_JSON(untagged, &exp);
 
         rte_pktmbuf_free(m1);
+        utl_rte_mempool_delete(mp1);
         delete rx_tpg_port;
         free(port_cntr);
         delete tag_mgr;

--- a/src/gtest/tuple_gen_test.cpp
+++ b/src/gtest/tuple_gen_test.cpp
@@ -562,6 +562,7 @@ TEST(tuple_gen_2,GenerateTuple2) {
         EXPECT_EQ(result_src, (uint32_t)(0x10000001+i%15));
         EXPECT_EQ(result_dest, (uint32_t) (((0x30000001+i)) ) );
     }
+    gen.Delete();
 }
 
 


### PR DESCRIPTION
- Fixed the heap-use-after-free issues in TPGRxStatsTest.
The tests uses `tpg_header` when validating the statistics while its memory `m1` has been freed.
`tmp_buf` is not used in tests but is now correct in size.

- Fixed direct and indirect leaks in tests
Fixed a couple of testcases that triggered errors by the leak sanitizer.

All issues are due to missing actions in the testcases.

There are still 2 testcase left that are expected to leak for some reason:
* gt_astf_inter.astf_negative_2
* gt_astf_inter.astf_negative_3

while negative_4 and negative_5 are commented away in legacy. Maybe we should remove all of them?
The flows are already covered by other testcases, except they perform proper cleanup.
    
Currently we need to filter out these negative testruns when using memory analysis tools:
 `./bp-sim-64 --ut --gtest_filter='-*.astf_negative*'`
