### PR TITLE
Revert "Use ie40evf instead of iavf driver"

### DIFF
--- a/src/dpdk/drivers/net/iavf/iavf_ethdev.c
+++ b/src/dpdk/drivers/net/iavf/iavf_ethdev.c
@@ -142,12 +142,10 @@ static int iavf_tm_ops_get(struct rte_eth_dev *dev __rte_unused, void *arg);
 
 static const struct rte_pci_id pci_id_iavf_map[] = {
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_ADAPTIVE_VF) },
-#ifndef TREX_PATCH  /* pci_id_i40evf_map */
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_VF) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_VF_HV) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_X722_VF) },
 	{ RTE_PCI_DEVICE(IAVF_INTEL_VENDOR_ID, IAVF_DEV_ID_X722_A0_VF) },
-#endif
 	{ .vendor_id = 0, /* sentinel */ },
 };
 


### PR DESCRIPTION
This reverts commit 7825d05cfbf2b8da3eaa3c6d9714a98e46086f6b - "Use ie40evf instead of iavf driver".

The commit "Use ie40evf instead of iavf driver" did not solve any issue. Instead it introduced other problems. After discussion with Gwangmoon Kim we came to the conclusion that we need to revert the previous commit.