### PR TITLE
Python 3.13.5 needs importlib instead of imp.

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/topo.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/topo.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import json
 import yaml
 import os
@@ -365,7 +365,7 @@ class ASTFTopologyManager(object):
         try:
             file   = os.path.basename(python_file).split('.')[0]
             module = __import__(file, globals(), locals(), [], 0)
-            imp.reload(module) # reload the update
+            importlib.reload(module) # reload the update
 
             topo = module.get_topo(**kw)
             if not isinstance(topo, ASTFTopology):

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -12,7 +12,7 @@ import traceback
 from ..common.trex_exceptions import *
 from ..common.trex_types import listify
 from ..utils.common import ip2int
-import imp
+import importlib
 import collections
 
 def pretty_exceptions(func):
@@ -2221,7 +2221,7 @@ class ASTFProfile(object):
         try:
             file    = os.path.basename(python_file).split('.')[0]
             module = __import__(file, globals(), locals(), [], 0)
-            imp.reload(module) # reload the update 
+            importlib.reload(module) # reload the update
 
             t = cls.get_module_tunables(module)
 

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/tunnels_topo.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/tunnels_topo.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import json
 import yaml
 import os
@@ -220,7 +220,7 @@ class TunnelsTopo(object):
         try:
             file   = os.path.basename(python_file).split('.')[0]
             module = __import__(file, globals(), locals(), [], 0)
-            imp.reload(module) # reload the update
+            importlib.reload(module) # reload the update
 
             topo = module.get_topo(**kw)
             if not isinstance(topo, TunnelsTopo):

--- a/scripts/automation/trex_control_plane/interactive/trex/emu/trex_emu_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/emu/trex_emu_profile.py
@@ -4,7 +4,7 @@ from trex.emu.trex_emu_conversions import *
 from trex.common.trex_types import listify
 from .trex_emu_validator import EMUValidator
 
-import imp
+import importlib
 import os
 import sys
 import traceback
@@ -561,7 +561,7 @@ class EMUProfile(object):
         try:
             file = os.path.basename(filename).split('.')[0]
             module = __import__(file, globals(), locals(), [], 0)
-            imp.reload(module)  # reload the update 
+            importlib.reload(module)  # reload the update
 
             try:
                 profile = module.register().get_profile(tunables)

--- a/scripts/automation/trex_control_plane/interactive/trex/examples/astf/ndr_bench.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/astf/ndr_bench.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 import time
 import math
-import imp
+import importlib
 from copy import deepcopy
 
 class MultiplierDomain:
@@ -145,7 +145,7 @@ class ASTFNdrBenchConfig:
         try:
             file    = os.path.basename(plugin_file).split('.')[0]
             module = __import__(file, globals(), locals(), [], 0)
-            imp.reload(module) # reload the update 
+            importlib.reload(module) # reload the update
 
             plugin = module.register()
 

--- a/scripts/automation/trex_control_plane/interactive/trex/examples/stl/ndr_bench.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/examples/stl/ndr_bench.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 import time
 import math
-import imp
+import importlib
 from copy import deepcopy
 
 
@@ -218,7 +218,7 @@ class NdrBenchConfig:
         try:
             file    = os.path.basename(plugin_file).split('.')[0]
             module = __import__(file, globals(), locals(), [], 0)
-            imp.reload(module) # reload the update 
+            importlib.reload(module) # reload the update
 
             plugin = module.register()
 

--- a/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_streams.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/stl/trex_stl_streams.py
@@ -9,7 +9,7 @@ import base64
 import string
 import traceback
 import copy
-import imp
+import importlib
 
 
 from ..common.trex_exceptions import *
@@ -426,7 +426,7 @@ class STLTaggedPktGroupTagConf:
             filename = os.path.basename(tpg_conf_path).split('.')[0]  # remove the file extension
             sys.dont_write_bytecode = True
             module = __import__(filename, globals(), locals(), [], 0)  # import the file
-            imp.reload(module)  # reload the update
+            importlib.reload(module)  # reload the update
 
             try:
                 tpg_conf = module.register().get_tpg_conf(**kwargs)
@@ -1163,7 +1163,7 @@ class STLProfile(object):
             file    = os.path.basename(python_file).split('.')[0]
             sys.dont_write_bytecode = True
             module = __import__(file, globals(), locals(), [], 0)
-            imp.reload(module) # reload the update 
+            importlib.reload(module) # reload the update
 
             t = STLProfile.get_module_tunables(module)
             #for arg in kwargs:


### PR DESCRIPTION
Modern Python does not support import imp.  Convert the scripts to module importlib.