### PR TITLE
docs: wget skip certificate check

### DIFF
--- a/doc/trex_book.asciidoc
+++ b/doc/trex_book.asciidoc
@@ -335,20 +335,20 @@ Latest (stable) release:
 ----
 [bash]>mkdir -p /opt/trex
 [bash]>cd /opt/trex
-[bash]>wget --no-cache https://trex-tgn.cisco.com/trex/release/latest
+[bash]>wget --no-cache --no-check-certificate https://trex-tgn.cisco.com/trex/release/latest
 [bash]>tar -xzvf latest
 ----
 
 Latest (bleeding edge) version:
 [source,bash]
 ----
-[bash]>wget --no-cache https://trex-tgn.cisco.com/trex/release/be_latest
+[bash]>wget --no-cache --no-check-certificate https://trex-tgn.cisco.com/trex/release/be_latest
 ----
 
 To obtain a specific version:
 [source,bash]
 ----
-[bash]>wget --no-cache https://trex-tgn.cisco.com/trex/release/vX.XX.tar.gz #<1>
+[bash]>wget --no-cache --no-check-certificate https://trex-tgn.cisco.com/trex/release/vX.XX.tar.gz #<1>
 ----
 <1> where X.XX = major.minor version number as per https://trex-tgn.cisco.com/trex/doc/release_notes.html
 


### PR DESCRIPTION
The cisco website doesnt have a valid certificate so the wget commands need --no-check-certificate added.
Pure documentation change