### PR TITLE
Make trex to run on x86 systems with more than 240 threads and sub-numa

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -109,7 +109,9 @@ extern "C" {
 #include "trex_defs.h"
 
 #define MAX_PKT_BURST   32
-#define BP_MAX_CORES 48
+// It is not clear why that is limited here
+// And probably everything around that requires a rework later
+#define BP_MAX_CORES 256
 #define BP_MASTER_AND_LATENCY 2
 
 void set_driver();

--- a/src/pal/linux_dpdk/dpdk_2303_x86_64/rte_build_config.h
+++ b/src/pal/linux_dpdk/dpdk_2303_x86_64/rte_build_config.h
@@ -274,7 +274,7 @@
 
 #define RTE_MAX_ETHPORTS 32
 
-#define RTE_MAX_LCORE 128
+#define RTE_MAX_LCORE 1536
 
 #define RTE_MAX_MEM_MB 524288
 

--- a/src/trex_defs.h
+++ b/src/trex_defs.h
@@ -27,16 +27,12 @@ limitations under the License.
 
 #define TREX_MAX_PORTS 32
 
-#ifdef __PPC64__
+// Nobody tested trex with more sockets and threads, at least now
 #define MAX_SOCKETS_SUPPORTED   (16)
 #define MAX_THREADS_SUPPORTED   (1536)
-#else
-#define MAX_SOCKETS_SUPPORTED   (4)
-#define MAX_THREADS_SUPPORTED   (120)
-#endif
 
-// 64 cores, each two digits, + 63 commas < 192
-#define MAX_CORES_LIST_STRLEN	192
+// 1536 cores, each two digits, + 1536 commas < 8192
+#define MAX_CORES_LIST_STRLEN	8192
 
 // maximum number of IP ID type flow stats we support. Must be in the form 2^x - 1
 #define MAX_FLOW_STATS 1023


### PR DESCRIPTION
clustering

 * Fix dpdk_setup_ports numa detection code - it now support sub-numa clustering
 * Remove artificial limitation on 63 max cores in dpdk_setup_ports
 * Change RTE_MAX_LCORE in build options for DPDK
 * Update trex_defs to unify ppc and x86 and also make arg string bigger
 * Change BP_MAX_CORES to 256 (not sure why it is not dynamically determined...)


Fixes #1119 