### PR TITLE
Remove template-id from BasicConstraint destructor.

### DIFF
--- a/external_libs/valijson/include/valijson/constraints/basic_constraint.hpp
+++ b/external_libs/valijson/include/valijson/constraints/basic_constraint.hpp
@@ -34,7 +34,7 @@ struct BasicConstraint: Constraint
     BasicConstraint(const BasicConstraint &other)
       : allocator(other.allocator) { }
 
-    virtual ~BasicConstraint<ConstraintType>() { }
+    virtual ~BasicConstraint() { }
 
     virtual bool accept(ConstraintVisitor &visitor) const
     {


### PR DESCRIPTION
g++ (Debian 14.2.0-19) 14.2.0 fails with error: template-id not allowed for destructor in C++20.  Remove template-id <ConstraintType> from ~BasicConstraint() destructor.  It has been deprecated by standard.