### PR TITLE
Initialize values in jsoncpp.

### DIFF
--- a/external_libs/json/jsoncpp.cpp
+++ b/external_libs/json/jsoncpp.cpp
@@ -425,7 +425,7 @@ bool Reader::readValue() {
     break;
   case tokenNull:
     {
-    Value v;
+    Value v(0);
     currentValue().swapPayload(v);
     currentValue().setOffsetStart(token.start_ - begin_);
     currentValue().setOffsetLimit(token.end_ - begin_);
@@ -438,7 +438,7 @@ bool Reader::readValue() {
       // "Un-read" the current token and mark the current value as a null
       // token.
       current_--;
-      Value v;
+      Value v(0);
       currentValue().swapPayload(v);
       currentValue().setOffsetStart(current_ - begin_ - 1);
       currentValue().setOffsetLimit(current_ - begin_);
@@ -1357,7 +1357,7 @@ bool OurReader::readValue() {
     break;
   case tokenNull:
     {
-    Value v;
+    Value v(0);
     currentValue().swapPayload(v);
     currentValue().setOffsetStart(token.start_ - begin_);
     currentValue().setOffsetLimit(token.end_ - begin_);
@@ -1394,7 +1394,7 @@ bool OurReader::readValue() {
       // "Un-read" the current token and mark the current value as a null
       // token.
       current_--;
-      Value v;
+      Value v(0);
       currentValue().swapPayload(v);
       currentValue().setOffsetStart(current_ - begin_ - 1);
       currentValue().setOffsetLimit(current_ - begin_);
@@ -2958,6 +2958,7 @@ Value::Value(Value const& other)
 // Move constructor
 Value::Value(Value&& other) {
   initBasic(nullValue);
+  value_.int_ = 0;
   swap(other);
 }
 #endif


### PR DESCRIPTION
Due do compiling json with -Werrro, g++ (Debian 14.2.0-19) 14.2.0 fails with "warning: '*(Json::Value::ValueHolder*)this' is used uninitialized".  The default constructor uses nullValue to initialize the Value without a value.  When calling method swapPayload() with such an object, the uninitialized internal value gets accessed.  As a simple workaround set new Value objects to integer 0.