### PR TITLE
Fix packet counters for mlx5 driver in trex

### DIFF
--- a/src/drivers/trex_driver_mlx5.h
+++ b/src/drivers/trex_driver_mlx5.h
@@ -22,6 +22,8 @@
   limitations under the License.
 */
 
+#include <unordered_map>
+
 #include "trex_driver_base.h"
 
 
@@ -70,7 +72,7 @@ private:
         uint16_t total_count;
         bool init;
 
-        uint16_t last_offset;
+        std::unordered_map<std::string, uint16_t> name_to_id;;
     };
     xstats_struct m_port_xstats[TREX_MAX_PORTS];
 };


### PR DESCRIPTION
That should fix wrong stats on ConnectX6 network cards once and for all

That is a minimized version of the patch (that retains counters diff).

Detailed changes:
 * Instead of keeping enums for counters, query them and store mapping in unordered_map
 * Remove xstats_array as it is no longer needed if we have mapping
 * Reference counters by their DPDK name
 * To make it future proof - make sure if counters are missing trex will crash with out_of_bound exception (asserts are there to verify counters still exists)
 * stats are now uint64_t instead of uint32_t as that is how they are reported from DPDK and down-conversion seems unnecessary


Screenshot of the change before the changes (current v3.04):
![v3.04](https://github.com/cisco-system-traffic-generator/trex-core/assets/844380/9565bc83-2005-4222-92fe-637636f750cd)


Screenshot of the state of counters after this change:
![This PR](https://github.com/cisco-system-traffic-generator/trex-core/assets/844380/cc0a541c-98bf-4378-a7b5-aa613e8eb0fc)



