### PR TITLE
Move trex_ixgbe_fdir_configure() prototype into header file.

### DIFF
--- a/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.c
+++ b/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.c
@@ -47,7 +47,6 @@
 #include "base/ixgbe_phy.h"
 #include "base/ixgbe_osdep.h"
 #include "ixgbe_regs.h"
-int trex_ixgbe_fdir_configure(struct rte_eth_dev *dev);
 
 /*
  * High threshold controlling when to start sending XOFF frames. Must be at

--- a/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.h
+++ b/src/dpdk/drivers/net/ixgbe/ixgbe_ethdev.h
@@ -832,4 +832,6 @@ ixgbe_ethertype_filter_remove(struct ixgbe_filter_info *filter_info,
 	return idx;
 }
 
+int trex_ixgbe_fdir_configure(struct rte_eth_dev *dev);
+
 #endif /* _IXGBE_ETHDEV_H_ */


### PR DESCRIPTION
g++ (Debian 14.2.0-19) 14.2.0 fails with error: implicit declaration of function 'trex_ixgbe_fdir_configure'.  Move prototype to ixgbe_ethdev.h header file.