### PR TITLE
Compile with C++ 17 standard.

### DIFF
--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -2721,7 +2721,7 @@ def build_prog (bld, build_obj):
 
     bld.program(features='cxx cxxprogram',
                 includes =inc_path + tcp_includes_path,
-                cxxflags = ( cxxflags + ['-std=gnu++11']),
+                cxxflags = ( cxxflags + ['-std=c++17']),
                 linkflags = linkflags ,
                 lib=['pthread','dl', 'z'] + lib_ext,
                 use =[build_obj.get_dpdk_target(), build_obj.get_bpf_target(), 'zmq', build_obj.get_tcp_target()],


### PR DESCRIPTION
g++ (Debian 14.2.0-19) 14.2.0 compiles with Intel SSE instructions that need 32 byte alignment.  With -std=gnu++11 flag it still uses these instructions, but the C++ 11 new operator does not support the additional alignment parameter.  This results in a segmentation fault due to unaligned access.  When using the -std=c++17 compile time option, the dynamically allocated memory is aligned correctly.