### PR TITLE
Avoid inconsistent typedef of __be64 and __le64.

### DIFF
--- a/src/dpdk/drivers/net/gve/base/gve_osdep.h
+++ b/src/dpdk/drivers/net/gve/base/gve_osdep.h
@@ -5,6 +5,8 @@
 #ifndef _GVE_OSDEP_H_
 #define _GVE_OSDEP_H_
 
+#include <sys/types.h>
+
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -33,16 +35,6 @@ typedef uint8_t u8;
 typedef uint16_t u16;
 typedef uint32_t u32;
 typedef uint64_t u64;
-
-typedef rte_be16_t __sum16;
-
-typedef rte_be16_t __be16;
-typedef rte_be32_t __be32;
-typedef rte_be64_t __be64;
-
-typedef rte_le16_t __le16;
-typedef rte_le32_t __le32;
-typedef rte_le64_t __le64;
 
 typedef rte_iova_t dma_addr_t;
 


### PR DESCRIPTION
Debian 13 "trixie" GNU/Linux provides declaration for many types in its header files.  Instead of providing conflicting types that cause compile errors just include sys/types.h within gve_osdep.h..