### PR TITLE
Escape backslash in Python scripts.

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/utils/common.py
@@ -349,7 +349,7 @@ def try_int(i):
 # a2 before a10 in sorting
 # https://blog.codinghorror.com/sorting-for-humans-natural-sort-order/
 def natural_sorted_key(val):
-    return [int(c) if c.isdigit() else c for c in re.split('(\d+)', val)]
+    return [int(c) if c.isdigit() else c for c in re.split('(\\d+)', val)]
 
 def filter_none(seq):
     return filter(lambda x: x is not None, seq)

--- a/scripts/dpdk_nic_bind.py
+++ b/scripts/dpdk_nic_bind.py
@@ -211,7 +211,7 @@ def find_module(mod):
 
     # check for a copy based off current path
     drivers_dir = '/lib/modules/%s/kernel/drivers' % kernel_ver
-    find_out = check_output(["find", drivers_dir, "-name", mod + ".ko\*"], universal_newlines = True)
+    find_out = check_output(["find", drivers_dir, "-name", mod + ".ko\\*"], universal_newlines = True)
     if find_out: #something matched
         path = find_out.splitlines()[0]
         if exists(path):
@@ -819,7 +819,7 @@ def get_info_from_trex(pci_addr_list):
         else:
             print('Error upon running TRex to get interfaces info:\n%s' % stdout)
         sys.exit(-1)
-    pci_mac_str = 'PCI: (\S+).+?MAC: (\S+).+?Driver: (\S*)'
+    pci_mac_str = 'PCI: (\\S+).+?MAC: (\\S+).+?Driver: (\\S*)'
     pci_mac_re = re.compile(pci_mac_str)
     for line in stdout.splitlines():
         match = pci_mac_re.match(line)
@@ -879,8 +879,8 @@ KILO = 1000
 MEGA = 1000000
 GIGA = 1000000000
 TERA = 1000000000000
-MEMORY_SIZE_RE = re.compile('(\d+)\s*(.?)b?$')
-BANK_LOCATOR_RE = re.compile('(node|cpu) (\d+) channel (\d+)')
+MEMORY_SIZE_RE = re.compile('(\\d+)\\s*(.?)b?$')
+BANK_LOCATOR_RE = re.compile('(node|cpu) (\\d+) channel (\\d+)')
 def parse_memory_section(section, flag_hypervisor):
     numa = channel = size = None
     for line in section.splitlines():

--- a/scripts/dpdk_setup_ports.py
+++ b/scripts/dpdk_setup_ports.py
@@ -61,7 +61,7 @@ def if_list_remove_sub_if(if_list):
 
 class ConfigCreator(object):
     mandatory_interface_fields = ['Slot_str', 'Device_str', 'NUMA']
-    _2hex_re = '[\da-fA-F]{2}'
+    _2hex_re = '[\\da-fA-F]{2}'
     mac_re = re.compile('^({0}:){{5}}{0}$'.format(_2hex_re))
 
     if march == 'ppc64le':
@@ -510,7 +510,7 @@ Other network devices
     def check_ofed_version (self):
         ofed_info='/usr/bin/ofed_info'
 
-        ofed_ver_re = re.compile('.*[-](\d)(\d)?[.](\d)(\d)?[-].*')
+        ofed_ver_re = re.compile('.*[-](\\d)(\\d)?[.](\\d)(\\d)?[-].*')
 
         ofed_ver = 52
         ofed_ver_show = '5.2'
@@ -862,7 +862,7 @@ Other network devices
         if not if_list:
             return
         af_names = []
-        ifname_re = re.compile('iface\s*=\s*([^\s,]+)')
+        ifname_re = re.compile('iface\\s*=\\s*([^\\s,]+)')
         found_vdev  = False
         found_pdev  = False
         for iface in if_list:


### PR DESCRIPTION
Python 3.13.5 warns when using unescaped backslash in strings for regular expressions.  SyntaxWarning: invalid escape sequence '\d'. By adding a second backslash it works as intended.