### PR TITLE
fix doc typo for bidirectional traffic

### DIFF
--- a/doc/trex_cookbook.asciidoc
+++ b/doc/trex_cookbook.asciidoc
@@ -1083,7 +1083,7 @@ try:
     c.add_streams(s2, ports = port_1)
 
     # start traffic with limit of 3 seconds (otherwise it will continue forever)
-    c.start(ports = port_0, duration = 3)
+    c.start(ports = [port_0, port_1], duration = 3)
 
     # hold until traffic ends
     c.wait_on_traffic()


### PR DESCRIPTION
As someone who was using the cookbook as a replacement for the documentation (whoops) this was a little gotcha that caught me, hoping this helps!