### PR TITLE
dpdk: use 1gb hugepages in priority

### DIFF
--- a/scripts/dpdk_setup_ports.py
+++ b/scripts/dpdk_setup_ports.py
@@ -729,7 +729,7 @@ Other network devices
             pass # should we fail here?
 
     def is_hugepage_file_exits(self,socket_id):
-        t = ['2048','1048576']
+        t = ['1048576', '2048']
         for obj in t:
             if map_driver.args.ignore_numa:
                 filename = '/sys/kernel/mm/hugepages/hugepages-{}kB/nr_hugepages'.format(obj)


### PR DESCRIPTION
Even when 1GB hugepages are allocated on boot and available, trex will try to allocate 2MB pages and ignore the 1GB pages. Change the logic and see if 1GB hugepages can be used in priority. If there are not enough 1GB hugepages, fallback on 2MB.