### PR TITLE
Initialize m_server_info in CTcpDataAssocTransHelp constructor.

### DIFF
--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -283,11 +283,10 @@ inline bool operator< (const CTcpDataAssocParams& lhs, const CTcpDataAssocParams
 class CTcpDataAssocTransHelp {
     friend class CTcpDataAssocTranslation;
 
-    CTcpDataAssocTransHelp(const CTcpDataAssocParams& params, CEmulAppProgram *prog, CTcpTuneables *tune, uint32_t temp_idx) {
+    CTcpDataAssocTransHelp(const CTcpDataAssocParams& params, CEmulAppProgram *prog, CTcpTuneables *tune, uint32_t temp_idx)
+        : m_server_info(prog, tune, temp_idx)
+    {
         m_params = params;
-        m_server_info.m_prog = prog;
-        m_server_info.m_tune = tune;
-        m_server_info.m_temp_idx = temp_idx;
     }
 
  private:


### PR DESCRIPTION
g++ (Debian 14.2.0-19) 14.2.0 fails with error:
'trans_help.CTcpDataAssocTransHelp::m_server_info.CTcpServerInfo::m_ip_end' may be used uninitialized.  Use CTcpServerInfo() constructor to initialize m_server_info which fills all values.