### PR TITLE
Add support TRex callbacks

### DIFF
--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -1,0 +1,24 @@
+#ifndef CALLBACKS_H
+#define CALLBACKS_H
+
+#include <rte_mbuf.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  uint16_t (*tx_burst)(uint16_t port, struct rte_mbuf **tx_pkts, uint16_t nb_pkts);
+} TrexCallbackFuncs;
+
+extern TrexCallbackFuncs trex_callback_funcs;
+
+inline void trex_callback_funcs_set(TrexCallbackFuncs*  cbs) {
+  trex_callback_funcs = *cbs;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -107,6 +107,7 @@ extern "C" {
 #include "astf/astf_db.h"
 #include "utl_offloads.h"
 #include "trex_defs.h"
+#include "callbacks.h"
 
 #define MAX_PKT_BURST   32
 #define BP_MAX_CORES 48
@@ -1185,6 +1186,8 @@ COLD_FUNC void CPhyEthIgnoreStats::dump(FILE *fd) {
     DP_A4(m_tx_arp);
     DP_A4(m_rx_arp);
 }
+
+TrexCallbackFuncs trex_callback_funcs{NULL};
 
 // Clear the RX queue of an interface, dropping all packets
 void CPhyEthIF::flush_rx_queue(void){


### PR DESCRIPTION
Hi,

Here is a suggestion to add support for a user defined callback in TX burst before the packet is sent.
This can for example be used to simulate packet drops by registering an implementation of the tx_burst callback function that returns a smaller packet count and moves all packets to send to the beginning of the tx_pkts array.

The callback function is encapsulated within a struct to make it possible to add more callback functions in the future.

Please take a look and let me know what you think.

BR
Henrik