### PR TITLE
Fix Python 3 Scapy template serialization

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_service.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/scapy_server/scapy_service.py
@@ -1096,7 +1096,7 @@ class Scapy_service(Scapy_service_api):
             return ""
         f  = os.path.join(self.scapy_service_dir, f)
         with open(f, 'r') as content_file:
-            content = base64.b64encode(str_to_bytes(content_file.read()))
+            content = bytes_to_b64(str_to_bytes(content_file.read()))
         return content
 
 

--- a/scripts/automation/trex_control_plane/interactive/trex/scapy_server/unit_tests/test_scapy_service.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/scapy_server/unit_tests/test_scapy_service.py
@@ -541,6 +541,17 @@ def test_get_templates_several_times():
     templates_2 = get_templates()
     assert(templates_1 == templates_2)
 
+def test_get_template_returns_json_serializable_string():
+    params = {"id": "TCP-SYN"}
+    template_b64 = service.get_template(v_handler, params)
+
+    assert isinstance(template_b64, str)
+    json.dumps(template_b64)
+
+    template_json = base64.b64decode(template_b64).decode("utf-8")
+    obj = json.loads(template_json)
+    assert obj["packet"][0]["id"] == "Ether"
+
 def test_get_template_root():
     obj = json.loads(get_template_by_id('TCP-SYN'))
     assert(obj['packet'][0]['id'] == 'Ether')


### PR DESCRIPTION
Fixes #1219
Return Base64 template content as JSON-safe text and add regression coverage for the Scapy RPC contract.

Physically validated against the official TRex v3.08 binary release with all visible built-in templates loading successfully after the patch.