### PR TITLE
dpdk: fix ice tx

### DIFF
--- a/src/dpdk/drivers/net/ice/base/ice_switch.c
+++ b/src/dpdk/drivers/net/ice/base/ice_switch.c
@@ -8146,16 +8146,16 @@ ice_add_adv_recipe(struct ice_hw *hw, struct ice_adv_lkup_elem *lkups,
 	 */
 	ice_get_compat_fv_bitmap(hw, rinfo, fv_bitmap);
 
-	status = ice_get_sw_fv_list(hw, lkup_exts, fv_bitmap, &rm->fv_list);
-	if (status)
-		goto err_unroll;
-
 	/* Create any special protocol/offset pairs, such as looking at tunnel
 	 * bits by extracting metadata
 	 */
 	status = ice_add_special_words(rinfo, lkup_exts, ice_is_dvm_ena(hw));
 	if (status)
 		goto err_free_lkup_exts;
+
+	status = ice_get_sw_fv_list(hw, lkup_exts, fv_bitmap, &rm->fv_list);
+	if (status)
+		goto err_unroll;
 
 	/* Group match words into recipes using preferred recipe grouping
 	 * criteria.

--- a/src/dpdk/drivers/net/ice/ice_ethdev.c
+++ b/src/dpdk/drivers/net/ice/ice_ethdev.c
@@ -6140,12 +6140,13 @@ ice_stats_get(struct rte_eth_dev *dev, struct rte_eth_stats *stats)
 
 	stats->ipackets = pf->main_vsi->eth_stats.rx_unicast +
 			  pf->main_vsi->eth_stats.rx_multicast +
+			  ns->eth.rx_unknown_protocol +
 			  pf->main_vsi->eth_stats.rx_broadcast -
 			  pf->main_vsi->eth_stats.rx_discards;
 	stats->opackets = ns->eth.tx_unicast +
 			  ns->eth.tx_multicast +
 			  ns->eth.tx_broadcast;
-	stats->ibytes   = pf->main_vsi->eth_stats.rx_bytes;
+	stats->ibytes   = ns->eth.rx_bytes;
 	stats->obytes   = ns->eth.tx_bytes;
 	stats->oerrors  = ns->eth.tx_errors +
 			  pf->main_vsi->eth_stats.tx_errors;

--- a/src/dpdk/drivers/net/ice/ice_switch_filter.c
+++ b/src/dpdk/drivers/net/ice/ice_switch_filter.c
@@ -1594,6 +1594,7 @@ invalid:
 			return -rte_errno;
 
 		case RTE_FLOW_ACTION_TYPE_DROP:
+			rule_info->add_dir_lkup = 1;
 			rule_info->sw_act.fltr_act = ICE_DROP_PACKET;
 			break;
 
@@ -1676,6 +1677,7 @@ ice_switch_parse_action(struct ice_pf *pf,
 			break;
 
 		case RTE_FLOW_ACTION_TYPE_DROP:
+			rule_info->add_dir_lkup = 1;
 			rule_info->sw_act.fltr_act =
 				ICE_DROP_PACKET;
 			break;


### PR DESCRIPTION
The tx packets were dropped when creating drop any rule for ingress direction only. Added a direction lookup flag to fix the issue. Added accounting for Rx drop packets in ipackets and ibytes.

The add_dir_lkup flag we set is considered in
ice_tun_type_match_word(), called by ice_add_special_words() When the flag is set, a "special" lookup is added to the field vector list to tell hardware to in fact lookup the direction.

The function that interprets/translates the lookups is ice_get_sw_fv_list(). When ice_get_sw_fv_list() is called *before* ice_add_special_words(), the "special" words don't exist yet, so they're not translated. The fix is to call ice_get_sw_fv_list() *after* ice_add_special_words().