### PR TITLE
Move iavf_security_ctx_destroy() prototype into header file.

### DIFF
--- a/src/dpdk/drivers/net/iavf/iavf.h
+++ b/src/dpdk/drivers/net/iavf/iavf.h
@@ -564,4 +564,10 @@ void iavf_dev_watchdog_enable(struct iavf_adapter *adapter);
 void iavf_dev_watchdog_disable(struct iavf_adapter *adapter);
 void iavf_handle_hw_reset(struct rte_eth_dev *dev);
 void iavf_set_no_poll(struct iavf_adapter *adapter, bool link_change);
+
+/**
+ * Destroy security context
+ */
+int iavf_security_ctx_destroy(struct iavf_adapter *adapterv);
+
 #endif /* _IAVF_ETHDEV_H_ */

--- a/src/dpdk/drivers/net/iavf/iavf_ipsec_crypto.h
+++ b/src/dpdk/drivers/net/iavf/iavf_ipsec_crypto.h
@@ -125,11 +125,6 @@ int iavf_ipsec_crypto_set_security_capabililites(struct iavf_security_ctx
 int iavf_security_get_pkt_md_offset(struct iavf_adapter *adapter);
 
 /**
- * Destroy security context
- */
-int iavf_security_ctx_destroy(struct iavf_adapter *adapterv);
-
-/**
  * Verify that the inline IPsec Crypto action is valid for this device
  */
 uint32_t


### PR DESCRIPTION
g++ (Debian 14.2.0-19) 14.2.0 fails with error: implicit declaration of function 'iavf_security_ctx_destroy'.  Move prototype to iavf.h header file.