### PR TITLE
Make amount of shown ports configurable

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -54,6 +54,7 @@ class ASTFClient(STLClient):
                  server = "localhost",
                  sync_port = 4501,
                  async_port = 4500,
+                 max_ports = 4,
                  verbose_level = "error",
                  logger = None,
                  sync_timeout = None,
@@ -74,6 +75,9 @@ class ASTFClient(STLClient):
 
               async_port : int 
                 the ASYNC port (subscriber port)
+
+              max_ports : int
+                maximum amount of ports to show
 
               verbose_level: str
                 one of "none", "critical", "error", "info", "debug"
@@ -99,6 +103,7 @@ class ASTFClient(STLClient):
                             server,
                             sync_port,
                             async_port,
+                            max_ports,
                             verbose_level,
                             logger,
                             sync_timeout,

--- a/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/common/trex_client.py
@@ -94,6 +94,7 @@ class TRexClient(object):
                  server = "localhost",
                  sync_port = 4501,
                  async_port = 4500,
+                 max_ports = 4,
                  verbose_level = "error",
                  logger = None,
                  sync_timeout = None,
@@ -132,6 +133,8 @@ class TRexClient(object):
 
         # server version check for dynamic port addition
         self.is_dynamic = False
+
+        self.max_ports = max_ports
 
 
     def get_mode (self):
@@ -3622,7 +3625,10 @@ class TRexClient(object):
             self.logger.warning(format_text('Empty set of ports\n', 'bold'))
             return
 
-        port_stats = [self.ports[port_id].get_port_stats() for port_id in ports[:4]]
+        if self.max_ports < 1:
+            port_stats = [self.ports[port_id].get_port_stats() for port_id in ports]
+        else:
+            port_stats = [self.ports[port_id].get_port_stats() for port_id in ports[:self.max_ports]]
 
         # update in a batch
         StatsBatch.update(port_stats, self.conn.rpc)
@@ -3649,7 +3655,11 @@ class TRexClient(object):
             self.logger.warning(format_text('Empty set of ports\n', 'bold'))
             return
 
-        port_xstats = [self.ports[port_id].get_port_xstats() for port_id in ports[:4]]
+        if self.max_ports < 1:
+            port_xstats = [self.ports[port_id].get_port_xstats() for port_id in ports]
+        else:
+            port_xstats = [self.ports[port_id].get_port_xstats() for port_id in ports[:self.max_ports]]
+
 
         # update in a batch
         StatsBatch.update(port_xstats, self.conn.rpc)

--- a/scripts/automation/trex_control_plane/interactive/trex/console/trex_console.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/console/trex_console.py
@@ -852,6 +852,8 @@ def setParserOptions():
                         action="store_true", help="Starts with all outputs suppressed",
                         default = False)
 
+    parser.add_argument("-m", "--max-ports", default=4, help="Set maximum amount of ports to show, any value below 1 is unlimited", type=int)
+
     return parser
 
 # a simple info printed on log on
@@ -896,6 +898,7 @@ def probe_server_mode (options):
                         server = options.server,
                         sync_port = options.port,
                         async_port = options.pub,
+                        max_ports = options.max_ports,
                         logger = ConsoleLogger(),
                         verbose_level = 'error')
 
@@ -992,6 +995,7 @@ def main():
                            server = options.server,
                            sync_port = options.port,
                            async_port = options.pub,
+                           max_ports = options.max_ports,
                            logger = logger,
                            verbose_level = verbose_level,
                            sync_timeout = sync_timeout,
@@ -1005,6 +1009,7 @@ def main():
                             server = options.server,
                             sync_port = options.port,
                             async_port = options.pub,
+                            max_ports = options.max_ports,
                             logger = logger,
                             verbose_level = verbose_level,
                             sync_timeout = sync_timeout,

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_client.py
@@ -126,6 +126,7 @@ class STLClient(TRexClient):
                  server = "localhost",
                  sync_port = 4501,
                  async_port = 4500,
+                 max_ports = 4,
                  verbose_level = "error",
                  logger = None,
                  sync_timeout = None,
@@ -146,6 +147,9 @@ class STLClient(TRexClient):
 
               async_port : int 
                 the ASYNC port (subscriber port)
+
+              max_ports : int
+                maximum number of ports to show
 
               verbose_level: str
                 one of "none", "critical", "error", "info", "debug"
@@ -172,6 +176,7 @@ class STLClient(TRexClient):
                             server,
                             sync_port,
                             async_port,
+                            max_ports,
                             verbose_level,
                             logger,
                             sync_timeout,


### PR DESCRIPTION
Currently it is hardcoded to '4' which is suboptimal for bigger screens. Add a new flag to trex-console, `-m` that allows to specify amount of ports user want to see.

Keep default value as 4 for compatibility reasons.

Related to #1109